### PR TITLE
Add preliminary support for stretchy-characters

### DIFF
--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -27,6 +27,7 @@ import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {HTMLNodes} from '../util/HTMLNodes.js';
+import {CHTMLWrapper} from './chtml/Wrapper.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
 import {BIGDIMEN, percent} from '../util/lengths.js';
 
@@ -57,6 +58,13 @@ export class CHTML extends AbstractOutputJax {
      */
     public document: MathDocument;
     public math: MathItem;
+
+    /*
+     * A map from the nodes in the expression currently being processed to the
+     * wrapper nodes for them (used by functions like core() to locate the wrappers
+     * from the core nodes)
+     */
+    public nodeMap: Map<MmlNode, CHTMLWrapper> = null;
 
     /*
      * Get the WrapperFactory and connect it to this output jax
@@ -91,7 +99,9 @@ export class CHTML extends AbstractOutputJax {
         if (scale !== 1) {
             node.style.fontSize = percent(scale);
         }
+        this.nodeMap = new Map<MmlNode, CHTMLWrapper>();
         this.toCHTML(math.root, node);
+        this.nodeMap = null;
         return node;
     }
 
@@ -107,7 +117,9 @@ export class CHTML extends AbstractOutputJax {
      * @override
      */
     public getMetrics(html: MathDocument) {
-
+        for (const math of html.math) {
+            math.setMetrics(16, 8, 1000000, 1000000, 1);
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -585,7 +585,9 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         if (this.node.isEmbellished) {
             let core = this.core();
             if (core && core.node !== this.node) {
-                if (core.canStretch(direction)) this.stretch = direction.substr(0,1);
+                if (core.canStretch(direction)) {
+                    this.stretch = direction.substr(0,1);
+                }
             }
         }
         return this.stretch !== '';

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -23,7 +23,7 @@
 
 import {AbstractWrapper} from '../../core/Tree/Wrapper.js';
 import {Node} from '../../core/Tree/Node.js';
-import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {MmlNode, TextNode} from '../../core/MmlTree/MmlNode.js';
 import {Property} from '../../core/Tree/Node.js';
 import {OptionList} from '../../util/Options.js';
 import {unicodeChars} from '../../util/string.js';
@@ -31,6 +31,7 @@ import * as LENGTHS from '../../util/lengths.js';
 import {HTMLNodes} from '../../util/HTMLNodes.js';
 import {CHTML} from '../chtml.js';
 import {CHTMLWrapperFactory} from './WrapperFactory.js';
+import {CHTMLmo} from './Wrappers/mo.js';
 import {BBox, BBoxData} from './BBox.js';
 import {TexFontParams} from './TeX.js';
 
@@ -76,6 +77,19 @@ export const SPACE: StringMap = {
     mediummathspace: '2',
     thickmathspace: '3'
 };
+
+export const FONTSIZE: StringMap = {
+    '70.7%': 's',
+    '70%': 's',
+    '50%': 'ss',
+    '60%': 'Tn',
+    '85%': 'sm',
+    '120%': 'lg',
+    '144%': 'Lg',
+    '173%': 'LG',
+    '207%': 'hg',
+    '249%': 'HG'
+}
 
 /*
  * Needed to access node.style[id] using variable id
@@ -189,6 +203,11 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     protected bboxComputed: boolean = false;
 
     /*
+     * Direction this node can be stretched (null means not yet determined)
+     */
+    public stretch: string = null;
+
+    /*
      * Easy access to the font parameters
      */
     public TeX = TexFontParams;
@@ -234,6 +253,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         if (parent) {
             parent.childNodes.push(wrapped);
         }
+        this.CHTML.nodeMap.set(node, wrapped);
         return wrapped;
     }
 
@@ -242,16 +262,11 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * Create the HTML for the wrapped node.
      *
      * @param{HTMLElement} parent  The HTML node where the output is added
-     * @param{number[]} WHD  Either [W] or [H,D], giving the dimensions to stretch
-     *                       a stretchable embellished operator to
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
-        let chtml = parent;
-        if (!this.node.isInferred) {
-            chtml = this.standardCHTMLnode(parent);
-        }
+    public toCHTML(parent: HTMLElement) {
+        let chtml = this.standardCHTMLnode(parent);
         for (const child of this.childNodes) {
-            child.toCHTML(chtml, WHD);
+            child.toCHTML(chtml);
         }
     }
 
@@ -469,7 +484,12 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     protected handleScale() {
         const scale = (Math.abs(this.bbox.rscale - 1) < .001 ? 1 : this.bbox.rscale);
         if (this.chtml && scale !== 1) {
-            this.chtml.style.fontSize = this.percent(scale);
+            const size = this.percent(scale);
+            if (FONTSIZE[size]) {
+                this.chtml.setAttribute('size', FONTSIZE[size]);
+            } else {
+                this.chtml.style.fontSize = size;
+            }
         }
     }
 
@@ -512,10 +532,10 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      */
     protected handleAttributes() {
         const attributes = this.node.attributes;
-        const globals = attributes.getAllGlobals();
+        const defaults = attributes.getAllDefaults();
         const skip = CHTMLWrapper.skipAttributes;
         for (const name of attributes.getExplicitNames()) {
-            if (skip[name] === false || (!globals.hasOwnProperty(name) && !skip[name] &&
+            if (skip[name] === false || (!(name in defaults) && !skip[name] &&
                                          typeof((this.chtml as {[name: string]: any})[name]) === 'undefined')) {
                 this.chtml.setAttribute(name, attributes.getExplicit(name) as string);
             }
@@ -523,6 +543,52 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         if (attributes.get('class')) {
             this.chtml.classList.add(attributes.get('class') as string);
         }
+    }
+
+    /*******************************************************************/
+
+    /*
+     * @return{CHTMLWrapper}  The wrapper for this node's core node
+     */
+    public core() {
+        return this.CHTML.nodeMap.get(this.node.core());
+    }
+
+    /*
+     * @return{CHTMLWrapper}  The wrapper for this node's core <mo> node
+     */
+    public coreMO(): CHTMLmo {
+        return this.CHTML.nodeMap.get(this.node.coreMO()) as CHTMLmo;
+    }
+
+    /*
+     * @return{string}  For a token node, the combined text content of the node's children
+     */
+    public getText() {
+        let text = "";
+        if (this.node.isToken) {
+            for (const child of this.node.childNodes) {
+                if (child instanceof TextNode) {
+                    text += child.getText();
+                }
+            }
+        }
+        return text;
+    }
+
+    /*
+     * @param{string} direction  The direction to stretch this node
+     * @return{boolean}  Whether the node can stretch in that direction
+     */
+    public canStretch(direction: string): boolean {
+        this.stretch = '';
+        if (this.node.isEmbellished) {
+            let core = this.core();
+            if (core && core.node !== this.node) {
+                if (core.canStretch(direction)) this.stretch = direction.substr(0,1);
+            }
+        }
+        return this.stretch !== '';
     }
 
     /*******************************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -22,11 +22,16 @@
  */
 
 import {CHTMLWrapper} from './Wrapper.js';
+import {CHTMLmo} from './Wrappers/mo.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
+import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
 
 export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
+    [CHTMLmrow.kind]: CHTMLmrow,
+    [CHTMLinferredMrow.kind]: CHTMLinferredMrow,
+    [CHTMLmo.kind]: CHTMLmo,
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmfrac.kind]: CHTMLmfrac,
     [CHTMLTextNode.kind]: CHTMLTextNode,

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -36,7 +36,7 @@ export class CHTMLTextNode extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let text = (this.node as TextNode).getText();
         if (this.parent.variant === '-explicitFont') {
             parent.appendChild(this.text(text));

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -37,7 +37,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let num, den;
         let chtml = this.html('mjx-frac', {}, [
             num = this.html('mjx-num', {}, [this.html('mjx-dstrut')]),
@@ -71,5 +71,12 @@ export class CHTMLmfrac extends CHTMLWrapper {
         bbox.w += pad;
         bbox.clean();
         return bbox;
+    }
+
+    /*
+     * @override
+     */
+    public canStretch(direction: string) {
+        return false;
     }
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -1,0 +1,163 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/*
+ *  These will be part of a font class in the future.  They are
+ *  just temporary for now.
+ */
+
+/*
+ * Stretchy delimiter data
+ */
+type DelimiterData = {
+    dir: string;
+    sizes: [number];
+    fonts?: [number];
+};
+
+/*
+ * The stretch direction
+ */
+const V = 'V';
+const H = 'H';
+
+/*
+ * The delimiter list (will be longer in the future)
+ */
+const DELIMITERS: {[n: number]: DelimiterData} = {
+    0x0028: {dir: V, sizes: [1, 1.2, 1.8, 2.4, 3.0]}
+};
+
+const VARIANT = ['normal', '-smallop', '-largeop', '-size3', '-size4'];
+
+/*****************************************************************/
+/*
+ *  The CHTMLmo wrapper for the MmlMo object
+ */
+export class CHTMLmo extends CHTMLWrapper {
+    public static kind = MmlMo.prototype.kind;
+
+    /*
+     * The font size that a stretched operator uses.
+     * If -1, then stretch arbitrarily, and WHD gives the actual width or height to use
+     */
+    protected size: number = null;
+    protected WH: number = 0;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        // eventually handle centering, largop, etc.
+        let attributes = this.node.attributes;
+        if (this.stretch && this.size === null) {
+            this.getStretchedVariant(0);
+        }
+        let chtml = this.standardCHTMLnode(parent);
+        if (attributes.get('symmetric') || attributes.get('largeop')) {
+            chtml = chtml.appendChild(this.html('mjx-symmetric'));
+        }
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        // eventually handle centering, largop, etc.
+        if (this.stretch && this.size === null) {
+            this.getStretchedVariant(0);
+        }
+        return super.computeBBox();
+    }
+
+    /*
+     * @override
+     */
+    getVariant() {
+        if (this.node.attributes.get('largeop')) {
+            this.variant = (this.node.attributes.get('displaystyle') ? '-largeop' : '-smallop');
+        } else {
+            super.getVariant();
+        }
+    }
+
+    /*
+     * @override
+     */
+    public canStretch(direction: string) {
+        const attributes = this.node.attributes;
+        if (!attributes.get('stretchy')) return false;
+        let c = this.getText();
+        if (c.length !== 1) return false;
+        let C = DELIMITERS[c.charCodeAt(0)];
+        this.stretch = (C && C.dir === direction.substr(0, 1) ? C.dir : '');
+        return this.stretch !== '';
+    }
+
+    /*
+     * Determint variant for vertically/horizontally stretched character
+     *
+     * @param{number} D  size to stretch to
+     */
+    public getStretchedVariant(D: number) {
+        if (this.stretch) {
+            let min = this.getSize('minsize', 0);
+            let max = this.getSize('maxsize', Infinity);
+            D = Math.max(min, Math.min(max, D));
+            const m = (min ? D : Math.max(D * this.TeX.delimiterfactor / 1000, D - this.TeX.delimitershortfall));
+            let i = 0;
+            for (const d of DELIMITERS[this.getText().charCodeAt(0)].sizes) {
+                if (d >= m) {
+                    this.variant = VARIANT[i];
+                    this.size = i;
+                    return;
+                }
+                i++;
+            }
+            this.size = -1;
+            this.WH = D;
+        }
+    }
+
+    /*
+     * @param{string} name  The name of the attribute to fix
+     * @param{number} value  The default value to use
+     */
+    protected getSize(name: string, value: number) {
+        let attributes = this.node.attributes;
+        if (attributes.isSet(name)) {
+            value = this.length2em(attributes.get(name), 1, 1); // FIXME: should use height of actual character
+        }
+        return value;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -1,0 +1,132 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {MmlMrow, MmlInferredMrow} from '../../../core/MmlTree/MmlNodes/mrow.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmrow wrapper for the MmlMrow object
+ */
+
+export class CHTMLmrow extends CHTMLWrapper {
+    public static kind = MmlMrow.prototype.kind;
+
+    /*
+     * @override
+     * @constructor
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        this.stretchChildren();
+    }
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        let chtml = parent;
+        if (!this.node.isInferred) {
+            chtml = this.standardCHTMLnode(parent);
+        }
+        let hasNegative = false;
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml);
+            if (child.bbox && child.bbox.w < 0) hasNegative = true;
+        }
+        // FIXME:  handle line breaks
+        if (hasNegative) {
+            const {w} = this.getBBox();
+            if (w) chtml.style.width = this.em(Math.max(0, w));
+            if (w < 0) chtml.style.marginRight = this.em(w);
+        }
+    }
+
+    /*
+     * @return{number}  The number of stretchable child nodes
+     */
+    /*
+     * Handle vertical stretching of children to match height of
+     *  other nodes in the row.
+     */
+    protected stretchChildren() {
+        let stretchy: CHTMLWrapper[] = [];
+        //
+        //  Locate and count the stretchy children
+        //
+        for (const child of this.childNodes) {
+            if (child.canStretch('Vertical')) {
+                stretchy.push(child);
+            }
+        }
+        let count = stretchy.length;
+        let nodeCount = this.childNodes.length;
+        if (count && nodeCount > 1) {
+            let H = 0, D = 0;
+            //
+            //  If all the children are stretchy, find the largest one,
+            //  otherwise, find the height and depth of the non-stretchy
+            //  children.
+            //
+            let all = (count > 1 && count === nodeCount);
+            for (const child of this.childNodes) {
+                const noStretch = !child.stretch;
+                if (all || noStretch) {
+                    const {h, d} = child.getBBox(noStretch);
+                    if (h > H) H = h;
+                    if (d > D) D = d;
+                }
+            }
+            //
+            //  Stretch the stretchable children
+            //
+            for (const child of stretchy) {
+                child.coreMO().getStretchedVariant(H+D);
+            }
+        }
+    }
+
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLinferredMrow wrapper for the MmlInferredMrow object
+ */
+
+export class CHTMLinferredMrow extends CHTMLmrow {
+    public static kind = MmlInferredMrow.prototype.kind;
+
+    /*
+     * Since inferred rows don't produce a container span, we can't
+     * set a font-size for it, so we inherit the parent scale
+     *
+     * @override
+     */
+    protected getScale() {
+        this.bbox.scale = this.parent.bbox.scale;
+        this.bbox.rscale = 1
+    }
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -55,7 +55,9 @@ export class CHTMLmrow extends CHTMLWrapper {
         let hasNegative = false;
         for (const child of this.childNodes) {
             child.toCHTML(chtml);
-            if (child.bbox && child.bbox.w < 0) hasNegative = true;
+            if (child.bbox && child.bbox.w < 0) {
+                hasNegative = true;
+            }
         }
         // FIXME:  handle line breaks
         if (hasNegative) {

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -37,7 +37,7 @@ export class CHTMLmspace extends CHTMLWrapper {
     /*
      * @override
      */
-    public toCHTML(parent: HTMLElement, WHD: number[] = []) {
+    public toCHTML(parent: HTMLElement) {
         let chtml = this.html('mjx-space');
         this.chtml = parent.appendChild(chtml);
         this.handleScale();


### PR DESCRIPTION
This PR adds preliminary support for stretchy characters.  It adds mrow, inferred mrow, and mo classes.  An `mrow` look for vertically stretchy children and determines the size to stretch them to before laying out the HTML for the row.  The core `mo` of a stretchy element determines the size of the stretchy character and produces the properly sized output (currently only for the fixed-size variants; the multi-character stretchy versions are still to come).

Because the sizes can actually be determined up front (not at typesetting time), the `WHD` parameters for `toCHTML()` and `computeBBox()` that I expected to use for stretchy characters are no longer needed, and have been removed.

This is just the framework; the font data needed for full functionality will come in a later pull request.  Some minimal data is included here, but will be moved to a separate file in the future.  

Some common font-size values are handled via CSS rather than explicitly setting the style on the element itself.

This PR is being made to the `minor-fixes` branch in order to avoid showing the changes that are part of it.  If that branch is merged to `master` before this one is reviews,  I will redirect this merge to `master`.