### PR TITLE
Minor fixes

### DIFF
--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -48,6 +48,7 @@
             }
           }
         }
+        if (this['class']) node.attributes.set('class',this['class']);
       }
       for (var i = 0, m = names.length; i < m; i++) {
         if (copy[names[i]] === 1 && !defaults.hasOwnProperty(names[i])) continue;

--- a/mathjax3-ts/core/MmlTree/Attributes.ts
+++ b/mathjax3-ts/core/MmlTree/Attributes.ts
@@ -175,17 +175,24 @@ export class Attributes {
     }
 
     /*
-     * @return {PropertyList}  The attribute object
+     * @return {PropertyList}  The inherited object
      */
     public getAllInherited() {
         return this.inherited;
     }
 
     /*
-     * @return {PropertyList}  The attribute object
+     * @return {PropertyList}  The defaults object
      */
     public getAllDefaults() {
         return this.defaults;
+    }
+
+    /*
+     * @return {PropertyList}  The global object
+     */
+    public getAllGlobals() {
+        return this.global;
     }
 
 }

--- a/mathjax3-ts/core/MmlTree/Attributes.ts
+++ b/mathjax3-ts/core/MmlTree/Attributes.ts
@@ -49,10 +49,10 @@ export class Attributes {
      * @constructor
      */
     constructor(defaults: PropertyList, global: PropertyList) {
-        this.defaults = defaults;
-        this.inherited = Object.create(defaults);
-        this.attributes = Object.create(this.inherited);
         this.global = global;
+        this.defaults = Object.create(global);
+        this.inherited = Object.create(this.defaults);
+        this.attributes = Object.create(this.inherited);
     }
 
     /*

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mi.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mi.ts
@@ -58,7 +58,7 @@ export class MmlMi extends AbstractMmlTokenNode {
                            display: boolean = false, level: number = 0, prime: boolean = false) {
         super.setInheritedAttributes(attributes, display, level, prime);
         let text = this.getText();
-        if (text.match(MmlMi.singleCharacter)) {
+        if (text.match(MmlMi.singleCharacter) && !attributes.mathvariant) {
             this.attributes.setInherited('mathvariant', 'italic');
         }
     }

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -65,6 +65,10 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
                 level = parseInt(scriptlevel);
             }
         }
+        let displaystyle = this.attributes.getExplicit('displaystyle') as string;
+        if (displaystyle != null) {
+            display = (displaystyle === 'true');
+        }
         attributes = this.addInheritedAttributes(attributes, this.attributes.getAllAttributes());
         this.childNodes[0].setInheritedAttributes(attributes, display, level, prime);
     }


### PR DESCRIPTION
This fixes up a few minor issues:

* In legacy TeX input jax, the class wasn't being passed along

* In MmlNode attributes, the global attributes need to be part of the lookup chain (and some comments were wrong)

* For mi elements, the mathvariant should be set only if it isn't being inherited

* For mstyle elements, they should set the displaystyle if it is explicitly included.