### PR TITLE
Add support for Options and refactor

### DIFF
--- a/v3/main.js
+++ b/v3/main.js
@@ -2,13 +2,20 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
+import {CHTML} from "mathjax/output/chtml.js";
+
+let OPTIONS = {
+  InputJax: new TeX(),
+  OutputJax: new CHTML()
+};
 
 var html;
 try {
   //
   //  Use browser document, if there is one
   //
-  html = MathJax.HandlerFor(document);
+  html = MathJax.HandlerFor(document,OPTIONS);
   var text = document.createTextNode('This is some math: \\(x+1\\).\n\\[x+1\\over x-1\\]');
   document.body.insertBefore(text,document.body.firstChild);
 } catch (err) {
@@ -21,7 +28,8 @@ try {
     <body>
     This is some math: \\(x+1\\).
     \\[x+1\\over x-1\\]
-    </body></html>`
+    </body></html>`,
+    OPTIONS
   );
 }
 

--- a/v3/mathjax/core/Document.js
+++ b/v3/mathjax/core/Document.js
@@ -19,6 +19,9 @@ export class Document {
       AddEventHandlers: false,
       UpdateDocument: false
     };
+    this.InputJaxMap = new Map();
+    this.InputJax = [];
+    this.OutputJax = null;
   }
   
   FindMath(options) {

--- a/v3/mathjax/core/Document.js
+++ b/v3/mathjax/core/Document.js
@@ -27,12 +27,7 @@ export class Document {
   }
   
   FindMath(options) {
-    if (!this.processed.FindMath) {
-      this.InputJax.forEach(jax => {
-        this.math = this.math.concat(jax.FindMath(this.document.body));
-      });
-      this.processed.FindMath = true;
-    }
+    this.processed.FindMath = true;
     return this;
   }
   
@@ -65,10 +60,7 @@ export class Document {
   }
 
   AddEventHandlers() {
-    if (!this.processed.AddEventHandlers) {
-      console.log("- AddEventHandlers");
-      this.processed.AddEventHandlers = true;
-    }
+    this.processed.AddEventHandlers = true;
     return this;
   }
 

--- a/v3/mathjax/core/Document.js
+++ b/v3/mathjax/core/Document.js
@@ -21,11 +21,9 @@ export class Document {
       AddEventHandlers: false,
       UpdateDocument: false
     };
-    this.InputJaxMap = new Map();
     this.InputJax = this.options["InputJax"] || new InputJax();
     this.OutputJax = this.options["OutputJax"] || new OutputJax();
     if (!Array.isArray(this.InputJax)) this.InputJax = [this.InputJax];
-    this.InputJax.forEach(jax => this.InputJaxMap.set(jax.name,jax));
   }
   
   FindMath(options) {

--- a/v3/mathjax/core/Document.js
+++ b/v3/mathjax/core/Document.js
@@ -2,16 +2,11 @@ import {UserOptions, DefaultOptions} from "../util/Options.js";
 import {InputJax} from "./InputJax.js";
 import {OutputJax} from "./OutputJax.js";
 
-const OPTIONS = {
-  OutputJax: null,
-  InputJax: null
-};
-
 export class Document {
   constructor (document,options) {
     this.document = document;
     this.type = this.constructor.type;
-    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
+    this.options = UserOptions(DefaultOptions({},this.constructor.OPTIONS),options);
     this.math = [];
     this.processed = {
       FindMath: false,
@@ -82,3 +77,8 @@ export class Document {
 };
 
 Document.type = "Document";
+Document.OPTIONS = {
+  OutputJax: null,
+  InputJax: null
+};
+

--- a/v3/mathjax/core/Document.js
+++ b/v3/mathjax/core/Document.js
@@ -1,9 +1,15 @@
+import {UserOptions, DefaultOptions} from "../util/Options.js";
+
+const OPTIONS = {
+  OutputJax: null,
+  InputJax: null
+};
 
 export class Document {
   constructor (document,type,options) {
     this.document = document;
     this.type = type;
-    this.options = options;
+    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
     this.math = [];
     this.processed = {
       FindMath: false,

--- a/v3/mathjax/core/InputJax.js
+++ b/v3/mathjax/core/InputJax.js
@@ -1,8 +1,17 @@
+import {UserOptions, DefaultOptions} from '../util/Options.js';
+
+//
+//  The default options for InputJax
+//  
+const OPTIONS = {
+  //  (none just yet).
+};
+
 export class InputJax {
   
   constructor(options = {}) {
     this.name = this.constructor.NAME;
-    this.options = options;
+    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
   }
   
   FindMath(node,options) {

--- a/v3/mathjax/core/InputJax.js
+++ b/v3/mathjax/core/InputJax.js
@@ -1,7 +1,7 @@
 export class InputJax {
   
-  constructor(name,options = {}) {
-    this.name = name;
+  constructor(options = {}) {
+    this.name = this.constructor.NAME;
     this.options = options;
   }
   
@@ -14,3 +14,5 @@ export class InputJax {
   }
   
 };
+
+InputJax.NAME = "Generic";

--- a/v3/mathjax/core/InputJax.js
+++ b/v3/mathjax/core/InputJax.js
@@ -1,17 +1,10 @@
 import {UserOptions, DefaultOptions} from '../util/Options.js';
 
-//
-//  The default options for InputJax
-//  
-const OPTIONS = {
-  //  (none just yet).
-};
-
 export class InputJax {
   
   constructor(options = {}) {
     this.name = this.constructor.NAME;
-    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
+    this.options = UserOptions(DefaultOptions({},this.constructor.OPTIONS),options);
   }
   
   FindMath(node,options) {
@@ -25,3 +18,6 @@ export class InputJax {
 };
 
 InputJax.NAME = "Generic";
+InputJax.OPTIONS = {
+  //  (none just yet).
+};

--- a/v3/mathjax/core/InputJax.js
+++ b/v3/mathjax/core/InputJax.js
@@ -6,7 +6,8 @@ export class InputJax {
   }
   
   FindMath(node,options) {
-    // should be on array of strings, but for now, use DOM node
+    // should operate on an array of strings, but for now, use DOM node
+    return [];
   }
   
   Compile(math,options) {

--- a/v3/mathjax/core/MathItem.js
+++ b/v3/mathjax/core/MathItem.js
@@ -1,8 +1,8 @@
 
 export class MathItem {
-  constructor (math,format,display=true,start={i:0, n:0, delim:""},end={i:0, n:0, delim:""}) {
+  constructor (math,jax,display=true,start={i:0, n:0, delim:""},end={i:0, n:0, delim:""}) {
     this.math = math;
-    this.format = format;
+    this.inputJax = jax;
     this.display = display;
     this.start = start;
     this.end = end;

--- a/v3/mathjax/core/MathItem.js
+++ b/v3/mathjax/core/MathItem.js
@@ -15,11 +15,24 @@ export class MathItem {
     this.outputData = {};
   }
   
-  Compile(options) {}
-  Typeset(options) {}
+  Compile(document,options) {
+    if (this.State() < STATE.COMPILED) {
+      this.tree = this.inputJax.Compile(this.math,this.display);
+      this.State(STATE.COMPILED);
+    }
+  }
+  
+  Typeset(document,options) {
+    if (this.State() < STATE.TYPESET) {
+      this.typeset = document.OutputJax.Typeset(this,document);
+      this.State(STATE.TYPESET);
+    }
+  }
   
   addEventHandlers() {}
-
+  
+  UpdateDocument(document,options) {}
+  
   setMetrics(em,ex,cwidth,lwidth,scale) {
     this.metrics = {
       em: em, ex: ex,
@@ -28,6 +41,7 @@ export class MathItem {
       scale: scale
     }
   }
+  
   State(state=null) {
     if (state != null) this.state = state;
     return this.state;

--- a/v3/mathjax/core/OutputJax.js
+++ b/v3/mathjax/core/OutputJax.js
@@ -1,8 +1,17 @@
+import {UserOptions, DefaultOptions} from '../util/Options.js';
+
+//
+//  The default options for OutputJax
+//  
+const OPTIONS = {
+  //  (none just yet).
+};
+
 export class OutputJax {
   
   constructor(options = {}) {
     this.name = this.constructor.NAME;
-    this.options = options;
+    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
   }
   
   Typeset(math,document,options) {

--- a/v3/mathjax/core/OutputJax.js
+++ b/v3/mathjax/core/OutputJax.js
@@ -1,7 +1,7 @@
 export class OutputJax {
   
-  constructor(name,options = {}) {
-    this.name = name;
+  constructor(options = {}) {
+    this.name = this.constructor.NAME;
     this.options = options;
   }
   
@@ -15,3 +15,5 @@ export class OutputJax {
   }
 
 };
+
+OutputJax.NAME = "Generic";

--- a/v3/mathjax/core/OutputJax.js
+++ b/v3/mathjax/core/OutputJax.js
@@ -10,5 +10,8 @@ export class OutputJax {
   
   GetMetrics(document) {
   }
+  
+  StyleSheet(document) {
+  }
 
 };

--- a/v3/mathjax/core/OutputJax.js
+++ b/v3/mathjax/core/OutputJax.js
@@ -1,17 +1,10 @@
 import {UserOptions, DefaultOptions} from '../util/Options.js';
 
-//
-//  The default options for OutputJax
-//  
-const OPTIONS = {
-  //  (none just yet).
-};
-
 export class OutputJax {
   
   constructor(options = {}) {
     this.name = this.constructor.NAME;
-    this.options = UserOptions(DefaultOptions({},OPTIONS),options);
+    this.options = UserOptions(DefaultOptions({},this.constructor.OPTIONS),options);
   }
   
   Typeset(math,document,options) {
@@ -26,3 +19,6 @@ export class OutputJax {
 };
 
 OutputJax.NAME = "Generic";
+OutputJax.OPTIONS = {
+  //  (none just yet).
+};

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -1,68 +1,11 @@
 import {Document} from "../../core/Document.js";
 import {HTMLMathItem} from "./HTMLMathItem.js";
-import {InputJax} from "../../core/InputJax.js";
-import {OutputJax} from "../../core/OutputJax.js";
 
 export class HTMLDocument extends Document {
-  constructor (document,options) {
-    super(document,"HTML",options);
-    this.InputJax = this.options["InputJax"] || new InputJax();
-    this.OutputJax = this.options["OutputJax"] || new OutputJax();
-    if (!Array.isArray(this.InputJax)) this.InputJax = [this.InputJax];
-    this.InputJax.forEach(jax => this.InputJaxMap.set(jax.name,jax));
-  }
-  
-  FindMath(options) {
-    if (!this.processed.FindMath) {
-      this.InputJax.forEach(jax => {
-        this.math = this.math.concat(jax.FindMath(this.document.body));
-      });
-      this.processed.FindMath = true;
-    }
-    return this;
-  }
-  
-  Compile(options) {
-    if (!this.processed.Compile) {
-      for (let i = 0, m = this.math.length; i < m; i++) {
-        if (this.math[i]) this.math[i].Compile(this);
-      }
-      this.processed.Compile = true;
-    }
-    return this;
-  }
-  
-  Typeset(options) {
-    if (!this.processed.Typeset) {
-      for (let i = 0, m = this.math.length; i < m; i++) {
-        if (this.math[i]) this.math[i].Typeset(this);
-      }
-      this.processed.Typeset = true;
-    }
-    return this;
-  }
-  
-  GetMetrics() {
-    if (!this.processed.GetMetrics) {
-      this.OutputJax.GetMetrics(this);
-      this.processed.GetMetrics = true;
-    }
-    return this;
-  }
-  
-  AddEventHandlers() {
-    if (!this.processed.AddEventHandlers) {
-      console.log("- AddEventHandlers");
-      this.processed.AddEventHandlers = true;
-    }
-    return this;
-  }
-  
+
   UpdateDocument() {
     if (!this.processed.UpdateDocument) {
-      for (let i = 0, m = this.math.length; i < m; i++) {
-        if (this.math[i]) this.math[i].UpdateDocument(this);
-      }
+      super.UpdateDocument();
       let sheet = this.DocumentStyleSheet();
       if (sheet) {
         let styles = this.document.getElementById(sheet.id);
@@ -90,3 +33,5 @@ export class HTMLDocument extends Document {
   }
 
 };
+
+HTMLDocument.type = "HTML";

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -8,11 +8,15 @@ export class HTMLDocument extends Document {
     super(document,"HTML",options);
     this.InputJax = this.options["InputJax"] || new InputJax();
     this.OutputJax = this.options["OutputJax"] || new OutputJax();
+    if (!Array.isArray(this.InputJax)) this.InputJax = [this.InputJax];
+    this.InputJax.forEach(jax => this.InputJaxMap.set(jax.name,jax));
   }
   
   FindMath(options) {
     if (!this.processed.FindMath) {
-      this.math = this.math.concat(this.InputJax.FindMath(this.document.body));
+      this.InputJax.forEach(jax => {
+        this.math = this.math.concat(jax.FindMath(this.document.body));
+      });
       this.processed.FindMath = true;
     }
     return this;

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -26,7 +26,7 @@ export class HTMLDocument extends Document {
   
   TestMath(string,display=true) {
     if (!this.processed.TestMath) {
-      this.math = [new HTMLMathItem(string,null,display)];
+      this.math = [new HTMLMathItem(string,this.InputJax[0],display)];
       this.processed.TestMath = true;
     }
     return this;

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -1,5 +1,6 @@
 import {Document} from "../../core/Document.js";
 import {HTMLMathItem} from "./HTMLMathItem.js";
+import {DefaultOptions} from "../../util/Options.js";
 
 export class HTMLDocument extends Document {
 
@@ -45,3 +46,4 @@ export class HTMLDocument extends Document {
 };
 
 HTMLDocument.type = "HTML";
+HTMLDocument.OPTIONS = DefaultOptions({},Document.OPTIONS);

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -1,18 +1,18 @@
 import {Document} from "../../core/Document.js";
 import {HTMLMathItem} from "./HTMLMathItem.js";
-import {TeX} from "../../input/tex.js";
-import {CHTML} from "../../output/chtml.js";
+import {InputJax} from "../../core/InputJax.js";
+import {OutputJax} from "../../core/OutputJax.js";
 
 export class HTMLDocument extends Document {
   constructor (document,options) {
     super(document,"HTML",options);
-    this.InputJax = new TeX();         // should come from options
-    this.OutputJax = new CHTML();      // should come from options
+    this.InputJax = this.options["InputJax"] || new InputJax();
+    this.OutputJax = this.options["OutputJax"] || new OutputJax();
   }
   
   FindMath(options) {
     if (!this.processed.FindMath) {
-      this.math = this.InputJax.FindMath(this.document.body);
+      this.math = this.math.concat(this.InputJax.FindMath(this.document.body));
       this.processed.FindMath = true;
     }
     return this;
@@ -60,11 +60,13 @@ export class HTMLDocument extends Document {
         if (this.math[i]) this.math[i].UpdateDocument(this);
       }
       let sheet = this.DocumentStyleSheet();
-      let styles = this.document.getElementById(sheet.id);
-      if (styles) {
-        styles.parentNode.replaceChild(sheet,styles);
-      } else {
-        this.document.head.appendChild(sheet);
+      if (sheet) {
+        let styles = this.document.getElementById(sheet.id);
+        if (styles) {
+          styles.parentNode.replaceChild(sheet,styles);
+        } else {
+          this.document.head.appendChild(sheet);
+        }
       }
       this.processed.UpdateDocument = true;
     }

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -26,7 +26,7 @@ export class HTMLDocument extends Document {
   
   TestMath(string,display=true) {
     if (!this.processed.TestMath) {
-      this.math = [new HTMLMathItem(string,"TeX",display)];
+      this.math = [new HTMLMathItem(string,null,display)];
       this.processed.TestMath = true;
     }
     return this;

--- a/v3/mathjax/handlers/html/HTMLDocument.js
+++ b/v3/mathjax/handlers/html/HTMLDocument.js
@@ -3,6 +3,16 @@ import {HTMLMathItem} from "./HTMLMathItem.js";
 
 export class HTMLDocument extends Document {
 
+  FindMath(options) {
+    if (!this.processed.FindMath) {
+      this.InputJax.forEach(jax => {
+        this.math = this.math.concat(jax.FindMath(this.document.body));
+      });
+      this.processed.FindMath = true;
+    }
+    return this;
+  }
+  
   UpdateDocument() {
     if (!this.processed.UpdateDocument) {
       super.UpdateDocument();

--- a/v3/mathjax/handlers/html/HTMLMathItem.js
+++ b/v3/mathjax/handlers/html/HTMLMathItem.js
@@ -9,7 +9,7 @@ export class HTMLMathItem extends MathItem {
   
   Compile(html,options) {
     if (this.State() < STATE.COMPILED) {
-      this.tree = html.InputJaxMap.get(this.format).Compile(this.math,this.display);
+      this.tree = this.inputJax.Compile(this.math,this.display);
       this.State(STATE.COMPILED);
     }
   }

--- a/v3/mathjax/handlers/html/HTMLMathItem.js
+++ b/v3/mathjax/handlers/html/HTMLMathItem.js
@@ -2,23 +2,10 @@ import {MathItem} from "../../core/MathItem.js";
 
 export class HTMLMathItem extends MathItem {
   
-  constructor(math,format,display=true,
-             start={node:null, n:0, delim:""},end={node:null, n:0, delim:""}) {
-    super(math,format,display,start,end);
-  }
-  
-  Compile(html,options) {
-    if (this.State() < STATE.COMPILED) {
-      this.tree = this.inputJax.Compile(this.math,this.display);
-      this.State(STATE.COMPILED);
-    }
-  }
-  
-  Typeset(html,options) {
-    if (this.State() < STATE.TYPESET) {
-      this.typeset = html.OutputJax.Typeset(this,html);
-      this.State(STATE.TYPESET);
-    }
+  constructor(math,jax,display=true,
+             start={node:null, n:0, delim:""},
+             end={node:null, n:0, delim:""}) {
+    super(math,jax,display,start,end);
   }
   
   addEventHandlers() {}

--- a/v3/mathjax/handlers/html/HTMLMathItem.js
+++ b/v3/mathjax/handlers/html/HTMLMathItem.js
@@ -9,7 +9,7 @@ export class HTMLMathItem extends MathItem {
   
   Compile(html,options) {
     if (this.State() < STATE.COMPILED) {
-      this.tree = html.InputJax.Compile(this.math,this.display);
+      this.tree = html.InputJaxMap.get(this.format).Compile(this.math,this.display);
       this.State(STATE.COMPILED);
     }
   }

--- a/v3/mathjax/input/legacy/tex2jax.js
+++ b/v3/mathjax/input/legacy/tex2jax.js
@@ -23,7 +23,7 @@ MathJax.Extension.tex2jax.createMathTag = function (mode,tex) {
   var node = HTML.TextNode(search.openDelim+tex + search.closeDelim)
   this.insertNode(node);
   var item = new HTMLMathItem(
-    tex, 'TeX', mode !== '',
+    tex, this.jax, mode !== '',
     {node:node, n:0, delim:search.openDelim},
     {node:node, n:tex.length-1, delim:search.closeDelim}
   );
@@ -33,9 +33,10 @@ MathJax.Extension.tex2jax.createMathTag = function (mode,tex) {
 
 var math;
 exports.LegacyTeX2jax = {
-  FindMath: function (node) {
+  FindMath: function (node,jax) {
     math = [];
     MathJax.HTML.setDocument(node.ownerDocument);
+    MathJax.Extension.tex2jax.jax = jax;
     MathJax.Extension.tex2jax.PreProcess(node);
     return math;
   }

--- a/v3/mathjax/input/tex.js
+++ b/v3/mathjax/input/tex.js
@@ -1,6 +1,7 @@
 import {InputJax} from "../core/InputJax.js";
 import {LegacyTeX} from "./legacy/TeX.js";
 import {LegacyTeX2jax} from "./legacy/tex2jax.js";
+import {DefaultOptions} from "../util/Options.js";
 
 export class TeX extends InputJax {
   
@@ -19,3 +20,4 @@ export class TeX extends InputJax {
 };
 
 TeX.NAME = "TeX";
+TeX.OPTIONS = DefaultOptions({},InputJax.OPTIONS);

--- a/v3/mathjax/input/tex.js
+++ b/v3/mathjax/input/tex.js
@@ -3,6 +3,10 @@ import {LegacyTeX} from "./legacy/TeX.js";
 import {LegacyTeX2jax} from "./legacy/tex2jax.js";
 
 export class TeX extends InputJax {
+  
+  constructor(options) {
+    super("TeX",options);
+  }
 
   Compile(tex,display) {
     return LegacyTeX.Compile(tex,display);

--- a/v3/mathjax/input/tex.js
+++ b/v3/mathjax/input/tex.js
@@ -17,7 +17,7 @@ export class TeX extends InputJax {
   }
   
   FindMath(node) {
-    return LegacyTeX2jax.FindMath(node);
+    return LegacyTeX2jax.FindMath(node,this);
   }
   
 };

--- a/v3/mathjax/input/tex.js
+++ b/v3/mathjax/input/tex.js
@@ -4,10 +4,6 @@ import {LegacyTeX2jax} from "./legacy/tex2jax.js";
 
 export class TeX extends InputJax {
   
-  constructor(options) {
-    super("TeX",options);
-  }
-
   Compile(tex,display) {
     return LegacyTeX.Compile(tex,display);
   }
@@ -21,3 +17,5 @@ export class TeX extends InputJax {
   }
   
 };
+
+TeX.NAME = "TeX";

--- a/v3/mathjax/output/chtml.js
+++ b/v3/mathjax/output/chtml.js
@@ -3,10 +3,6 @@ import {LegacyCHTML} from "./legacy/CommonHTML.js";
 
 export class CHTML extends OutputJax {
 
-  constructor(options) {
-    super("CHTML",options);
-  }
-
   //
   //  Typeset a MathItem tree
   //
@@ -29,3 +25,5 @@ export class CHTML extends OutputJax {
   }
 
 };
+
+CHTML.NAME = "CHTML";

--- a/v3/mathjax/output/chtml.js
+++ b/v3/mathjax/output/chtml.js
@@ -1,5 +1,6 @@
 import {OutputJax} from "../core/OutputJax.js";
 import {LegacyCHTML} from "./legacy/CommonHTML.js";
+import {DefaultOptions} from "../util/Options.js";
 
 export class CHTML extends OutputJax {
 
@@ -27,3 +28,4 @@ export class CHTML extends OutputJax {
 };
 
 CHTML.NAME = "CHTML";
+CHTML.OPTIONS = DefaultOptions({},OutputJax.OPTIONS);

--- a/v3/mathjax/output/chtml.js
+++ b/v3/mathjax/output/chtml.js
@@ -3,6 +3,10 @@ import {LegacyCHTML} from "./legacy/CommonHTML.js";
 
 export class CHTML extends OutputJax {
 
+  constructor(options) {
+    super("CHTML",options);
+  }
+
   //
   //  Typeset a MathItem tree
   //

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -1,0 +1,86 @@
+//
+//  Check if an object is an object literal (as opposed to an instance of a class)
+//
+const OBJECT = {}.constructor;
+function isObject(obj) {
+  return typeof obj === 'object' && obj !== null && obj.constructor === OBJECT;
+}
+
+//
+//  Used to append an array to an array in default options
+//
+export const APPEND = Symbol('Append to option array');
+
+//
+//  Get all keys and symbols from an object
+//
+export function Keys(def) {
+  if (!def) return [];
+  return Object.keys(def).concat(Object.getOwnPropertySymbols(def));
+}
+
+//
+//  Make a deep copy of an object
+//
+export function Copy(def) {
+  let props = {};
+  Keys(def).forEach(key => {
+    let prop = Object.getOwnPropertyDescriptor(def,key);
+    let value = prop.value;
+    if (Array.isArray(value)) {
+      prop.value = Insert([],value,false);
+    } else if (isObject(value)) {
+      prop.value = Copy(value);
+    }
+    if (prop.enumerable) props[key] = prop;
+  });
+  return Object.defineProperties({},props);
+}
+
+//
+//  Insert one object into another (with optional warnings about
+//  keys that aren't in the original)
+//
+export function Insert(dst,src,warn = true) {
+  Keys(src).forEach(key => {
+    if (warn && dst[key] === undefined) {
+      if (typeof key === "symbol") key = key.toString();
+      throw new Error("Invalid option '"+key+"' (no default value).");
+    }
+    let sval = src[key], dval = dst[key];
+    if (isObject(sval) && dval !== null && 
+       (typeof dval === 'object' || typeof dval === 'function')) {
+      if (Array.isArray(dval) && Array.isArray(sval[APPEND]) && Keys(sval).length === 1) {
+        dval.push(...(sval[APPEND]));
+      } else {
+        Insert(dval,sval,warn);
+      }
+    } else if (Array.isArray(sval)) {
+      dst[key] = [];
+      Insert(dval,sval,warn);
+    } else if (isObject(sval)) {
+      dst[key] = Copy(sval);
+    } else {
+      dst[key] = sval;
+    }
+  });
+  return dst;
+}
+
+//
+//  Merge options without warnings (so we can add new default values into an
+//  existing default list)
+//
+export function DefaultOptions(options,...defs) {
+  defs.forEach(def => Insert(options,def,false));
+  return options;
+}
+
+//
+//  Merge options with warnings about undefined one (so we can merge
+//  user options into the default list)
+//
+export function UserOptions(options,...defs) {
+  defs.forEach(def => Insert(options,def,true));
+  return options;
+}

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -24,7 +24,7 @@ export function Keys(def) {
 //
 export function Copy(def) {
   let props = {};
-  Keys(def).forEach(key => {
+  for (let key of Keys(def)) {
     let prop = Object.getOwnPropertyDescriptor(def,key);
     let value = prop.value;
     if (Array.isArray(value)) {
@@ -33,7 +33,7 @@ export function Copy(def) {
       prop.value = Copy(value);
     }
     if (prop.enumerable) props[key] = prop;
-  });
+  }
   return Object.defineProperties({},props);
 }
 
@@ -42,7 +42,7 @@ export function Copy(def) {
 //  keys that aren't in the original)
 //
 export function Insert(dst,src,warn = true) {
-  Keys(src).forEach(key => {
+  for (let key of Keys(src)) {
     if (warn && dst[key] === undefined) {
       if (typeof key === "symbol") key = key.toString();
       throw new Error("Invalid option '"+key+"' (no default value).");
@@ -63,7 +63,7 @@ export function Insert(dst,src,warn = true) {
     } else {
       dst[key] = sval;
     }
-  });
+  }
   return dst;
 }
 
@@ -90,6 +90,8 @@ export function UserOptions(options,...defs) {
 //
 export function SelectOptions(options,...keys) {
   let subset = {};
-  keys.forEach(key => subset[key] = options[key]);
+  for (let key of keys) {
+    subset[key] = options[key];
+  }
   return subset;
 }

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -57,7 +57,7 @@ export function Insert(dst,src,warn = true) {
       }
     } else if (Array.isArray(sval)) {
       dst[key] = [];
-      Insert(dval,sval,warn);
+      Insert(dst[key],sval,warn);
     } else if (isObject(sval)) {
       dst[key] = Copy(sval);
     } else {

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -57,7 +57,7 @@ export function Insert(dst,src,warn = true) {
       }
     } else if (Array.isArray(sval)) {
       dst[key] = [];
-      Insert(dst[key],sval,warn);
+      Insert(dst[key],sval,false);
     } else if (isObject(sval)) {
       dst[key] = Copy(sval);
     } else {

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -24,7 +24,7 @@ export function Keys(def) {
 //
 export function Copy(def) {
   let props = {};
-  for (let key of Keys(def)) {
+  for (const key of Keys(def)) {
     let prop = Object.getOwnPropertyDescriptor(def,key);
     let value = prop.value;
     if (Array.isArray(value)) {
@@ -90,12 +90,27 @@ export function UserOptions(options,...defs) {
 //
 export function SelectOptions(options,...keys) {
   let subset = {};
-  for (let key of keys) {
+  for (const key of keys) {
     subset[key] = options[key];
   }
   return subset;
 }
 
+//
+//  Select a subset of options by keys from an object
+//
 export function SelectOptionsFromKeys(options,object) {
   return SelectOptions(options,...Object.keys(object));
+}
+
+//
+//  Separate options into two sets: the ones having the same keys
+//  as the second object, and the ones that don't.
+//
+export function SeparateOptions(options,object) {
+  let exists = {}, missing = {};
+  for (const key of Object.keys(options)) {
+    (object[key] === undefined ? missing : exists)[key] = options[key];
+  }
+  return [missing,exists];
 }

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -95,3 +95,7 @@ export function SelectOptions(options,...keys) {
   }
   return subset;
 }
+
+export function SelectOptionsFromKeys(options,object) {
+  return SelectOptions(options,...Object.keys(object));
+}

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -77,10 +77,19 @@ export function DefaultOptions(options,...defs) {
 }
 
 //
-//  Merge options with warnings about undefined one (so we can merge
+//  Merge options with warnings about undefined ones (so we can merge
 //  user options into the default list)
 //
 export function UserOptions(options,...defs) {
   defs.forEach(def => Insert(options,def,true));
   return options;
+}
+
+//
+//  Select a subset of options by key name
+//
+export function SelectOptions(options,...keys) {
+  let subset = {};
+  keys.forEach(key => subset[key] = options[key]);
+  return subset;
 }

--- a/v3/mathjax/util/Options.js
+++ b/v3/mathjax/util/Options.js
@@ -109,7 +109,7 @@ export function SelectOptionsFromKeys(options,object) {
 //
 export function SeparateOptions(options,object) {
   let exists = {}, missing = {};
-  for (const key of Object.keys(options)) {
+  for (const key of Object.keys(options||{})) {
     (object[key] === undefined ? missing : exists)[key] = options[key];
   }
   return [missing,exists];

--- a/v3/samples/document.js
+++ b/v3/samples/document.js
@@ -2,13 +2,20 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
+import {CHTML} from "mathjax/output/chtml.js";
+
+let OPTIONS = {
+  InputJax: new TeX(),
+  OutputJax: new CHTML()
+};
 
 var html;
 try {
   //
   //  Use browser document, if there is one
   //
-  html = MathJax.HandlerFor(document);
+  html = MathJax.HandlerFor(document,OPTIONS);
   var text = document.createTextNode('This is some math: \\(x+1\\).\n\\[x+1\\over x-1\\]');
   document.body.insertBefore(text,document.body.firstChild);
 } catch (err) {
@@ -21,7 +28,8 @@ try {
     <body>
     This is some math: \\(x+1\\).
     \\[x+1\\over x-1\\]
-    </body></html>`
+    </body></html>`,
+    OPTIONS
   );
 }
 

--- a/v3/samples/find-tex.js
+++ b/v3/samples/find-tex.js
@@ -2,17 +2,20 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
+
+let OPTIONS = {InputJax: new TeX()};
 
 let html = MathJax.HandlerFor(`
-<html>
-<head><title>Test MathJax3</title></head>
-<body>
-This is some math: \\(x+1\\).
-<p>\\[x+1\\over x-1\\]</p>
-more: \\(1-x\\)
-</body>
-</html>
-`);
+  <html>
+  <head><title>Test MathJax3</title></head>
+  <body>
+  This is some math: \\(x+1\\).
+  <p>\\[x+1\\over x-1\\]</p>
+  more: \\(1-x\\)
+  </body></html>`,
+  OPTIONS
+);
 
 MathJax.HandleRetriesFor(function () {
 

--- a/v3/samples/mml-tree.js
+++ b/v3/samples/mml-tree.js
@@ -2,10 +2,11 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
 import {MmlVisitor} from "TreeJax/lib/mml_visitor.js";
 
 let mml = new MmlVisitor();
-let html = MathJax.HandlerFor("<html></html>");
+let html = MathJax.HandlerFor("<html></html>",{InputJax: new TeX()});
 
 MathJax.HandleRetriesFor(function () {
 

--- a/v3/samples/tex-tree.js
+++ b/v3/samples/tex-tree.js
@@ -2,8 +2,9 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
 
-let html = MathJax.HandlerFor("<html></html>");
+let html = MathJax.HandlerFor("<html></html>", {InputJax: new TeX()});
 
 MathJax.HandleRetriesFor(function () {
 

--- a/v3/samples/tex-typeset.js
+++ b/v3/samples/tex-typeset.js
@@ -2,16 +2,23 @@ import {MathJax} from "mathjax/mathjax.js";
 export {MathJax} from "mathjax/mathjax.js";
 
 import "mathjax/handlers/html.js";
+import {TeX} from "mathjax/input/tex.js";
+import {CHTML} from "mathjax/output/chtml.js";
+
+let OPTIONS = {
+  InputJax: new TeX(),
+  OutputJax: new CHTML()
+};
 
 let html = MathJax.HandlerFor(`
-<html>
-<head><title>Test MathJax3</title></head>
-<body>
-This is some math: \\(x+1\\).
-\\[x+1\\over x-1\\]
-</body>
-</html>
-`);
+  <html>
+  <head><title>Test MathJax3</title></head>
+  <body>
+  This is some math: \\(x+1\\).
+  \\[x+1\\over x-1\\]
+  </body></html>`,
+  OPTIONS
+);
 
 MathJax.HandleRetriesFor(function () {
 


### PR DESCRIPTION
This PR adds support for default and user-supplied options for Document, InputJax, and OutputJax objects.  In particular, `MathJax.HandlerFor()` now takes options that select the input and output jax, so the main program must load the desired jax and pass them in (otherwise, default, do-nothing jax are used).

This also refactors generic code from `HTMLDocument.js` to `Document.js` and `HTMLMathItem.js` to `MathItem.js`.

Finally, Document and MathItem types and names are no longer passed to the constructor, they are taken from the object itself.