### PR TITLE
Make Factory object use generic types

### DIFF
--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -26,7 +26,7 @@ import {InputJax, AbstractInputJax} from './InputJax.js';
 import {OutputJax, AbstractOutputJax} from './OutputJax.js';
 import {MathList, AbstractMathList} from './MathList.js';
 import {MathItem, AbstractMathItem} from './MathItem.js';
-import {MmlNode} from './MmlTree/MmlNode.js';
+import {MmlNode, TextNode} from './MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
 
 /*****************************************************************/
@@ -313,7 +313,7 @@ export abstract class AbstractMathDocument implements MathDocument {
         math.root = errorFactory.create('math', {'data-mjx-error': err.message}, [
             errorFactory.create('merror', null, [
                 errorFactory.create('mtext', null, [
-                    errorFactory.create('text').setText('Math input error')
+                    (errorFactory.create('text') as TextNode).setText('Math input error')
                 ])
             ])
         ]);

--- a/mathjax3-ts/core/MmlTree/MmlFactory.ts
+++ b/mathjax3-ts/core/MmlTree/MmlFactory.ts
@@ -23,7 +23,7 @@
 
 import {Node, PropertyList} from '../Tree/Node.js';
 import {AbstractNodeFactory} from '../Tree/NodeFactory.js';
-import {MmlNodeClass} from './MmlNode.js';
+import {MmlNode, MmlNodeClass} from './MmlNode.js';
 import {MML} from './MML.js';
 
 /*****************************************************************/
@@ -31,29 +31,8 @@ import {MML} from './MML.js';
  *  Implements the MmlFactory (subclass of NodeFactory)
  */
 
-export class MmlFactory extends AbstractNodeFactory {
-    /*
-     * Mark this as containing MmlNodeClass entries
-     */
-    protected nodeMap: Map<string, MmlNodeClass>;
-
-    /*
-     * @parm {object} nodes  The list of node kinds and classes that can be created
-     *                       (defaults to the standard MML nodes)
-     *
-     * @constructor
-     * @extends {AbstractNodeFactory}
-     */
-    constructor(nodes: {[kind: string]: MmlNodeClass} = MML) {
-        super(nodes);
-    }
-
-    /*
-     * @override
-     */
-    public getNodeClass(kind: string): MmlNodeClass {
-        return this.nodeMap.get(kind);
-    }
+export class MmlFactory extends AbstractNodeFactory<MmlNode, MmlNodeClass> {
+    public static defaultNodes = MML;
 
     /*
      * @return {object}  The list of node-creation functions (similar to the

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -652,7 +652,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         let merror = this.factory.create('merror');
         if (options['fullErrors'] || short) {
             let mtext = this.factory.create('mtext');
-            let text = this.factory.create('text');
+            let text = this.factory.create('text') as TextNode;
             text.setText(options['fullErrors'] ? message : this.kind);
             mtext.appendChild(text);
             merror.appendChild(mtext);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mfenced.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mfenced.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList} from '../../Tree/Node.js';
-import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
+import {MmlNode, TextNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
 /*
@@ -141,7 +141,7 @@ export class MmlMfenced extends AbstractMmlNode {
      * @return {MmlNode}                 The generated <mo> node
      */
     protected fakeNode(c: string, properties: PropertyList = {}, texClass: number = null): MmlNode {
-        let text = this.factory.create('text').setText(c);
+        let text = (this.factory.create('text') as TextNode).setText(c);
         let node = this.factory.create('mo', properties, [text]);
         node.texClass = texClass;
         node.parent = this;

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -30,15 +30,34 @@ export interface FactoryNode {
     readonly kind: string;
 }
 
+/*
+ * @template N  The Node type being created by teh factory
+ */
 export interface FactoryNodeClass<N extends FactoryNode> {
+    /*
+     * @param{Factory<N, FactoryNodeClass<N>>} factory  The factory for creating more nodes
+     * @param{any[]} args  Any additional arguments needed by the node
+     * @return{N}  The newly created node
+     */
     new(factory: Factory<N, FactoryNodeClass<N>>, ...args: any[]): N;
 }
 
 /*****************************************************************/
 /*
  * The Factory interface
+ *
+ * Factory<N, C> takes a node type N and a node class C, which give
+ * the interfaces for the node instance and the node constructors. We
+ * need both for two reasons: first, you can't use typeof N to get C,
+ * since N is a type not an object, and if N has static members, we
+ * may want to access them from the results of getNodeClass(kind)
+ * (this is done in MmlNodes, for example).
  */
 
+/*
+ * @template N  The node type created by the factory
+ * @template C  The class of the node being constructed (for access to static properties)
+ */
 export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
     /*
      * @param {string} kind  The kind of node to create
@@ -53,11 +72,13 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
      * @param {C} nodeClass  The class for the given kind
      */
     setNodeClass(kind: string, nodeClass: C): void;
+
     /*
      * @param {string} kind  The kind of node whose class is to be returned
      * @return {C}  The class object for the given kind
      */
     getNodeClass(kind: string): C;
+
     /*
      * @param {string} kind  The kind whose definition is to be deleted
      */
@@ -83,6 +104,10 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
  *   (needed for access to defaultNodes via the constructor)
  */
 
+/*
+ * @template N  The node type created by the factory
+ * @template C  The class of the node being constructed (for access to static properties)
+ */
 interface AbstractFactoryClass<N extends FactoryNode, C extends FactoryNodeClass<N>> extends Function {
     defaultNodes: {[kind: string]: C};
 }
@@ -93,6 +118,10 @@ interface AbstractFactoryClass<N extends FactoryNode, C extends FactoryNodeClass
  * The generic AbstractFactory class
  */
 
+/*
+ * @template N  The node type created by the factory
+ * @template C  The class of the node being constructed (for access to static properties)
+ */
 export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNodeClass<N>> implements Factory<N, C> {
 
     /*
@@ -151,6 +180,7 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
     public getNodeClass(kind: string): C {
         return this.nodeMap.get(kind);
     }
+
     /*
      * @override
      */

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -103,7 +103,7 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
     /*
      * The default kind
      */
-    public defaultKind = "unknown";
+    public defaultKind = 'unknown';
 
     /*
      * The map of node kinds to node classes
@@ -113,7 +113,7 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
     /*
      * An object containing functions for creating the various node kinds
      */
-    protected node: {[kind: string]: Function} = {};
+    protected node: {[kind: string]: (...args: any[]) => N} = {};
 
     /*
      * @override
@@ -137,11 +137,13 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
     /*
      * @override
      */
-        public setNodeClass(kind: string, nodeClass: C) {
+    public setNodeClass(kind: string, nodeClass: C) {
         this.nodeMap.set(kind, nodeClass);
         let THIS = this;
         let KIND = this.nodeMap.get(kind);
-        this.node[kind] = (...args: any[]) => {return new KIND(THIS, ...args);};
+        this.node[kind] = (...args: any[]) => {
+            return new KIND(THIS, ...args);
+        };
     }
     /*
      * @override

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -1,0 +1,174 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The generic Factory class for creating arbitrary objects
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+/*****************************************************************/
+/*
+ * The Factory node interfaces (one for the node instance, one for the node class)
+ */
+
+export interface FactoryNode {
+    readonly kind: string;
+}
+
+export interface FactoryNodeClass<N extends FactoryNode> {
+    new(factory: Factory<N, FactoryNodeClass<N>>, ...args: any[]): N;
+}
+
+/*****************************************************************/
+/*
+ * The Factory interface
+ */
+
+export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
+    /*
+     * @param {string} kind  The kind of node to create
+     * @return {N}  The newly created node of the given kind
+     */
+    create(kind: string): N;
+
+    /*
+     * Defines a class for a given node kind
+     *
+     * @param {string} kind  The kind whose class is being defined
+     * @param {NodeClass} nodeClass  The class for the given kind
+     */
+    setNodeClass(kind: string, nodeClass: C): void;
+    /*
+     * @param {string} kind  The kind of node whose class is to be returned
+     * @return {NodeClass}  The class object for the given kind
+     */
+    getNodeClass(kind: string): C;
+    /*
+     * @param {string} kind  The kind whose definition is to be deleted
+     */
+    deleteNodeClass(kind: string): void;
+
+    /*
+     * @param {Node} node  The node to test if it is of a given kind
+     * @param {string} kind  The kind to test for
+     * @return {boolean}  True if the node is of the given kind, false otherwise
+     */
+    nodeIsKind(node: N, kind: string): boolean;
+
+    /*
+     * @return {string[]}  The names of all the available kinds of nodes
+     */
+    getKinds(): string[];
+}
+
+
+/*****************************************************************/
+/*
+ * The generic AbstractFactoryClass interface
+ *   (needed for access to defaultNodes via the constructor)
+ */
+
+interface AbstractFactoryClass<N extends FactoryNode, C extends FactoryNodeClass<N>> extends Function {
+    defaultNodes: {[kind: string]: C};
+}
+
+
+/*****************************************************************/
+/*
+ * The generic AbstractFactory class
+ */
+
+export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNodeClass<N>> implements Factory<N, C> {
+
+    /*
+     * The default collection of objects to use for the node map
+     */
+    public static defaultNodes = {};
+
+    /*
+     * The default kind
+     */
+    public defaultKind = "unknown";
+
+    /*
+     * The map of node kinds to node classes
+     */
+    protected nodeMap: Map<string, C> = new Map();
+
+    /*
+     * An object containing functions for creating the various node kinds
+     */
+    protected node: {[kind: string]: Function} = {};
+
+    /*
+     * @override
+     */
+    constructor(nodes: {[kind: string]: C} = null) {
+        if (nodes === null) {
+            nodes = (this.constructor as AbstractFactoryClass<N, C>).defaultNodes;
+        }
+        for (const kind of Object.keys(nodes)) {
+            this.setNodeClass(kind, nodes[kind]);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public create(kind: string, ...args: any[]) {
+        return (this.node[kind] || this.node[this.defaultKind])(...args);
+    }
+
+    /*
+     * @override
+     */
+        public setNodeClass(kind: string, nodeClass: C) {
+        this.nodeMap.set(kind, nodeClass);
+        let THIS = this;
+        let KIND = this.nodeMap.get(kind);
+        this.node[kind] = (...args: any[]) => {return new KIND(THIS, ...args);};
+    }
+    /*
+     * @override
+     */
+    public getNodeClass(kind: string): C {
+        return this.nodeMap.get(kind);
+    }
+    /*
+     * @override
+     */
+    public deleteNodeClass(kind: string) {
+        this.nodeMap.delete(kind);
+        delete this.node[kind];
+    }
+
+    /*
+     * @override
+     */
+    public nodeIsKind(node: N, kind: string) {
+        return (node instanceof this.getNodeClass(kind));
+    }
+
+    /*
+     * @override
+     */
+    public getKinds() {
+        return Array.from(this.nodeMap.keys());
+    }
+
+}

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -50,12 +50,12 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
      * Defines a class for a given node kind
      *
      * @param {string} kind  The kind whose class is being defined
-     * @param {NodeClass} nodeClass  The class for the given kind
+     * @param {C} nodeClass  The class for the given kind
      */
     setNodeClass(kind: string, nodeClass: C): void;
     /*
      * @param {string} kind  The kind of node whose class is to be returned
-     * @return {NodeClass}  The class object for the given kind
+     * @return {C}  The class object for the given kind
      */
     getNodeClass(kind: string): C;
     /*
@@ -64,7 +64,7 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
     deleteNodeClass(kind: string): void;
 
     /*
-     * @param {Node} node  The node to test if it is of a given kind
+     * @param {N} node  The node to test if it is of a given kind
      * @param {string} kind  The kind to test for
      * @return {boolean}  True if the node is of the given kind, false otherwise
      */

--- a/mathjax3-ts/core/Tree/Node.ts
+++ b/mathjax3-ts/core/Tree/Node.ts
@@ -123,7 +123,7 @@ export interface NodeClass {
      * @param {Node[]} children  The initial child nodes, if any
      * @return {Node}  The newly created node
      */
-    new (factory: NodeFactory, properties?: PropertyList, children?: Node[]): Node;
+    new (factory: NodeFactory<Node, NodeClass>, properties?: PropertyList, children?: Node[]): Node;
 }
 
 /*********************************************************/
@@ -146,7 +146,7 @@ export abstract class AbstractNode implements Node {
     /*
      * The NodeFactory to use to create additional nodes, as needed
      */
-    protected _factory: NodeFactory = null;
+    protected _factory: NodeFactory<Node, NodeClass> = null;
 
     /*
      * The children for this node
@@ -162,7 +162,7 @@ export abstract class AbstractNode implements Node {
      * @constructor
      * @implements {Node}
      */
-    constructor(factory: NodeFactory, properties: PropertyList = {}, children: Node[] = []) {
+    constructor(factory: NodeFactory<Node, NodeClass>, properties: PropertyList = {}, children: Node[] = []) {
         this._factory = factory;
         for (const name of Object.keys(properties)) {
             this.setProperty(name, properties[name]);

--- a/mathjax3-ts/core/Tree/NodeFactory.ts
+++ b/mathjax3-ts/core/Tree/NodeFactory.ts
@@ -22,49 +22,21 @@
  */
 
 import {Node, NodeClass, PropertyList} from './Node.js';
+import {Factory, FactoryNodeClass, AbstractFactory} from './Factory.js';
 
 /*****************************************************************/
 /*
  * The NodeFactory interface
  */
 
-export interface NodeFactory {
+export interface NodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends Factory<N, C> {
     /*
      * @param {string} kind  The kind of node to create
      * @param {PropertyList} properties  The list of initial properties for the node (if any)
-     * @param {Node[]} children  The array of initial child nodes (if any)
-     * @return {Node}  The newly created node of the given kind
+     * @param {N[]} children  The array of initial child nodes (if any)
+     * @return {N}  The newly created node of the given kind
      */
-    create(kind: string, properties?: PropertyList, children?: Node[]): Node;
-
-    /*
-     * Defines a class for a given node kind
-     *
-     * @param {string} kind  The kind whose class is being defined
-     * @param {NodeClass} nodeClass  The class for the given kind
-     */
-    setNodeClass(kind: string, nodeClass: NodeClass): void;
-    /*
-     * @param {string} kind  The kind of node whose class is to be returned
-     * @return {NodeClass}  The class object for the given kind
-     */
-    getNodeClass(kind: string): NodeClass;
-    /*
-     * @param {string} kind  The kind whose definition is to be deleted
-     */
-    deleteNodeClass(kind: string): void;
-
-    /*
-     * @param {Node} node  The node to test if it is of a given kind
-     * @param {string} kind  The kind to test for
-     * @return {boolean}  True if the node is of the given kind, false otherwise
-     */
-    nodeIsKind(node: Node, kind: string): boolean;
-
-    /*
-     * @return {string[]}  The names of all the available kinds of nodes
-     */
-    getKinds(): string[];
+    create(kind: string, properties?: PropertyList, children?: N[]): N;
 }
 
 /*****************************************************************/
@@ -72,69 +44,12 @@ export interface NodeFactory {
  * The generic NodeFactory class
  */
 
-export abstract class AbstractNodeFactory implements NodeFactory {
-    /*
-     * The map of node kinds to node classes
-     */
-    protected nodeMap: Map<string, NodeClass> = new Map();
-    /*
-     * An object containing functions for creating the various node kinds
-     */
-    protected node: {[kind: string]: Function} = {};
-
+export abstract class AbstractNodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends AbstractFactory<N, C> {
     /*
      * @override
      */
-    constructor(nodes: {[kind: string]: NodeClass} = {}) {
-        for (const kind of Object.keys(nodes)) {
-            this.setNodeClass(kind, nodes[kind]);
-        }
-    }
-
-    /*
-     * @override
-     */
-    public create(kind: string, properties: PropertyList = {}, children: Node[] = []) {
+    public create(kind: string, properties: PropertyList = {}, children: N[] = []) {
         return this.node[kind](properties, children);
-    }
-
-    /*
-     * @override
-     */
-    public setNodeClass(kind: string, nodeClass: NodeClass) {
-        this.nodeMap.set(kind, nodeClass);
-        let THIS = this;
-        let KIND = this.nodeMap.get(kind);
-        this.node[kind] = function (properties: PropertyList, children: Node[]) {
-            return new KIND(THIS, properties, children);
-        };
-    }
-    /*
-     * @override
-     */
-    public getNodeClass(kind: string): NodeClass {
-        return this.nodeMap.get(kind);
-    }
-    /*
-     * @override
-     */
-    public deleteNodeClass(kind: string) {
-        this.nodeMap.delete(kind);
-        delete this.node[kind];
-    }
-
-    /*
-     * @override
-     */
-    public nodeIsKind(node: Node, kind: string) {
-        return (node instanceof this.getNodeClass(kind));
-    }
-
-    /*
-     * @override
-     */
-    public getKinds() {
-        return Array.from(this.nodeMap.keys());
     }
 
 }

--- a/mathjax3-ts/core/Tree/NodeFactory.ts
+++ b/mathjax3-ts/core/Tree/NodeFactory.ts
@@ -29,6 +29,10 @@ import {Factory, FactoryNodeClass, AbstractFactory} from './Factory.js';
  * The NodeFactory interface
  */
 
+/*
+ * @template N  The node type created by the factory
+ * @template C  The class of the node being constructed (for access to static properties)
+ */
 export interface NodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends Factory<N, C> {
     /*
      * @param {string} kind  The kind of node to create
@@ -44,6 +48,10 @@ export interface NodeFactory<N extends Node, C extends FactoryNodeClass<N>> exte
  * The generic NodeFactory class
  */
 
+/*
+ * @template N  The node type created by the factory
+ * @template C  The class of the node being constructed (for access to static properties)
+ */
 export abstract class AbstractNodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends AbstractFactory<N, C> {
     /*
      * @override

--- a/mathjax3-ts/core/Tree/Visitor.ts
+++ b/mathjax3-ts/core/Tree/Visitor.ts
@@ -21,13 +21,13 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {Node, AbstractNode} from './Node.js';
+import {Node, NodeClass, AbstractNode} from './Node.js';
 import {NodeFactory} from './NodeFactory.js';
 
 /*
  * The type for the functions associated with each node class
  */
-export type VisitorFunction = (visitor: NodeFactory, node: Node, ...args: any[]) => any;
+export type VisitorFunction = (visitor: NodeFactory<Node, NodeClass>, node: Node, ...args: any[]) => any;
 
 /*****************************************************************/
 /*
@@ -114,7 +114,7 @@ export abstract class AbstractVisitor implements Visitor {
      * @constructor
      * @param {NodeFactory} factory  The node factory for the kinds of nodes this visitor handles
      */
-    constructor(factory: NodeFactory) {
+    constructor(factory: NodeFactory<Node, NodeClass>) {
         for (const kind of factory.getKinds()) {
             let method = (this as Visitor)[AbstractVisitor.methodName(kind)] as VisitorFunction;
             if (method) {

--- a/mathjax3-ts/input/mathml/MathMLCompile.ts
+++ b/mathjax3-ts/input/mathml/MathMLCompile.ts
@@ -23,7 +23,8 @@
 
 import {MmlFactory} from '../../core/MmlTree/MmlFactory.js';
 import {MmlEntities} from './MmlEntities.js';
-import {MmlNode, AbstractMmlNode, AbstractMmlTokenNode, TEXCLASS} from '../../core/MmlTree/MmlNode.js';
+import {MmlNode, TextNode, XMLNode, AbstractMmlNode, AbstractMmlTokenNode, TEXCLASS}
+    from '../../core/MmlTree/MmlNode.js';
 import {userOptions, defaultOptions, OptionList} from '../../util/Options.js';
 
 /********************************************************************/
@@ -87,7 +88,7 @@ export class MathMLCompile {
     public compile(node: HTMLElement) {
         let mml = this.makeNode(node);
         mml.verifyTree(this.options['verify']);
-        mml.setInheritedAttributes();
+        mml.setInheritedAttributes({}, false, 0, false);
         mml.walkTree(this.markMrows);
         return mml;
     }
@@ -174,7 +175,7 @@ export class MathMLCompile {
             if (child.nodeName === '#text') {
                 this.addText(mml, child);
             } else if (mml.isKind('annotation-xml')) {
-                mml.appendChild(this.factory.create('XML').setXML(child));
+                mml.appendChild((this.factory.create('XML') as XMLNode).setXML(child));
             } else {
                 let childMml = mml.appendChild(this.makeNode(child)) as MmlNode;
                 if (childMml.arity === 0 && child.childNodes.length) {
@@ -202,7 +203,7 @@ export class MathMLCompile {
                 text = this.entities.translate(text);
                 text = this.trimSpace(text);
             }
-            mml.appendChild(this.factory.create('text').setText(text));
+            mml.appendChild((this.factory.create('text') as TextNode).setText(text));
         } else if (text.match(/\S/)) {
             this.error('Unexpected text node "' + text + '"');
         }


### PR DESCRIPTION
This implements factories for generic types, as the `Factory` object in `mathjax3-ts/core/Tree/Factory.ts`.

Most of the functionality of `NodeFactory` has been moved to `Factory` and made generic.  `Factory<N, C>` takes a node type `N` and a node class `C` which give the interfaces for the node instance and the node constructors.  We need both for two reasons:  first, you can't use `typeof N` to get `C`, since `N` is a type not an object, and if `N` has static members, we may want to access them from the results of `getNodeClass(kind)` (this is done in MmlNodes, for example).

Most of `MmlFactory` can now be removed, since it is in the generic `Factory<MmlNode, MmlNodeClass>` object and was only in `MmlFactory` to set the types from `Node` to `MmlNode` and `NodeClass` to `MmlNodeClass`, and to set the default for `nodes` in the constructor (this is now handled via a static property).

Finally, `mathjax3-ts/core/Tree/Node.js` and `mathjax3-ts/core/Tree/Visitor.js` needed to have their references to `NodeFactory` to be updated.  The `Node` and `Visitor` objects themselves need to be made generic, which will be handled in a later PR (since Volker asked for small changes).