### PR TITLE
Minor fixes

### DIFF
--- a/mathjax3-ts/core/MmlTree/Attributes.ts
+++ b/mathjax3-ts/core/MmlTree/Attributes.ts
@@ -53,6 +53,7 @@ export class Attributes {
         this.defaults = Object.create(global);
         this.inherited = Object.create(this.defaults);
         this.attributes = Object.create(this.inherited);
+        Object.assign(this.defaults, defaults);
     }
 
     /*
@@ -131,6 +132,15 @@ export class Attributes {
     }
 
     /*
+     * @param {string} name  The name of a attribute to check
+     * @return {boolena}     True if attribute is set explicitly or inherited
+     *                         from an explicit mstyle or math attribute
+     */
+    public isSet(name: string) {
+        return this.attributes.hasOwnProperty(name) || this.inherited.hasOwnProperty(name);
+    }
+
+    /*
      * @param {string} name  The name of an attribute to test for the existance of a default
      * @return {boolean}     True of there is a default for the named attribute, false otherwise
      */
@@ -165,7 +175,6 @@ export class Attributes {
     public getGlobalNames() {
         return Object.keys(this.global);
     }
-
 
     /*
      * @return {PropertyList}  The attribute object

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -36,7 +36,7 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
         scriptlevel: INHERIT,
         displaystyle: INHERIT,
         scriptsizemultiplier: 1 / Math.sqrt(2),
-        scriptminsize: '8pt',
+        scriptminsize: '8px',  // should be 8pt, but that is too large
         mathbackground: INHERIT,
         mathcolor: INHERIT,
         dir: INHERIT,

--- a/mathjax3-ts/handlers/html/HTMLDocument.ts
+++ b/mathjax3-ts/handlers/html/HTMLDocument.ts
@@ -228,7 +228,7 @@ export class HTMLDocument extends AbstractMathDocument {
     public TestMath(text: string, display: boolean = true) {
         if (!this.processed['TestMath']) {
             let math = new HTMLMathItem(text, this.inputJax[0], display);
-            math.setMetrics(6, 14, 1000000, 1000000, 1);
+            math.setMetrics(16, 8, 1000000, 1000000, 1);
             this.math.push(math);
             this.processed['TestMath'] = true;
         }

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -27,6 +27,7 @@ import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {HTMLNodes} from '../util/HTMLNodes.js';
+import {CHTMLWrapper} from './chtml/Wrapper.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
 import {BIGDIMEN, percent} from '../util/lengths.js';
 
@@ -57,6 +58,13 @@ export class CHTML extends AbstractOutputJax {
      */
     public document: MathDocument;
     public math: MathItem;
+
+    /*
+     * A map from the nodes in the expression currently being processed to the
+     * wrapper nodes for them (used by functions like core() to locate the wrappers
+     * from the core nodes)
+     */
+    public nodeMap: Map<MmlNode, CHTMLWrapper> = null;
 
     /*
      * Get the WrapperFactory and connect it to this output jax
@@ -91,7 +99,9 @@ export class CHTML extends AbstractOutputJax {
         if (scale !== 1) {
             node.style.fontSize = percent(scale);
         }
+        this.nodeMap = new Map<MmlNode, CHTMLWrapper>();
         this.toCHTML(math.root, node);
+        this.nodeMap = null;
         return node;
     }
 
@@ -107,7 +117,9 @@ export class CHTML extends AbstractOutputJax {
      * @override
      */
     public getMetrics(html: MathDocument) {
-
+        for (const math of html.math) {
+            math.setMetrics(16, 8, 1000000, 1000000, 1);
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -22,11 +22,16 @@
  */
 
 import {CHTMLWrapper} from './Wrapper.js';
+import {CHTMLmo} from './Wrappers/mo.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
+import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
 
 export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
+    [CHTMLmrow.kind]: CHTMLmrow,
+    [CHTMLinferredMrow.kind]: CHTMLinferredMrow,
+    [CHTMLmo.kind]: CHTMLmo,
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmfrac.kind]: CHTMLmfrac,
     [CHTMLTextNode.kind]: CHTMLTextNode,

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -36,7 +36,7 @@ export class CHTMLTextNode extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let text = (this.node as TextNode).getText();
         if (this.parent.variant === '-explicitFont') {
             parent.appendChild(this.text(text));

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -37,7 +37,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let num, den;
         let chtml = this.html('mjx-frac', {}, [
             num = this.html('mjx-num', {}, [this.html('mjx-dstrut')]),
@@ -71,5 +71,12 @@ export class CHTMLmfrac extends CHTMLWrapper {
         bbox.w += pad;
         bbox.clean();
         return bbox;
+    }
+
+    /*
+     * @override
+     */
+    public canStretch(direction: string) {
+        return false;
     }
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -1,0 +1,163 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/*
+ *  These will be part of a font class in the future.  They are
+ *  just temporary for now.
+ */
+
+/*
+ * Stretchy delimiter data
+ */
+type DelimiterData = {
+    dir: string;
+    sizes: [number];
+    fonts?: [number];
+};
+
+/*
+ * The stretch direction
+ */
+const V = 'V';
+const H = 'H';
+
+/*
+ * The delimiter list (will be longer in the future)
+ */
+const DELIMITERS: {[n: number]: DelimiterData} = {
+    0x0028: {dir: V, sizes: [1, 1.2, 1.8, 2.4, 3.0]}
+};
+
+const VARIANT = ['normal', '-smallop', '-largeop', '-size3', '-size4'];
+
+/*****************************************************************/
+/*
+ *  The CHTMLmo wrapper for the MmlMo object
+ */
+export class CHTMLmo extends CHTMLWrapper {
+    public static kind = MmlMo.prototype.kind;
+
+    /*
+     * The font size that a stretched operator uses.
+     * If -1, then stretch arbitrarily, and WHD gives the actual width or height to use
+     */
+    protected size: number = null;
+    protected WH: number = 0;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        // eventually handle centering, largop, etc.
+        let attributes = this.node.attributes;
+        if (this.stretch && this.size === null) {
+            this.getStretchedVariant(0);
+        }
+        let chtml = this.standardCHTMLnode(parent);
+        if (attributes.get('symmetric') || attributes.get('largeop')) {
+            chtml = chtml.appendChild(this.html('mjx-symmetric'));
+        }
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        // eventually handle centering, largop, etc.
+        if (this.stretch && this.size === null) {
+            this.getStretchedVariant(0);
+        }
+        return super.computeBBox();
+    }
+
+    /*
+     * @override
+     */
+    getVariant() {
+        if (this.node.attributes.get('largeop')) {
+            this.variant = (this.node.attributes.get('displaystyle') ? '-largeop' : '-smallop');
+        } else {
+            super.getVariant();
+        }
+    }
+
+    /*
+     * @override
+     */
+    public canStretch(direction: string) {
+        const attributes = this.node.attributes;
+        if (!attributes.get('stretchy')) return false;
+        let c = this.getText();
+        if (c.length !== 1) return false;
+        let C = DELIMITERS[c.charCodeAt(0)];
+        this.stretch = (C && C.dir === direction.substr(0, 1) ? C.dir : '');
+        return this.stretch !== '';
+    }
+
+    /*
+     * Determint variant for vertically/horizontally stretched character
+     *
+     * @param{number} D  size to stretch to
+     */
+    public getStretchedVariant(D: number) {
+        if (this.stretch) {
+            let min = this.getSize('minsize', 0);
+            let max = this.getSize('maxsize', Infinity);
+            D = Math.max(min, Math.min(max, D));
+            const m = (min ? D : Math.max(D * this.TeX.delimiterfactor / 1000, D - this.TeX.delimitershortfall));
+            let i = 0;
+            for (const d of DELIMITERS[this.getText().charCodeAt(0)].sizes) {
+                if (d >= m) {
+                    this.variant = VARIANT[i];
+                    this.size = i;
+                    return;
+                }
+                i++;
+            }
+            this.size = -1;
+            this.WH = D;
+        }
+    }
+
+    /*
+     * @param{string} name  The name of the attribute to fix
+     * @param{number} value  The default value to use
+     */
+    protected getSize(name: string, value: number) {
+        let attributes = this.node.attributes;
+        if (attributes.isSet(name)) {
+            value = this.length2em(attributes.get(name), 1, 1); // FIXME: should use height of actual character
+        }
+        return value;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -1,0 +1,134 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {MmlMrow, MmlInferredMrow} from '../../../core/MmlTree/MmlNodes/mrow.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmrow wrapper for the MmlMrow object
+ */
+
+export class CHTMLmrow extends CHTMLWrapper {
+    public static kind = MmlMrow.prototype.kind;
+
+    /*
+     * @override
+     * @constructor
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        this.stretchChildren();
+    }
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        let chtml = parent;
+        if (!this.node.isInferred) {
+            chtml = this.standardCHTMLnode(parent);
+        }
+        let hasNegative = false;
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml);
+            if (child.bbox && child.bbox.w < 0) {
+                hasNegative = true;
+            }
+        }
+        // FIXME:  handle line breaks
+        if (hasNegative) {
+            const {w} = this.getBBox();
+            if (w) chtml.style.width = this.em(Math.max(0, w));
+            if (w < 0) chtml.style.marginRight = this.em(w);
+        }
+    }
+
+    /*
+     * @return{number}  The number of stretchable child nodes
+     */
+    /*
+     * Handle vertical stretching of children to match height of
+     *  other nodes in the row.
+     */
+    protected stretchChildren() {
+        let stretchy: CHTMLWrapper[] = [];
+        //
+        //  Locate and count the stretchy children
+        //
+        for (const child of this.childNodes) {
+            if (child.canStretch('Vertical')) {
+                stretchy.push(child);
+            }
+        }
+        let count = stretchy.length;
+        let nodeCount = this.childNodes.length;
+        if (count && nodeCount > 1) {
+            let H = 0, D = 0;
+            //
+            //  If all the children are stretchy, find the largest one,
+            //  otherwise, find the height and depth of the non-stretchy
+            //  children.
+            //
+            let all = (count > 1 && count === nodeCount);
+            for (const child of this.childNodes) {
+                const noStretch = !child.stretch;
+                if (all || noStretch) {
+                    const {h, d} = child.getBBox(noStretch);
+                    if (h > H) H = h;
+                    if (d > D) D = d;
+                }
+            }
+            //
+            //  Stretch the stretchable children
+            //
+            for (const child of stretchy) {
+                child.coreMO().getStretchedVariant(H+D);
+            }
+        }
+    }
+
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLinferredMrow wrapper for the MmlInferredMrow object
+ */
+
+export class CHTMLinferredMrow extends CHTMLmrow {
+    public static kind = MmlInferredMrow.prototype.kind;
+
+    /*
+     * Since inferred rows don't produce a container span, we can't
+     * set a font-size for it, so we inherit the parent scale
+     *
+     * @override
+     */
+    protected getScale() {
+        this.bbox.scale = this.parent.bbox.scale;
+        this.bbox.rscale = 1
+    }
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -37,7 +37,7 @@ export class CHTMLmspace extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let chtml = this.html('mjx-space');
         this.chtml = parent.appendChild(chtml);
         this.handleScale();


### PR DESCRIPTION
This is a small set of changes to existing files:

* Fixes a problem where the default attributes were not being set in `core/MmlTree/Attributes.js` (due to changes in a previous commit).

* Adds a `isSet()` method to `core/MmlTree/Attributes.js` to be able to test if an attribute is present explicitly either on the node itself or on a parent `mstyle` or `math` node (as opposed to being set via default values).

* Makes the `mstyle` default for `scriptminsize` match that for the `math` node.

* Puts the em and ex values in the right order, and makes them slightly larger (so `scriptminsize` will not come into play).  These are fake values for testing in any case. 