### PR TITLE
Beginnings of CHTML output jax

### DIFF
--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -31,7 +31,7 @@ export interface FactoryNode {
 }
 
 /*
- * @template N  The Node type being created by teh factory
+ * @template N  The Node type being created by the factory
  */
 export interface FactoryNodeClass<N extends FactoryNode> {
     /*

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -32,7 +32,7 @@ import {WrapperFactory} from './WrapperFactory.js';
  */
 
 /*
- * @template N  The Node type being created by the factory
+ * @template N  The Node type being wrapped
  * @template W  The Wrapper type being produced
  */
 export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
@@ -41,8 +41,8 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
 
     /*
      * @param {Node} node  A node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when wrapping the node
-     * @return {Wrapper}   The newly wrapped node
+     * @param{any[]} args  Any additional arguments needed when creating the wrapper
+     * @return {Wrapper}   The wrapped node
      */
     wrap(node: N, ...args: any[]): W;
 }
@@ -53,14 +53,14 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
  */
 
 /*
- * @template N  The Node type being created by the factory
+ * @template N  The Node type being wrapped
  * @template W  The Wrapper type being produced
  */
 export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
     /*
      * @param{WrapperFactory} factory  The factory used to create more wrappers
      * @param{N} node  The node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when wrapping the node
+     * @param{any[]} args  Any additional arguments needed when creating the wrapper
      * @return{W}  The wrapped node
      */
     new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N, ...args: any[]): W;

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -31,15 +31,20 @@ import {WrapperFactory} from './WrapperFactory.js';
  *  It points to a Node object.  Subclasses add methods for the visitor to call.
  */
 
+/*
+ * @template N  The Node type being created by the factory
+ * @template W  The Wrapper type being produced
+ */
 export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
     node: N;
     readonly kind: string;
 
     /*
-     * @param {Node} node  A (child) node to be wrapped
-     * @return {Wrapper}  The newly wrapped node
+     * @param {Node} node  A node to be wrapped
+     * @param{any[]} args  Any additional arguments needed when wrapping the node
+     * @return {Wrapper}   The newly wrapped node
      */
-    wrap(node: N): W;
+    wrap(node: N, ...args: any[]): W;
 }
 
 /*********************************************************/
@@ -47,7 +52,17 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
  *  The Wrapper class interface
  */
 
+/*
+ * @template N  The Node type being created by the factory
+ * @template W  The Wrapper type being produced
+ */
 export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
+    /*
+     * @param{WrapperFactory} factory  The factory used to create more wrappers
+     * @param{N} node  The node to be wrapped
+     * @param{any[]} args  Any additional arguments needed when wrapping the node
+     * @return{W}  The wrapped node
+     */
     new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N, ...args: any[]): W;
 }
 
@@ -56,6 +71,10 @@ export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
  *  The abstract Wrapper class
  */
 
+/*
+ * @template N  The Node type being created by the factory
+ * @template W  The Wrapper type being produced
+ */
 export class AbstractWrapper<N extends Node, W extends Wrapper<N, W>> implements Wrapper<N, W> {
     /*
      * The Node object associated with this instance
@@ -67,6 +86,9 @@ export class AbstractWrapper<N extends Node, W extends Wrapper<N, W>> implements
      */
     protected factory: WrapperFactory<N, W, WrapperClass<N, W>>;
 
+    /*
+     * The kind of this wrapper
+     */
     get kind() {
         return this.node.kind;
     }

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -1,0 +1,94 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Generic Wrapper class for adding methods to a Node class for visitors
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {Node} from './Node.js';
+import {WrapperFactory} from './WrapperFactory.js';
+
+/*********************************************************/
+/*
+ *  The Wrapper interface
+ *
+ *  It points to a Node object.  Subclasses add methods for the visitor to call.
+ */
+
+export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
+    node: N;
+    readonly kind: string;
+
+    /*
+     * @param {Node} node  A (child) node to be wrapped
+     * @return {Wrapper}  The newly wrapped node
+     */
+    wrap(node: N): W;
+}
+
+/*********************************************************/
+/*
+ *  The Wrapper class interface
+ */
+
+export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
+    new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N): W;
+}
+
+/*********************************************************/
+/*
+ *  The abstract Wrapper class
+ */
+
+export class AbstractWrapper<N extends Node, W extends Wrapper<N, W>> implements Wrapper<N, W> {
+    /*
+     * The Node object associated with this instance
+     */
+    public node: N;
+
+    /*
+     * The WrapperFactory to use to wrap child nodes, as needed
+     */
+    protected factory: WrapperFactory<N, W, WrapperClass<N, W>>;
+
+    get kind() {
+        return this.node.kind;
+    }
+
+    /*
+     * @param {WrapperFactory} factory  The WrapperFactory to use to wrap child nodes when needed
+     * @param {Node} node               The node to wrap
+     * @return {Wrapper}                The newly created wrapped node
+     *
+     * @constructor
+     * @implements {Wrapper}
+     */
+    constructor(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N) {
+        this.factory = factory;
+        this.node = node;
+    }
+
+    /*
+     * @override
+     */
+    public wrap(node: N) {
+        return this.factory.wrap(node);
+    }
+
+}

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -48,7 +48,7 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
  */
 
 export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
-    new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N): W;
+    new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N, ...args: any[]): W;
 }
 
 /*********************************************************/

--- a/mathjax3-ts/core/Tree/WrapperFactory.ts
+++ b/mathjax3-ts/core/Tree/WrapperFactory.ts
@@ -4,7 +4,7 @@ import {Factory, AbstractFactory} from './Factory.js';
 
 export interface WrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends Factory<W, C> {
-    wrap(node: N): W;
+    wrap(node: N, ...args: any[]): W;
 }
 
 /*****************************************************************/
@@ -14,7 +14,7 @@ extends Factory<W, C> {
 
 export abstract class AbstractWrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends AbstractFactory<W, C> implements WrapperFactory<N, W, C> {
-    public wrap(node: N) {
-        return this.create(node.kind, node);
+    public wrap(node: N, ...args: any[]) {
+        return this.create(node.kind, node, ...args);
     }
 }

--- a/mathjax3-ts/core/Tree/WrapperFactory.ts
+++ b/mathjax3-ts/core/Tree/WrapperFactory.ts
@@ -1,9 +1,47 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Generic WrapperFactory class for creating Wrapper objects
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
 import {Node} from './Node.js';
 import {Wrapper, WrapperClass} from './Wrapper.js';
 import {Factory, AbstractFactory} from './Factory.js';
 
+/*****************************************************************/
+/*
+ * The generic WrapperFactory class
+ */
+
+/*
+ * @template N  The Node type being created by the factory
+ * @template W  The Wrapper type being produced (instance type)
+ * @template C  The Wrapper class (for static values)
+ */
 export interface WrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends Factory<W, C> {
+    /*
+     * @param{N} node  The node to be wrapped
+     * @param{any[]} args  Any additional arguments needed when wrapping the node
+     * @return{W}  The newly wrapped node
+     */
     wrap(node: N, ...args: any[]): W;
 }
 
@@ -12,8 +50,18 @@ extends Factory<W, C> {
  * The generic WrapperFactory class
  */
 
+/*
+ * @template N  The Node type being created by the factory
+ * @template W  The Wrapper type being produced (instance type)
+ * @template C  The Wrapper class (for static values)
+ */
 export abstract class AbstractWrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends AbstractFactory<W, C> implements WrapperFactory<N, W, C> {
+    /*
+     * @param{N} node  The node to be wrapped
+     * @param{any[]} args  Any additional arguments needed when wrapping the node
+     * @return{W}  The newly wrapped node
+     */
     public wrap(node: N, ...args: any[]) {
         return this.create(node.kind, node, ...args);
     }

--- a/mathjax3-ts/core/Tree/WrapperFactory.ts
+++ b/mathjax3-ts/core/Tree/WrapperFactory.ts
@@ -1,0 +1,20 @@
+import {Node} from './Node.js';
+import {Wrapper, WrapperClass} from './Wrapper.js';
+import {Factory, AbstractFactory} from './Factory.js';
+
+export interface WrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
+extends Factory<W, C> {
+    wrap(node: N): W;
+}
+
+/*****************************************************************/
+/*
+ * The generic WrapperFactory class
+ */
+
+export abstract class AbstractWrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
+extends AbstractFactory<W, C> implements WrapperFactory<N, W, C> {
+    public wrap(node: N) {
+        return this.create(node.kind, node);
+    }
+}

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -28,7 +28,7 @@ import {MathItem} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {HTMLNodes} from '../util/HTMLNodes.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
-import {BIGDIMEN, percent} from '../util/lengths.js';
+import {percent} from '../util/lengths.js';
 
 /*****************************************************************/
 /*

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -52,7 +52,7 @@ export class CHTML extends AbstractOutputJax {
     public factory: CHTMLWrapperFactory;
 
     /*
-     * The MatahDocument for the math we find
+     * The MathDocument for the math we find
      * and the MathItem currently being processed
      */
     public document: MathDocument;

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -22,10 +22,13 @@
  */
 
 import {AbstractOutputJax} from '../core/OutputJax.js';
-import {LegacyCHTML} from '../../mathjax2/output/CommonHTML.js';
 import {OptionList} from '../util/Options.js';
 import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
+import {MmlNode} from '../core/MmlTree/MmlNode.js';
+import {HTMLNodes} from '../util/HTMLNodes.js';
+import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
+import {BIGDIMEN, percent} from '../util/lengths.js';
 
 /*****************************************************************/
 /*
@@ -36,41 +39,110 @@ export class CHTML extends AbstractOutputJax {
 
     public static NAME: string = 'CHTML';
     public static OPTIONS: OptionList = {
-        ...AbstractOutputJax.OPTIONS
+        ...AbstractOutputJax.OPTIONS,
+        scale: 1,                      // Global scaling factor for all expressions
+        skipAttributes: {},            // RFDa and other attributes NOT to copy to CHTML output
+        CHTMLWrapperFactory: null      // The CHTMLWrapper factory to use
     };
 
     /*
-     * @override
+     *  Used to store the HTMLNodes factory and the CHTMLWraper factory.
      */
-    public typeset(math: MathItem, html: MathDocument) {
-        return LegacyCHTML.Typeset(math, html);
+    public nodes: HTMLNodes;
+    public factory: CHTMLWrapperFactory;
+
+    /*
+     * The MatahDocument for the math we find
+     * and the MathItem currently being processed
+     */
+    public document: MathDocument;
+    public math: MathItem;
+
+    /*
+     * Get the WrapperFactory and connect it to this output jax
+     * Get the HTMLNodes instance
+     *
+     * @param{OptionList} options  The configuration options
+     * @constructor
+     */
+    constructor(options: OptionList = null) {
+        super(options);
+        this.factory = this.options.CHTMLWrapperFactory || new CHTMLWrapperFactory();
+        this.factory.chtml = this;
+        this.nodes = new HTMLNodes();
     }
 
     /*
-     * Handle an escaped character
-     *  (put it in a span so that it won't be a delimiter if
-     *  the page is typeset again).
+     * Save the math document and the math item
+     * Set the document where HTMLNodes will be created
+     * Recusrively set the TeX classes for the nodes
+     * Create the container mjx-chtml node
+     * Create the CHTML output for the root MathML node in the container
      *
      * @override
      */
+    public typeset(math: MathItem, html: MathDocument) {
+        this.document = html;
+        this.math = math;
+        this.nodes.document(html.document);
+        math.root.setTeXclass(null);
+        let node = this.html('mjx-chtml', {'class': 'MathJax_CHTML MJX-TEX'});
+        const scale = math.metrics.scale * this.options.scale;
+        if (scale !== 1) {
+            node.style.fontSize = percent(scale);
+        }
+        this.toCHTML(math.root, node);
+        return node;
+    }
+
+    /*
+     * @override
+     */
     public escaped(math: MathItem, html: MathDocument) {
-        let span = html.document.createElement('span');
-        span.appendChild(html.document.createTextNode(math.math));
-        return span;
+        this.nodes.document(html.document);
+        return this.html('span', {}, [this.text(math.math)]);
     }
 
     /*
      * @override
      */
     public getMetrics(html: MathDocument) {
-        return LegacyCHTML.GetMetrics(html);
+
     }
 
     /*
      * @override
      */
     public styleSheet(html: MathDocument) {
-        return LegacyCHTML.StyleSheet(html);
+        return null as Element;
+    }
+
+    /*
+     * @param{MmlNode} node  The MML node whose HTML is to be produced
+     * @param{HTMLElement} parent  The HTML node to contain the HTML
+     */
+    public toCHTML(node: MmlNode, parent: HTMLElement) {
+        return this.factory.wrap(node).toCHTML(parent);
+    }
+
+    /*
+     * @param{string} type  The type of HTML node to create
+     * @param{OptionList} def  The properties to set on the HTML node
+     * @param{Node[]} content  Array of child nodes to set for the HTML node
+     *
+     * @return{HTMLElement} The newly created HTML tree
+     */
+    public html(type: string, def: OptionList = {}, content: Node[] = []) {
+        return this.nodes.node(type, def, content);
+    }
+
+    /*
+     * @param{string} text  The text string for which to make a text node
+     *
+     * @return{HTMLElement}  A text node with the given text
+     */
+    public text(text: string) {
+        return this.nodes.text(text);
     }
 
 }

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -84,7 +84,7 @@ export class CHTML extends AbstractOutputJax {
     public typeset(math: MathItem, html: MathDocument) {
         this.document = html;
         this.math = math;
-        this.nodes.document(html.document);
+        this.nodes.document = html.document;
         math.root.setTeXclass(null);
         let node = this.html('mjx-chtml', {'class': 'MathJax_CHTML MJX-TEX'});
         const scale = math.metrics.scale * this.options.scale;
@@ -99,7 +99,7 @@ export class CHTML extends AbstractOutputJax {
      * @override
      */
     public escaped(math: MathItem, html: MathDocument) {
-        this.nodes.document(html.document);
+        this.nodes.document = html.document;
         return this.html('span', {}, [this.text(math.math)]);
     }
 

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -1,0 +1,156 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements a bounding-box object and operations on it
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {BIGDIMEN, length2em} from '../../util/lengths.js';
+
+/*
+ *  CSS styles that affect BBoxes
+ */
+export const BBoxstyleAdjust = [
+    ['borderTopWidth', 'h'],
+    ['borderRightWidth', 'w'],
+    ['borderBottomWidth', 'd'],
+    ['borderLeftWidth', 'w', 0],
+    ['paddingTop', 'h'],
+    ['paddingRight', 'w'],
+    ['paddingBottom', 'd'],
+    ['paddingLeft', 'w', 0]
+];
+
+/*
+ *  The data used to initialie a BBox
+ */
+export type BBoxData = {
+    w?: number,
+    h?: number,
+    d?: number
+};
+
+/*****************************************************************/
+/*
+ *  The BBox class
+ */
+
+export class BBox {
+    /*
+     *  These are the data stored for a bounding box
+     */
+    public w: number;
+    public h: number;
+    public d: number;
+    public x: number;
+    public y: number;
+    public scale: number;
+    public rscale: number; // scale relative to the parent's scale
+    public L: number;      // extra space on the left
+    public R: number;      // extra space on the right
+    public pwidth: string; // percentage width (for tables)
+
+    /*
+     * @return{BBox}  A BBox initialized to zeros
+     */
+    public static zero() {
+        return new BBox({h: 0, d: 0, w: 0});
+    }
+
+    /*
+     * @return{BBox}  A BBox with height and depth not set
+     */
+    public static empty() {
+        return new BBox();
+    }
+
+    /*
+     * @param{BBoxData} def  The data with which to initialize the BBox
+     *
+     * @return{BBox}  The newly created BBox
+     *
+     * @constructor
+     */
+    constructor(def: BBoxData = {w: 0, h: -BIGDIMEN, d: -BIGDIMEN}) {
+        this.w = ('w' in def ? def.w : 0);
+        this.h = ('h' in def ? def.h : -BIGDIMEN);
+        this.d = ('d' in def ? def.d : -BIGDIMEN);
+        this.x = this.y = this.L = this.R = 0;
+        this.scale = this.rscale = 1;
+        this.pwidth = '';
+    }
+
+    /*
+     * Convert any unspecified values into zeros
+     */
+    public clean () {
+        if (this.w === -BIGDIMEN) this.w = 0;
+        if (this.h === -BIGDIMEN) this.h = 0;
+        if (this.d === -BIGDIMEN) this.d = 0;
+    }
+
+    /*
+     * @param{number} scale  The scale to use to modify the bounding box size
+     */
+    public rescale(scale: number) {
+        this.w *= scale;
+        this.h *= scale;
+        this.d *= scale;
+    }
+
+    /*
+     * @param{BBox} cbox  A bounding to combine with this one
+     * @param{number} x   An x-offest for the child bounding box
+     * @param{number} y   A y-offset for the child bounding box
+     */
+    public combine(cbox: BBox, x: number = 0, y: number = 0) {
+        cbox.x = x;
+        cbox.x = y;
+        let rscale = cbox.rscale;
+        if (x + rscale * (cbox.w + cbox.L + cbox.R) > this.w) {
+            this.w  = x + rscale * (cbox.w + cbox.L + cbox.R);
+        }
+        if (y + rscale * cbox.h > this.h) {
+            this.h = y + rscale * cbox.h;
+        }
+        if (rscale * cbox.d - y > this.d) {
+            this.d = rscale * cbox.d - y;
+        }
+    }
+
+    /*
+     * @param{BBox} cbox  A bounding box to be added to the right of this one
+     */
+    public append(cbox: BBox) {
+        this.combine(cbox, this.w, 0);
+    }
+
+    /*
+     * @param{BBox} cbox  The bounding box to use to overright this one
+     */
+    public updateFrom(cbox: BBox) {
+        this.h = cbox.h;
+        this.d = cbox.d;
+        this.w = cbox.w;
+        if (cbox.pwidth !== '') {
+            this.pwidth = cbox.pwidth;
+        }
+    }
+
+}

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -88,7 +88,7 @@ export class BBox {
      * @constructor
      */
     constructor(def: BBoxData = {w: 0, h: -BIGDIMEN, d: -BIGDIMEN}) {
-        this.w = ('w' in def ? def.w : 0);
+        this.w = def.w || 0;
         this.h = ('h' in def ? def.h : -BIGDIMEN);
         this.d = ('d' in def ? def.d : -BIGDIMEN);
         this.x = this.y = this.L = this.R = 0;
@@ -155,7 +155,7 @@ export class BBox {
         this.h = cbox.h;
         this.d = cbox.d;
         this.w = cbox.w;
-        if (cbox.pwidth !== '') {
+        if (cbox.pwidth) {
             this.pwidth = cbox.pwidth;
         }
     }

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -149,7 +149,7 @@ export class BBox {
     }
 
     /*
-     * @param{BBox} cbox  The bounding box to use to overright this one
+     * @param{BBox} cbox  The bounding box to use to overwrite this one
      */
     public updateFrom(cbox: BBox) {
         this.h = cbox.h;

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -138,7 +138,14 @@ export class BBox {
      * @param{BBox} cbox  A bounding box to be added to the right of this one
      */
     public append(cbox: BBox) {
-        this.combine(cbox, this.w, 0);
+        let scale = cbox.rscale;
+        this.w += scale * (cbox.w + cbox.L + cbox.R);
+        if (scale * cbox.h > this.h) {
+            this.h = scale * cbox.h;
+        }
+        if (scale * cbox.d > this.d) {
+            this.d = scale*cbox.d;
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/TeX.ts
+++ b/mathjax3-ts/output/chtml/TeX.ts
@@ -1,0 +1,57 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The TeX font parameters as an object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+export const TexFontParams = {
+    x_height:         .442,
+    quad:             1,
+    num1:             .676508,
+    num2:             .393732,
+    num3:             .44373,
+    denom1:           .685951,
+    denom2:           .344841,
+    sup1:             .412892,
+    sup2:             .362892,
+    sup3:             .288888,
+    sub1:             .15,
+    sub2:             .247217,
+    sup_drop:         .386108,
+    sub_drop:         .05,
+    delim1:          2.39,
+    delim2:          1.0,
+    axis_height:      .25,
+    rule_thickness:   .06,
+    big_op_spacing1:  .111111,
+    big_op_spacing2:  .166666,
+    big_op_spacing3:  .2,
+    big_op_spacing4:  .45, // .6,  // better spacing for under arrows and braces
+    big_op_spacing5:  .1,
+
+    surd_height:      .075,
+
+    scriptspace:         .05,
+    nulldelimiterspace:  .12,
+    delimiterfactor:     901,
+    delimitershortfall:   .3,
+
+    min_rule_thickness:  1.25     // in pixels
+};

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -265,7 +265,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      */
     public getBBox(save: boolean = true) {
         if (this.bboxComputed) {
-            retirn this.bbox;
+            return this.bbox;
         }
         let bbox = this.computeBBox();
         if (save) {

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -212,8 +212,9 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     /*
      * @override
      */
-    constructor(factory: CHTMLWrapperFactory, node: MmlNode) {
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
         super(factory, node);
+        this.parent = parent;
         this.bbox = BBox.zero();
         this.getStyles();
         this.getVariant();
@@ -229,8 +230,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * @return{CHTMLWrapper}  The newly wrapped node
      */
     public wrap(node: MmlNode, parent: CHTMLWrapper = null) {
-        const wrapped = this.factory.wrap(node);
-        wrapped.parent = parent || this;
+        const wrapped = this.factory.wrap(node, parent || this);
         if (parent) {
             parent.childNodes.push(wrapped);
         }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -226,7 +226,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
 
     /*
      * @param{MmlNode} node  The node to the wrapped
-     * @param{CHTMLWrapper} parent  The parent wrapped node
+     * @param{CHTMLWrapper} parent  The wrapped parent node
      * @return{CHTMLWrapper}  The newly wrapped node
      */
     public wrap(node: MmlNode, parent: CHTMLWrapper = null) {
@@ -258,21 +258,21 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     /*******************************************************************/
     /*
      * Return the wrapped node's bounding box, either the cached one, if it exists,
-     *   or computed direcctly if not.
+     *   or computed directly if not.
      *
      * @param{boolean} save  Whether to cache the bbox or not (used for stretchy elements)
      * @return{BBox}  The computed bounding box
      */
     public getBBox(save: boolean = true) {
-        if (!this.bboxComputed) {
-            let bbox = this.computeBBox();
-            if (save) {
-                this.bbox = bbox;
-                this.bboxComputed = true;
-            }
-            return bbox;
+        if (this.bboxComputed) {
+            retirn this.bbox;
         }
-        return this.bbox;
+        let bbox = this.computeBBox();
+        if (save) {
+            this.bbox = bbox;
+            this.bboxComputed = true;
+        }
+        return bbox;
     }
 
     /*
@@ -561,14 +561,14 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
 
     /*
      * @param{string} text  The text to turn into unicode locations
-     * @return{number[]}  Array of numbers represeting the string's unicode charater positions
+     * @return{number[]}  Array of numbers represeting the string's unicode character positions
      */
     protected unicodeChars(text: string) {
         return unicodeChars(text);
     }
 
     /*
-     * @param{number} n  A unicode code point to be converred to a character reference for use with the
+     * @param{number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).
      * @return{string}  The character as a properly encoded string.

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -458,7 +458,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * Set the CSS for the math variant
      */
     protected handleVariant() {
-        if (this.variant !== '-explicitFont') {
+        if (this.node.isToken && this.variant !== '-explicitFont') {
             this.chtml.className = VARIANT[this.variant] || VARIANT.normal;
         }
     }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -1,0 +1,604 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLWrapper class
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {AbstractWrapper} from '../../core/Tree/Wrapper.js';
+import {Node} from '../../core/Tree/Node.js';
+import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {Property} from '../../core/Tree/Node.js';
+import {OptionList} from '../../util/Options.js';
+import {unicodeChars} from '../../util/string.js';
+import * as LENGTHS from '../../util/lengths.js';
+import {HTMLNodes} from '../../util/HTMLNodes.js';
+import {CHTML} from '../chtml.js';
+import {CHTMLWrapperFactory} from './WrapperFactory.js';
+import {BBox, BBoxData} from './BBox.js';
+import {TexFontParams} from './TeX.js';
+
+/*****************************************************************/
+
+/*
+ * Shorthand for a dictionary object (an object of key:value pairs)
+ */
+export type StringMap = {[key: string]: string};
+
+/*
+ * The classes to use for each variant
+ */
+export const VARIANT: StringMap = {
+    normal: 'mjx-n',
+    bold: 'mjx-b',
+    italic: 'mjx-i',
+    'bold-italic': 'mjx-b mjx-i',
+    'double-struck': 'mjx-ds',
+    'fraktur': 'mjx-fr',
+    'bold-fraktur': 'mjx-fr mjx-b',
+    'script': 'mjx-sc',
+    'bold-script': 'mjx-sc mjx-b',
+    'sans-serif': 'mjx-ss',
+    'bold-sans-serif': 'mjx-ss mjx-b',
+    'sans-serif-italic': 'mjx-ss mjx-i',
+    'bold-sans-serif-italic': 'mjx-ss mjx-b mjx-i',
+    monospace: 'mjx-ty',
+    '-tex-caligraphic': 'mjx-cal',
+    '-tex-oldstyle': 'mjx-os',
+    '-tex-mathit': 'mjx-mit',
+    '-smallop': 'mjx-sop',
+    '-largeop': 'mjx-lop',
+    '-size3': 'mjx-s3',
+    '-size4': 'mjx-s4',
+};
+
+/*
+ * The value to use for each spacing size
+ */
+export const SPACE: StringMap = {
+    thinmathspace: '1',
+    mediummathspace: '2',
+    thickmathspace: '3'
+};
+
+/*
+ * Needed to access node.style[id] using variable id
+ */
+interface CSSStyle extends CSSStyleDeclaration {
+    [id: string]: string | Function | number | CSSRule;
+}
+
+/*****************************************************************/
+/*
+ *  The base CHTMLWrapper class
+ */
+
+export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
+
+    public static kind: string = 'unknown';
+
+    /*
+     * Styles that should not be passed on from style attribute
+     */
+    public static removeStyles: [string] = [
+        'fontSize', 'fontFamily', 'fontWeight',
+        'fontStyle', 'fontVariant', 'font'
+    ];
+
+    /*
+     * Non-MathML attributes on MathML elements NOT to be copied to the
+     * corresponding CHTML elements.  If set to false, then the attribute
+     * WILL be copied.  Most of these (like the font attributes) are handled
+     * in other ways.
+     */
+    public static skipAttributes: {[name: string]: boolean} = {
+        fontfamily: true, fontsize: true, fontweight: true, fontstyle: true,
+        color: true, background: true,
+        'class': true, href: true, style: true,
+        xmlns: true
+    };
+
+    /*
+     * The translation of mathvariant to bold or italic styles, or to remove
+     * bold or italic from a mathvariant.
+     */
+    public static BOLDVARIANTS: {[name: string]: StringMap} =  {
+        bold: {
+            normal: 'bold',
+            italic: 'bold-italic',
+            fraktur: 'bold-fraktur',
+            script: 'bold-script',
+            'sans-serif': 'bold-sans-serif',
+            'sans-serif-italic': 'sans-serif-bold-italic'
+        },
+        normal: {
+            bold: 'normal',
+            'bold-italic': 'italic',
+            'bold-fraktur': 'fraktur',
+            'bold-script': 'script',
+            'bold-sans-serif': 'sans-serif',
+            'sans-serif-bold-italic': 'sans-serif-italic'
+        }
+    };
+    public static ITALICVARIANTS: {[name: string]: StringMap} = {
+        italic: {
+            normal: 'italic',
+            bold: 'bold-italic',
+            'sans-serif': 'sans-serif-italic',
+            'bold-sans-serif': 'sans-serif-bold-italic'
+        },
+        normal: {
+            italic: 'normal',
+            'bold-italic': 'bold',
+            'sans-serif-italic': 'sans-serif',
+            'sans-serif-bold-italic': 'bold-sans-serif'
+        }
+    };
+
+    /*
+     * The factory used to create more CHTMLWrappers
+     */
+    protected factory: CHTMLWrapperFactory;
+
+    /*
+     * The parent and children of this node
+     */
+    public parent: CHTMLWrapper = null;
+    public childNodes: CHTMLWrapper[];
+
+    /*
+     * The HTML element generated for this wrapped node
+     */
+    public chtml: HTMLElement = null;
+
+    /*
+     * Styles that must be handled directly by CHTML (mostly having to do with fonts)
+     */
+    protected removedStyles: StringMap = null;
+
+    /*
+     * The explicit styles set by the node
+     */
+    protected styles: CSSStyleDeclaration = null;
+
+    /*
+     * The mathvariant for this node
+     */
+    public variant: string = '';
+
+    /*
+     * The bounding box for this node, and whether it has been computed yet
+     */
+    public bbox: BBox;
+    protected bboxComputed: boolean = false;
+
+    /*
+     * Easy access to the font parameters
+     */
+    public TeX = TexFontParams;
+
+    /*
+     * Easy access to the CHTML output jax for this node
+     */
+    get CHTML() {
+        return this.factory.chtml;
+    }
+
+    /*
+     * Easy access to the metric data for this node
+     */
+    get metrics() {
+        return this.factory.chtml.math.metrics;
+    }
+
+    /*******************************************************************/
+
+    /*
+     * @override
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode) {
+        super(factory, node);
+        this.bbox = BBox.zero();
+        this.getStyles();
+        this.getVariant();
+        this.getScale();
+        this.childNodes = node.childNodes.map((child: Node) => {
+            return this.wrap(child as MmlNode);
+        });
+    }
+
+    /*
+     * @param{MmlNode} node  The node to the wrapped
+     * @param{CHTMLWrapper} parent  The parent wrapped node
+     * @return{CHTMLWrapper}  The newly wrapped node
+     */
+    public wrap(node: MmlNode, parent: CHTMLWrapper = null) {
+        const wrapped = this.factory.wrap(node);
+        wrapped.parent = parent || this;
+        if (parent) {
+            parent.childNodes.push(wrapped);
+        }
+        return wrapped;
+    }
+
+    /*******************************************************************/
+    /*
+     * Create the HTML for the wrapped node.
+     *
+     * @param{HTMLElement} parent  The HTML node where the output is added
+     * @param{number[]} WHD  Either [W] or [H,D], giving the dimensions to stretch
+     *                       a stretchable embellished operator to
+     */
+    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+        let chtml = parent;
+        if (!this.node.isInferred) {
+            chtml = this.standardCHTMLnode(parent);
+        }
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml, WHD);
+        }
+    }
+
+    /*******************************************************************/
+    /*
+     * Return the wrapped node's bounding box, either the cached one, if it exists,
+     *   or computed direcctly if not.
+     *
+     * @param{boolean} save  Whether to cache the bbox or not (used for stretchy elements)
+     * @return{BBox}  The computed bounding box
+     */
+    public getBBox(save: boolean = true) {
+        if (!this.bboxComputed) {
+            let bbox = this.computeBBox();
+            if (save) {
+                this.bbox = bbox;
+                this.bboxComputed = true;
+            }
+            return bbox;
+        }
+        return this.bbox;
+    }
+
+    /*
+     * @return{BBox}  The computed bounding box for the wrapped node
+     */
+    protected computeBBox() {
+        const bbox = BBox.empty();
+        for (const child of this.childNodes) {
+            bbox.append(child.getBBox());
+        }
+        bbox.clean();
+        return bbox;
+    }
+
+    /*******************************************************************/
+
+    /*
+     * Add the style attribute, but remove any font-related styles
+     *   (since these are handled separately by the variant)
+     */
+    protected getStyles() {
+        const styleString = this.node.attributes.getExplicit('style') as string;
+        if (styleString) {
+            this.styles = this.html('span').style;
+            const style = this.styles as CSSStyle;
+            style.cssText = styleString;
+            for (let i = 0, m = CHTMLWrapper.removeStyles.length; i < m; i++) {
+                const id = CHTMLWrapper.removeStyles[i];
+                if (style[id]) {
+                    if (!this.removedStyles) this.removedStyles = {};
+                    this.removedStyles[id] = style[id] as string;
+                    style[id] = '';
+                }
+            }
+        }
+    }
+
+    /*
+     * Get the mathvariant (or construct one, if needed).
+     */
+    protected getVariant() {
+        if (this.node.isToken) {
+            const attributes = this.node.attributes;
+            let variant = attributes.get('mathvariant') as string;
+            if (!attributes.getExplicit('mathvariant')) {
+                const values = attributes.getList('fontfamily', 'fontweight', 'fontstyle') as StringMap;
+                if (this.removedStyles) {
+                    const style = this.removedStyles;
+                    if (style.fontFamily) values.family = style.fontFamily;
+                    if (style.fontWeight) values.weight = style.fontWeight;
+                    if (style.fontStyle)  values.style  = style.fontStyle;
+                }
+                if (values.fontfamily) values.family = values.fontfamily;
+                if (values.fontweight) values.weight = values.fontweight;
+                if (values.fontstyle)  values.style  = values.fontstyle;
+                if (values.weight && values.weight.match(/^\d+$/)) {
+                    values.weight = (parseInt(values.weight) > 600 ? 'bold' : 'normal');
+                }
+                if (values.family) {
+                    variant = this.explicitVariant(values.family, values.weight, values.style);
+                } else {
+                    if (this.node.getProperty('variantForm')) variant = '-TeX-variant';
+                    variant = (CHTMLWrapper.BOLDVARIANTS[values.weight] || {})[variant] || variant;
+                    variant = (CHTMLWrapper.ITALICVARIANTS[values.style] || {})[variant] || variant;
+                }
+            }
+            this.variant = variant;
+        }
+    }
+
+    /*
+     * Set the CSS for a token element having an explicit font (rather than regular mathvariant).
+     *
+     * @param{string} fontFamily  The font family to use
+     * @param{string} fontWeight  The font weight to use
+     * @param{string} fontStyle   The font style to use
+     */
+    protected explicitVariant(fontFamily: string, fontWeight: string, fontStyle: string) {
+        let style = this.styles;
+        if (!style) style = this.styles = this.html('span').style;
+        style.fontFamily = fontFamily;
+        if (fontWeight) style.fontWeight = fontWeight;
+        if (fontStyle)  style.fontStyle = fontStyle;
+        return '-explicitFont';
+    }
+
+    /*
+     * Determine the scaling factor to use for this wrapped node, and set the styles for it.
+     *
+     * @return{number}   The scaling factor for this node
+     */
+    protected getScale() {
+        let scale = 1, parent = this.parent;
+        let pscale = (parent ? parent.bbox.scale : 1);
+        let attributes = this.node.attributes;
+        let scriptlevel = Math.min(attributes.get('scriptlevel') as number, 2);
+        let fontsize = attributes.get('fontsize');
+        let mathsize = (parent && !this.node.isToken ? parent : this).node.attributes.get('mathsize');
+        //
+        // If scriptsize is non-zero, set scale based on scriptsizemultiplier
+        //
+        if (scriptlevel !== 0) {
+            scale = Math.pow(attributes.get('scriptsizemultiplier') as number, scriptlevel);
+            let scriptminsize = this.length2em(attributes.get('scriptminsize'), .8, 1);
+            if (scale < scriptminsize) scale = scriptminsize;
+        }
+        //
+        // If there is style="font-size:...", and not fontsize attribute, use that as fontsize
+        //
+        if (this.removedStyles && this.removedStyles.fontSize && !fontsize) {
+            fontsize = this.removedStyles.fontSize;
+        }
+        //
+        // If there is a fontsize and no mathsize attribute, is that
+        //
+        if (fontsize && !mathsize) {
+            mathsize = fontsize;
+        }
+        //
+        //  Incorporate the mathsize, if any
+        //
+        if (mathsize !== '1') {
+            scale *= this.length2em(mathsize, 1, 1);
+        }
+        //
+        // For explicit font family, go back to the scaing of the surrounding text
+        //
+        if (this.variant === '-explicitFont') {
+           scale /= this.metrics.scale;
+        }
+        //
+        // Record the scaling factors and set the element's CSS
+        //
+        this.bbox.scale = scale;
+        this.bbox.rscale = scale / pscale;
+    }
+
+    /*******************************************************************/
+
+    /*
+     * Create the standard CHTML element for the given wrapped node.
+     *
+     * @param{HTMLElement} parent  The HTML element in which the node is to be created
+     * @returns{HTMLElement}  The root of the HTML tree for the wrapped node's output
+     */
+    protected standardCHTMLnode(parent: HTMLElement) {
+        const chtml = this.createCHTMLnode(parent);
+        this.handleStyles();
+        this.handleVariant();
+        this.handleScale();
+        this.handleColor();
+        this.handleSpace();
+        this.handleAttributes();
+        return chtml;
+    }
+
+    /*
+     * @param{HTMLElement} parent  The HTML element in which the node is to be created
+     * @returns{HTMLElement}  The root of the HTML tree for the wrapped node's output
+     */
+    protected createCHTMLnode(parent: HTMLElement) {
+        const href = this.node.attributes.get('href');
+        if (href) {
+            parent = parent.appendChild(this.html('a', {href: href}));
+        }
+        this.chtml = parent.appendChild(this.html('mjx-' + this.node.kind));
+        return this.chtml;
+    }
+
+    /*
+     * Set the CSS styles for the chtml element
+     */
+    protected handleStyles() {
+        if (this.styles) {
+            const styles = this.styles.cssText;
+            if (styles) {
+                this.chtml.style.cssText = styles;
+            }
+        }
+    }
+
+    /*
+     * Set the CSS for the math variant
+     */
+    protected handleVariant() {
+        if (this.variant !== '-explicitFont') {
+            this.chtml.className = VARIANT[this.variant] || VARIANT.normal;
+        }
+    }
+
+    /*
+     * Set the (relative) scaling factor for the node
+     */
+    protected handleScale() {
+        const scale = (Math.abs(this.bbox.rscale - 1) < .001 ? 1 : this.bbox.rscale);
+        if (this.chtml && scale !== 1) {
+            this.chtml.style.fontSize = this.percent(scale);
+        }
+    }
+
+    /*
+     * Add the proper spacing according to the TeX rules
+     *   FIXME:  still need to handle MathML spacing
+     */
+    protected handleSpace() {
+        const space = this.node.texSpacing();
+        if (space) {
+            this.bbox.L = this.length2em(space);
+            this.chtml.setAttribute('space', SPACE[space]);
+        }
+    }
+
+    /*
+     * Add the foreground and background colors
+     * (Only look at explicit attributes, since inherited ones will
+     *  be applied to a parent element, and we will inherit from that)
+     */
+    protected handleColor() {
+        const attributes = this.node.attributes;
+        const mathcolor = attributes.getExplicit('mathcolor') as string;
+        const color = attributes.getExplicit('color') as string;
+        const mathbackground = attributes.getExplicit('mathbackground') as string;
+        const background = attributes.getExplicit('background') as string;
+        if (mathcolor || color) {
+            this.chtml.style.color = mathcolor || color;
+        }
+        if (mathbackground || background) {
+            this.chtml.style.backgroundColor = mathbackground || background;
+        }
+    }
+
+    /*
+     * Copy RDFa, aria, and other tags from the MathML to the CHTML output nodes.
+     * Don't copy those in the skipAttributes list, or anything that already exists
+     * as a property of the node (e.g., no "onlick", etc.).  If a name in the
+     * skipAttributes object is set to false, then the attribute WILL be copied.
+     */
+    protected handleAttributes() {
+        const attributes = this.node.attributes;
+        const globals = attributes.getAllGlobals();
+        const skip = CHTMLWrapper.skipAttributes;
+        for (const name of attributes.getExplicitNames()) {
+            if (skip[name] === false || (!globals.hasOwnProperty(name) && !skip[name] &&
+                                         typeof((this.chtml as {[name: string]: any})[name]) === 'undefined')) {
+                this.chtml.setAttribute(name, attributes.getExplicit(name) as string);
+            }
+        }
+        if (attributes.get('class')) {
+            this.chtml.classList.add(attributes.get('class') as string);
+        }
+    }
+
+    /*******************************************************************/
+    /*
+     * Easy access to some utility routines
+     */
+
+    /*
+     * @param{number} m  A number to be shown as a percent
+     * @return{string}  The number m as a percent
+     */
+    protected percent(m: number) {
+        return LENGTHS.percent(m);
+    }
+
+    /*
+     * @param{number} m  A number to be shown in ems
+     * @return{string}  The number with units of ems
+     */
+    protected em(m: number) {
+        return LENGTHS.em(m);
+    }
+
+    /*
+     * @param{Property} length  A dimension (giving number and units) or number to be converted to ems
+     * @param{number} size  The default size of the dimension (for percentage values)
+     * @param{number} scale  The current scaling factor (to handle absolute units)
+     * @return{number}  The dimension converted to ems
+     */
+    protected length2em(length: Property, size: number = 1, scale: number = null) {
+        if (scale === null) {
+            scale = this.bbox.scale;
+        }
+        return LENGTHS.length2em(length as string, size, scale, this.metrics.em);
+    }
+
+    /*
+     * @param{string} text  The text to turn into unicode locations
+     * @return{number[]}  Array of numbers represeting the string's unicode charater positions
+     */
+    protected unicodeChars(text: string) {
+        return unicodeChars(text);
+    }
+
+    /*
+     * @param{number} n  A unicode code point to be converred to a character reference for use with the
+     *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
+     *                   for higher values, or for the double quote and backslash characters).
+     * @return{string}  The character as a properly encoded string.
+     */
+    protected char(n: number, escape: boolean = false) {
+        return (n >= 0x20 && n <= 0x7E && n !== 0x22 && n !== 0x5C ?
+                String.fromCharCode(n) : (escape ? '\\' : '') + n.toString(16).toUpperCase());
+    }
+
+    /*
+     * @param{string} type  The tag name of the HTML node to be created
+     * @param{OptionList} def  The properties to set for the created node
+     * @param{HTMLElement[]} content  The child nodes for the created HTML node
+     * @return{HTMLElement}   The generated HTML tree
+     */
+    public html(type: string, def: OptionList = {}, content: HTMLElement[] = []) {
+        return this.factory.chtml.html(type, def, content);
+    }
+
+    /*
+     * @param{string} text  The text from which to create an HTML text node
+     * @return{HTMLElement}  The generated text node with the given text
+     */
+    public text(text: string) {
+        return this.factory.chtml.text(text);
+    }
+
+}
+
+/*
+ *  The type of the CHTMLWrapper class (used when creating the wrapper factory for this class)
+ */
+export type CHTMLWrapperClass = typeof CHTMLWrapper;

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -295,17 +295,16 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      */
     protected getStyles() {
         const styleString = this.node.attributes.getExplicit('style') as string;
-        if (styleString) {
-            this.styles = this.html('span').style;
-            const style = this.styles as CSSStyle;
-            style.cssText = styleString;
-            for (let i = 0, m = CHTMLWrapper.removeStyles.length; i < m; i++) {
-                const id = CHTMLWrapper.removeStyles[i];
-                if (style[id]) {
-                    if (!this.removedStyles) this.removedStyles = {};
-                    this.removedStyles[id] = style[id] as string;
-                    style[id] = '';
-                }
+        if (!styleString) return;
+        this.styles = this.html('span').style;
+        const style = this.styles as CSSStyle;
+        style.cssText = styleString;
+        for (let i = 0, m = CHTMLWrapper.removeStyles.length; i < m; i++) {
+            const id = CHTMLWrapper.removeStyles[i];
+            if (style[id]) {
+                if (!this.removedStyles) this.removedStyles = {};
+                this.removedStyles[id] = style[id] as string;
+                style[id] = '';
             }
         }
     }
@@ -314,33 +313,32 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * Get the mathvariant (or construct one, if needed).
      */
     protected getVariant() {
-        if (this.node.isToken) {
-            const attributes = this.node.attributes;
-            let variant = attributes.get('mathvariant') as string;
-            if (!attributes.getExplicit('mathvariant')) {
-                const values = attributes.getList('fontfamily', 'fontweight', 'fontstyle') as StringMap;
-                if (this.removedStyles) {
-                    const style = this.removedStyles;
-                    if (style.fontFamily) values.family = style.fontFamily;
-                    if (style.fontWeight) values.weight = style.fontWeight;
-                    if (style.fontStyle)  values.style  = style.fontStyle;
-                }
-                if (values.fontfamily) values.family = values.fontfamily;
-                if (values.fontweight) values.weight = values.fontweight;
-                if (values.fontstyle)  values.style  = values.fontstyle;
-                if (values.weight && values.weight.match(/^\d+$/)) {
-                    values.weight = (parseInt(values.weight) > 600 ? 'bold' : 'normal');
-                }
-                if (values.family) {
-                    variant = this.explicitVariant(values.family, values.weight, values.style);
-                } else {
-                    if (this.node.getProperty('variantForm')) variant = '-TeX-variant';
-                    variant = (CHTMLWrapper.BOLDVARIANTS[values.weight] || {})[variant] || variant;
-                    variant = (CHTMLWrapper.ITALICVARIANTS[values.style] || {})[variant] || variant;
-                }
+        if (!this.node.isToken) return;
+        const attributes = this.node.attributes;
+        let variant = attributes.get('mathvariant') as string;
+        if (!attributes.getExplicit('mathvariant')) {
+            const values = attributes.getList('fontfamily', 'fontweight', 'fontstyle') as StringMap;
+            if (this.removedStyles) {
+                const style = this.removedStyles;
+                if (style.fontFamily) values.family = style.fontFamily;
+                if (style.fontWeight) values.weight = style.fontWeight;
+                if (style.fontStyle)  values.style  = style.fontStyle;
             }
-            this.variant = variant;
+            if (values.fontfamily) values.family = values.fontfamily;
+            if (values.fontweight) values.weight = values.fontweight;
+            if (values.fontstyle)  values.style  = values.fontstyle;
+            if (values.weight && values.weight.match(/^\d+$/)) {
+                values.weight = (parseInt(values.weight) > 600 ? 'bold' : 'normal');
+            }
+            if (values.family) {
+                    variant = this.explicitVariant(values.family, values.weight, values.style);
+            } else {
+                if (this.node.getProperty('variantForm')) variant = '-TeX-variant';
+                variant = (CHTMLWrapper.BOLDVARIANTS[values.weight] || {})[variant] || variant;
+                variant = (CHTMLWrapper.ITALICVARIANTS[values.style] || {})[variant] || variant;
+            }
         }
+        this.variant = variant;
     }
 
     /*
@@ -446,11 +444,10 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * Set the CSS styles for the chtml element
      */
     protected handleStyles() {
-        if (this.styles) {
-            const styles = this.styles.cssText;
-            if (styles) {
-                this.chtml.style.cssText = styles;
-            }
+        if (!this.styles) return;
+        const styles = this.styles.cssText;
+        if (styles) {
+            this.chtml.style.cssText = styles;
         }
     }
 

--- a/mathjax3-ts/output/chtml/WrapperFactory.ts
+++ b/mathjax3-ts/output/chtml/WrapperFactory.ts
@@ -1,0 +1,54 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLWrapperFactory class
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTML} from '../chtml.js';
+import {AbstractWrapperFactory} from '../../core/Tree/WrapperFactory.js';
+import {CHTMLWrapper, CHTMLWrapperClass} from './Wrapper.js';
+import {CHTMLWrappers} from './Wrappers.js';
+import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLWrapperFactory class for creating CHTMLWrapper nodes
+ */
+
+export class CHTMLWrapperFactory extends AbstractWrapperFactory<MmlNode, CHTMLWrapper, CHTMLWrapperClass> {
+
+    /*
+     * The default list of wrapper nodes this factory can create
+     */
+    public static defaultNodes = CHTMLWrappers;
+
+    /*
+     * The CHTML output jax associated with this factory
+     */
+    public chtml: CHTML = null;
+
+    /*
+     * @return {object}  The list of node-creation functions
+     */
+    get Wrappers() {
+        return this.node;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -1,0 +1,34 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  An object listing all the CHTMLWrapper classes
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from './Wrapper.js';
+import {CHTMLmspace} from './Wrappers/mspace.js';
+import {CHTMLmfrac} from './Wrappers/mfrac.js';
+import {CHTMLTextNode} from './Wrappers/TextNode.js';
+
+export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
+    [CHTMLmspace.kind]: CHTMLmspace,
+    [CHTMLmfrac.kind]: CHTMLmfrac,
+    [CHTMLTextNode.kind]: CHTMLTextNode,
+    [CHTMLWrapper.kind]: CHTMLWrapper
+};

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -1,0 +1,83 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLTextNode wrapper for the TextNode object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+import {TextNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLTextNode wrapper for the TextNode object
+ */
+
+export class CHTMLTextNode extends CHTMLWrapper {
+    public static kind = TextNode.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+        let text = (this.node as TextNode).getText();
+        if (this.parent.variant === '-explicitFont') {
+            parent.appendChild(this.text(text));
+        } else {
+            for (const n of this.unicodeChars(text)) {
+                parent.appendChild(this.html('mjx-c', {c: this.char(n)}));
+            }
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        //
+        // Fake a bbox for now (eventually, this will get looked up in the font table)
+        //
+        this.bbox.w = .5;
+        this.bbox.h = .8;
+        this.bbox.d = .2;
+        return this.bbox;
+    }
+
+    /******************************************************/
+    /*
+     * TextNodes don't need these, since these properties
+     *   are inherited from the parent nodes
+     */
+
+    /*
+     * @override
+     */
+    public getStyles() {}
+
+    /*
+     * @override
+     */
+    public getVariant() {}
+
+    /*
+     * @override
+     */
+    public getScale() {}
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -37,7 +37,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: Element, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
         let num, den;
         let chtml = this.html('mjx-frac', {}, [
             num = this.html('mjx-num', {}, [this.html('mjx-dstrut')]),
@@ -67,7 +67,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
         const a = this.TeX.axis_height;
         const t = this.TeX.rule_thickness;
         bbox.combine(dbox, pad, a + 1.5 * t + nbox.d);
-        bbox.combine(nbox, pad, a + 1.5 * t + dbox.h);
+        bbox.combine(nbox, pad, a - 1.5 * t - dbox.h);
         bbox.w += pad;
         bbox.clean();
         return bbox;

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMfrac object
+ * @fileoverview  Implements the CHTMLmfrac wrapper for the MmlMfrac object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -1,0 +1,75 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMfrac object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {MmlMfrac} from '../../../core/MmlTree/MmlNodes/mfrac.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmfrac wrapper for the MmlMfrac object
+ */
+
+export class CHTMLmfrac extends CHTMLWrapper {
+    public static kind = MmlMfrac.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: Element, WHD: number[] = []) {
+        let num, den;
+        let chtml = this.html('mjx-frac', {}, [
+            num = this.html('mjx-num', {}, [this.html('mjx-dstrut')]),
+            this.html('mjx-dbox', {}, [
+                this.html('mjx-dtable', {}, [
+                    this.html('mjx-line'),
+                    this.html('mjx-row', {}, [
+                        den = this.html('mjx-den', {}, [this.html('mjx-hstrut')])
+                    ])
+                ])
+            ])
+        ]);
+        this.chtml = parent.appendChild(chtml);
+        this.handleScale();
+        this.childNodes[0].toCHTML(num);
+        this.childNodes[1].toCHTML(den);
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const bbox = BBox.empty();
+        const nbox = this.childNodes[0].getBBox();
+        const dbox = this.childNodes[1].getBBox();
+        const pad = (this.node.getProperty('withDelims') as boolean ? this.TeX.nulldelimiterspace : 0);
+        const a = this.TeX.axis_height;
+        const t = this.TeX.rule_thickness;
+        bbox.combine(dbox, pad, a + 1.5 * t + nbox.d);
+        bbox.combine(nbox, pad, a + 1.5 * t + dbox.h);
+        bbox.w += pad;
+        bbox.clean();
+        return bbox;
+    }
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -1,0 +1,72 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmspace wrapper for the MmlMspace object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+import {MmlMspace} from '../../../core/MmlTree/MmlNodes/mspace.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmspace wrapper for the MmlMspace object
+ */
+
+export class CHTMLmspace extends CHTMLWrapper {
+    public static kind = MmlMspace.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: Element, WHD: number[] = []) {
+        let chtml = this.html('mjx-space');
+        this.chtml = parent.appendChild(chtml);
+        this.handleScale();
+        let {w, h, d} = this.getBBox();
+        if (w < 0) {
+            chtml.style.marginRight = this.em(w);
+            w = 0;
+        }
+        if (w) {
+            chtml.style.width = this.em(w);
+        }
+        h = Math.max(0, h + d);
+        if (h) {
+            chtml.style.height = this.em(Math.max(0, h + d));
+        }
+        if (d) {
+            chtml.style.verticalAlign = this.em(-d);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const attributes = this.node.attributes;
+        const bbox = this.bbox;
+        bbox.w = this.length2em(attributes.get('width'), 0);
+        bbox.h = this.length2em(attributes.get('height'), 0);
+        bbox.d = this.length2em(attributes.get('depth'), 0);
+        return bbox;
+    }
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -37,7 +37,7 @@ export class CHTMLmspace extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: Element, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
         let chtml = this.html('mjx-space');
         this.chtml = parent.appendChild(chtml);
         this.handleScale();
@@ -68,5 +68,13 @@ export class CHTMLmspace extends CHTMLWrapper {
         bbox.h = this.length2em(attributes.get('height'), 0);
         bbox.d = this.length2em(attributes.get('depth'), 0);
         return bbox;
+    }
+
+    /*
+     * No contents, so no need for variant class
+     *
+     * @override
+     */
+    protected handleVariant() {
     }
 }

--- a/mathjax3-ts/util/HTMLNodes.ts
+++ b/mathjax3-ts/util/HTMLNodes.ts
@@ -25,7 +25,7 @@ import {OptionList} from './Options.js';
 
 /*****************************************************************/
 /*
- *  Implements the HTMLNodes class for creting HTML elements
+ *  Implements the HTMLNodes class for creating HTML elements
  */
 
 export class HTMLNodes {
@@ -43,7 +43,7 @@ export class HTMLNodes {
     }
 
     /*
-     * @param{string} type     The tag name of rhe HTML node to be created
+     * @param{string} type     The tag name of the HTML node to be created
      * @param{OptionList} def  The properties to set for the created node
      * @param{Node[]} content  The child nodes for the created HTML node
      * @return{HTMLElement}    The generated HTML tree
@@ -73,7 +73,7 @@ export class HTMLNodes {
         if (def.style) {
             let style = node.style as OptionList;
             for (let key of Object.keys(def.style)) {
-                style[key.replace(/-([a-z])/g, (m, c) => c.tpUpperCase())] = def.style[key];
+                style[key.replace(/-([a-z])/g, (m, c) => c.toUpperCase())] = def.style[key];
             }
         }
         if (def.properties) {

--- a/mathjax3-ts/util/lengths.ts
+++ b/mathjax3-ts/util/lengths.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Utility functions for handing dimensions (lengths)
+ * @fileoverview  Utility functions for handling dimensions (lengths)
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */
@@ -24,7 +24,6 @@
 /*
  *  A very large number
  */
-
 export const BIGDIMEN = 1000000;
 
 /*
@@ -86,16 +85,28 @@ export const MATHSPACE: {[name: string]: number} = {
  * @return{number}          The dimension converted to ems
  */
 export function length2em(length: string, size: number = 0, scale: number = 1, em: number = 16) {
-    if (length === '' || length == null) return size;
-    if (MATHSPACE[length]) return MATHSPACE[length];
+    if (length === '' || length == null) {
+        return size;
+    }
+    if (MATHSPACE[length]) {
+        return MATHSPACE[length];
+    }
 
     let match = length.match(/^\s*([-+]?(?:\.\d+|\d+(?:\.\d*)?))?(pt|em|ex|mu|px|pc|in|mm|cm|%)?/);
-    if (!match) return size;
+    if (!match) {
+        return size;
+    }
     let m = parseFloat(match[1] || '1'), unit = match[2];
-    if (UNITS.hasOwnProperty(unit)) return m * UNITS[unit] / em / scale;
-    if (RELUNITS.hasOwnProperty(unit)) return m * RELUNITS[unit];
-    if (unit === '%') return m / 100 * size;  // percentage of the size
-    return m * size;                          // relative to size
+    if (UNITS.hasOwnProperty(unit)) {
+        return m * UNITS[unit] / em / scale;
+    }
+    if (RELUNITS.hasOwnProperty(unit)) {
+        return m * RELUNITS[unit];
+    }
+    if (unit === '%') {
+        return m / 100 * size;  // percentage of the size
+    }
+    return m * size;            // relative to size
 }
 
 /*

--- a/mathjax3-ts/util/lengths.ts
+++ b/mathjax3-ts/util/lengths.ts
@@ -1,0 +1,141 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Utility functions for handing dimensions (lengths)
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+/*
+ *  A very large number
+ */
+
+export const BIGDIMEN = 1000000;
+
+/*
+ *  Sizes of various units in pixels
+ */
+export const UNITS: {[unit: string]: number} = {
+    px: 1,
+    pt: 96 / 72,         // 72 pt to an inch
+    pc: 96 / 12,         // 12 pc to an inch
+    'in': 96,            // 96 px to an inch
+    cm: 96 / 2.54,       // 2.54 cm to an inch
+    mm: 96 / 25.4        // 10 mm to a cm
+};
+
+/*
+ *  Sizes of various relative units in em's
+ */
+export const RELUNITS: {[unit: string]: number} = {
+    em: 1,
+    ex: .431,        // this.TEX.x_height;
+    mu: 1 / 18       // 18mu to an em for the scriptlevel
+};
+
+/*
+ *  The various named spaces
+ */
+export const MATHSPACE: {[name: string]: number} = {
+    veryverythinmathspace:           1/18,
+    verythinmathspace:               2/18,
+    thinmathspace:                   3/18,
+    mediummathspace:                 4/18,
+    thickmathspace:                  5/18,
+    verythickmathspace:              6/18,
+    veryverythickmathspace:          7/18,
+    negativeveryverythinmathspace:  -1/18,
+    negativeverythinmathspace:      -2/18,
+    negativethinmathspace:          -3/18,
+    negativemediummathspace:        -4/18,
+    negativethickmathspace:         -5/18,
+    negativeverythickmathspace:     -6/18,
+    negativeveryverythickmathspace: -7/18,
+
+    thin:   .04,
+    medium: .06,
+    thick:  .1,
+
+    normal:  1,
+    big:     2,
+    small:   1 / Math.sqrt(2),
+
+    infinity:  BIGDIMEN
+};
+
+
+/*
+ * @param{Property} length  A dimension (giving number and units) to be converted to ems
+ * @param{number} size      The default size of the dimension (for percentage values)
+ * @param{number} scale     The current scaling factor (to handle absolute units)
+ * @return{number}          The dimension converted to ems
+ */
+export function length2em(length: string, size: number = 0, scale: number = 1, em: number = 16) {
+    if (length === '' || length == null) return size;
+    if (MATHSPACE[length]) return MATHSPACE[length];
+
+    let match = length.match(/^\s*([-+]?(?:\.\d+|\d+(?:\.\d*)?))?(pt|em|ex|mu|px|pc|in|mm|cm|%)?/);
+    if (!match) return size;
+    let m = parseFloat(match[1] || '1'), unit = match[2];
+    if (UNITS.hasOwnProperty(unit)) return m * UNITS[unit] / em / scale;
+    if (RELUNITS.hasOwnProperty(unit)) return m * RELUNITS[unit];
+    if (unit === '%') return m / 100 * size;  // percentage of the size
+    return m * size;                          // relative to size
+}
+
+/*
+ * @param{number} m  A number to be shown as a percent
+ * @return{string}   The number m as a percent
+ */
+export function percent(m: number) {
+    return (100 * m).toFixed(1).replace(/\.?0+$/, '') + '%';
+}
+
+/*
+ * @param{number} m  A number to be shown in ems
+ * @return{string}   The number with units of ems
+ */
+export function em(m: number) {
+    if (Math.abs(m) < .001) return '0';
+    return (m.toFixed(3).replace(/\.?0+$/, '')) + 'em';
+}
+
+/*
+ * @param{number} m   A number to be shown in ems, but rounded to pixel boundaries
+ * @param{number} em  The number of pixels in an em
+ * @return{string}    The number with units of em
+ */
+export function emRounded(m: number, em: number = 16) {
+    m = (Math.round(m * em) + .05) / em;
+    if (Math.abs(m) < .001) return '0em';
+    return m.toFixed(3).replace(/\.?0+$/, '') + 'em';
+}
+
+
+/*
+ * @param{number} m   A number of em's to be shown as pixels
+ * @param{number} M   The minimum number of pixels to allow
+ * @param{number} em  The number of pixels in an em
+ * @return{string}    The number with units of px
+ */
+export function px(m: number, M: number = -BIGDIMEN, em: number = 16) {
+    m *= em;
+    if (M && m < M) m = M;
+    if (Math.abs(m) < .1) return '0';
+    return m.toFixed(1).replace(/\.0$/, '') + 'px';
+}

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -23,16 +23,39 @@
 
 
 /*
- *  Sort strings by length
+ * Sort strings by length
+ *
+ * @param{string} a, b  The strings to be compared
+ * @return{number}  -1 id a < b, 0 of a === b, 1 if a > b
  */
 export function sortLength(a: string, b: string) {
     return a.length !== b.length ? b.length - a.length : a === b ? 0 : a < b ? -1 : 1;
 }
 
 /*
- *  Quote a string for use in regular expressions
+ * Quote a string for use in regular expressions
+ *
+ * @param{string} text  The text whose regex characters are to be quoted
+ * @return{string}  The quoted string
  */
 export function quotePattern(text: string) {
     return text.replace(/([\^$(){}+*?\-|\[\]\:\\])/g, '\\$1');
 }
 
+/*
+ * Convert a UTF-8 string to an array of unicode code points
+ *
+ * @param{string} text  The string to be turned into unicode positions
+ * @return{number[]}  Array of numbers represeting the string's unicode charater positions
+ */
+export function unicodeChars(text: string) {
+    let unicode: number[] = [];
+    for (let i = 0, m = text.length; i < m; i++) {
+        let n = text.charCodeAt(i);
+        if (n >= 0xD800 && n < 0xDBFF) {
+            n = (((n - 0xD800) << 10) + (text.charCodeAt(i++) - 0xDC00)) + 0x10000;
+        }
+        unicode.push(n);
+    }
+    return unicode;
+}

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -46,7 +46,7 @@ export function quotePattern(text: string) {
  * Convert a UTF-8 string to an array of unicode code points
  *
  * @param{string} text  The string to be turned into unicode positions
- * @return{number[]}  Array of numbers represeting the string's unicode charater positions
+ * @return{number[]}  Array of numbers representing the string's unicode character positions
  */
 export function unicodeChars(text: string) {
     let unicode: number[] = [];

--- a/samples/tex-document.js
+++ b/samples/tex-document.js
@@ -11,7 +11,7 @@ let OPTIONS = {
 };
 
 let HTML = `
-  This is \\$ some math: \\(x+1\\).
+  This is \\$ some math: \\(\\sin(x+1)\\) and \\(\\bf x \\scr X \\mathbb X \\sf X \\cal X \\frak X\\).
   \\[x+1\\over x-1\\]
 `;
 

--- a/samples/tex-document.js
+++ b/samples/tex-document.js
@@ -10,7 +10,7 @@ let OPTIONS = {
   OutputJax: new CHTML()
 };
 
-let HTML = `
+let HTML = process.argv[3] || `
   This is \\$ some math: \\(\\sin(x+1)\\) and \\(\\bf x \\scr X \\mathbb X \\sf X \\cal X \\frak X\\).
   \\[x+1\\over x-1\\]
 `;

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,10 @@
       "check-space"
 //      "check-uppercase"
     ],
-    "curly": true,
+    "curly": [
+      true,
+      "ignore-same-line"
+    ],
     "eofline": true,
     "indent": [
       true,


### PR DESCRIPTION
This is the main framework for the CHTML output jax.  It implements a "Wrapper" object that is the solution to not being able to add methods to the MmlNode objects.  It is essential a shadow hierarchy that mirrors the MmlNode hierarchy, so that you can inherit methods, but not modify the MmlNode classes themselves.  I added generic `Wrapper` and `WrapperFunction` classes in `core/Tree`, and the CHTML-specific ones in `output/chtml`. 

The `CHTMLWrapper` is the base class for CHTML output, and includes all the generic functionality needed to produce CHTML output.  The node-specific methods are in the `output/chtml/Wrappers` directory.  There are only three at the moment, as examples (and the mfrac is just a preliminary version, as more needs to be done there).

This doesn't include the creation of the CSS needed to handle the output yet (I use a fixed CSS file for testing, but it is not included here), but this does produce the proper HTML.  If you want to test actual output, I can send the CSS file(s) and a load.html replacement that includes them.

So this is still preliminary and a work in progress, but since you asked for smaller chunks to review, I thought it would be easier to get through things at this point before all the details are in place.  This does include the HTMLNodes file that is part of a separate PR, so you can ignore that here and deal with it only in the other PR.

