### PR TITLE
Support more mml nodes

### DIFF
--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -614,6 +614,15 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     }
 
     /*
+     * @param{number} m   A number of em's to be shown as pixels
+     * @param{number} M   The minimum number of pixels to allow
+     * @return{string}  The number with units of px
+     */
+    protected px(m: number, M: number = -LENGTHS.BIGDIMEN) {
+        return LENGTHS.px(m, M, this.metrics.em);
+    }
+
+    /*
      * @param{Property} length  A dimension (giving number and units) or number to be converted to ems
      * @param{number} size  The default size of the dimension (for percentage values)
      * @param{number} scale  The current scaling factor (to handle absolute units)

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -22,8 +22,8 @@
  */
 
 import {AbstractWrapper} from '../../core/Tree/Wrapper.js';
-import {Node} from '../../core/Tree/Node.js';
-import {MmlNode, TextNode} from '../../core/MmlTree/MmlNode.js';
+import {Node, PropertyList} from '../../core/Tree/Node.js';
+import {MmlNode, TextNode, AbstractMmlNode} from '../../core/MmlTree/MmlNode.js';
 import {Property} from '../../core/Tree/Node.js';
 import {OptionList} from '../../util/Options.js';
 import {unicodeChars} from '../../util/string.js';
@@ -670,6 +670,24 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      */
     public text(text: string) {
         return this.factory.chtml.text(text);
+    }
+
+    /*
+     * @param{string} text  The text from which to create a TextNode object
+     * @return{CHTMLTextNode}  The TextNode with the given text
+     */
+    public mmlText(text: string) {
+        return ((this.node as AbstractMmlNode).factory.create('text') as TextNode).setText(text);
+    }
+
+    /*
+     * @param{string} kind  The kind of MmlNode to create
+     * @paramProperyList} properties  The properties to set initially
+     * @param{MmlNode[]} children  The child nodes to add to the created node
+     * @return{MmlNode}  The newly created MmlNode
+     */
+    public mmlNode(kind: string, properties: PropertyList = {}, children: MmlNode[] = []) {
+        return (this.node as AbstractMmlNode).factory.create(kind, properties, children);
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -28,6 +28,7 @@ import {CHTMLmspace} from './Wrappers/mspace.js';
 import {CHTMLmpadded} from './Wrappers/mpadded.js';
 import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
+import {CHTMLsemantics, CHTMLannotation, CHTMLannotationXML, CHTMLxml} from './Wrappers/semantics.js';
 import {CHTMLTeXAtom} from './Wrappers/TeXAtom.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
 
@@ -39,6 +40,10 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmpadded.kind]: CHTMLmpadded,
     [CHTMLmfrac.kind]: CHTMLmfrac,
+    [CHTMLsemantics.kind]: CHTMLsemantics,
+    [CHTMLannotation.kind]: CHTMLannotation,
+    [CHTMLannotationXML.kind]: CHTMLannotationXML,
+    [CHTMLxml.kind]: CHTMLxml,
     [CHTMLTeXAtom.kind]: CHTMLTeXAtom,
     [CHTMLTextNode.kind]: CHTMLTextNode,
     [CHTMLWrapper.kind]: CHTMLWrapper

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -23,6 +23,7 @@
 
 import {CHTMLWrapper} from './Wrapper.js';
 import {CHTMLmo} from './Wrappers/mo.js';
+import {CHTMLms} from './Wrappers/ms.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
 import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
@@ -32,6 +33,7 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmrow.kind]: CHTMLmrow,
     [CHTMLinferredMrow.kind]: CHTMLinferredMrow,
     [CHTMLmo.kind]: CHTMLmo,
+    [CHTMLms.kind]: CHTMLms,
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmfrac.kind]: CHTMLmfrac,
     [CHTMLTextNode.kind]: CHTMLTextNode,

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -28,6 +28,8 @@ import {CHTMLmspace} from './Wrappers/mspace.js';
 import {CHTMLmpadded} from './Wrappers/mpadded.js';
 import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
+import {CHTMLmsqrt} from './Wrappers/msqrt.js';
+import {CHTMLmroot} from './Wrappers/mroot.js';
 import {CHTMLsemantics, CHTMLannotation, CHTMLannotationXML, CHTMLxml} from './Wrappers/semantics.js';
 import {CHTMLTeXAtom} from './Wrappers/TeXAtom.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
@@ -40,6 +42,8 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmpadded.kind]: CHTMLmpadded,
     [CHTMLmfrac.kind]: CHTMLmfrac,
+    [CHTMLmsqrt.kind]: CHTMLmsqrt,
+    [CHTMLmroot.kind]: CHTMLmroot,
     [CHTMLsemantics.kind]: CHTMLsemantics,
     [CHTMLannotation.kind]: CHTMLannotation,
     [CHTMLannotationXML.kind]: CHTMLannotationXML,

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -25,6 +25,7 @@ import {CHTMLWrapper} from './Wrapper.js';
 import {CHTMLmo} from './Wrappers/mo.js';
 import {CHTMLms} from './Wrappers/ms.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
+import {CHTMLmpadded} from './Wrappers/mpadded.js';
 import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
@@ -35,6 +36,7 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmo.kind]: CHTMLmo,
     [CHTMLms.kind]: CHTMLms,
     [CHTMLmspace.kind]: CHTMLmspace,
+    [CHTMLmpadded.kind]: CHTMLmpadded,
     [CHTMLmfrac.kind]: CHTMLmfrac,
     [CHTMLTextNode.kind]: CHTMLTextNode,
     [CHTMLWrapper.kind]: CHTMLWrapper

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -28,6 +28,7 @@ import {CHTMLmspace} from './Wrappers/mspace.js';
 import {CHTMLmpadded} from './Wrappers/mpadded.js';
 import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
+import {CHTMLTeXAtom} from './Wrappers/TeXAtom.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
 
 export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
@@ -38,6 +39,7 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmpadded.kind]: CHTMLmpadded,
     [CHTMLmfrac.kind]: CHTMLmfrac,
+    [CHTMLTeXAtom.kind]: CHTMLTeXAtom,
     [CHTMLTextNode.kind]: CHTMLTextNode,
     [CHTMLWrapper.kind]: CHTMLWrapper
 };

--- a/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
@@ -1,0 +1,72 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLTeXAtom wrapper for the MmlTeXAtom object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+import {TeXAtom} from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
+import {MmlNode, TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLTeXAtom wrapper for the TeXAtom object
+ */
+
+export class CHTMLTeXAtom extends CHTMLWrapper {
+    public static kind = TeXAtom.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        super.toCHTML(parent);
+        //
+        // Center VCENTER atoms vertically
+        //
+        if (this.node.texClass === TEXCLASS.VCENTER) {
+            const bbox = super.computeBBox();  // get unmodified bbox of children
+            const {h, d} = bbox;
+            const a = this.font.params.axis_height;
+            const dh = ((h + d) / 2 + a) - h;  // new height minus old height
+            this.chtml.style.verticalAlign = this.em(dh);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const bbox = super.computeBBox();
+        //
+        // Center VCENTER atoms vertically
+        //
+        if (this.node.texClass === TEXCLASS.VCENTER) {
+            const {h, d} = bbox;
+            const a = this.font.params.axis_height;
+            const dh = ((h + d) / 2 + a) - h;  // new height minus old height
+            bbox.h += dh;
+            bbox.d += dh;
+        }
+        return bbox;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -57,12 +57,12 @@ export class CHTMLTextNode extends CHTMLWrapper {
             // FIXME:  measure this using DOM, if possible
         } else {
             const chars = this.unicodeChars((this.node as TextNode).getText());
-            let [h, d, w] = this.font.getChar(variant, chars[0]);
+            let [h, d, w] = this.font.getChar(variant, chars[0]) || [0, 0, 0];
             bbox.h = h;
             bbox.d = d;
             bbox.w = w;
             for (let i = 1, m = chars.length; i < m; i++) {
-                [h, d, w] = this.font.getChar(variant, chars[i]);
+                [h, d, w] = this.font.getChar(variant, chars[i]) || [0, 0, 0];
                 bbox.w += w;
                 if (h > bbox.h) bbox.h = h;
                 if (d > bbox.d) bbox.d = d;

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -38,7 +38,7 @@ export class CHTMLmo extends CHTMLWrapper {
      * The font size that a stretched operator uses.
      * If -1, then stretch arbitrarily, and bbox gives the actual height, depth, width
      */
-    protected size: number = null;
+    public size: number = null;
 
     /*
      * @override

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -88,7 +88,7 @@ export class CHTMLmpadded extends CHTMLWrapper {
      */
     getDimens() {
         const values = this.node.attributes.getList('width', 'height', 'depth', 'lspace', 'voffset');
-        const bbox = (this.childNodes.length ? this.childNodes[0].getBBox() : BBox.zero());
+        const bbox = super.computeBBox();  // get unmodified bbox of children
         let {w, h, d} = bbox;
         let W = w, H = h, D = d, x = 0, y = 0;
         if (values.width !== '')   w = this.dimen(values.width, bbox, 'w', 0);

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -27,13 +27,6 @@ import {MmlMpadded} from '../../../core/MmlTree/MmlNodes/mpadded.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {Property} from '../../../core/Tree/Node.js';
 
-/*
- * Needed in order to access BBox properties by variable
- */
-interface IBBox extends BBox {
-    [name: string]: number | string | Function;
-}
-
 /*****************************************************************/
 /*
  *  The CHTMLmpadded wrapper for the MmlMpadded object
@@ -63,8 +56,8 @@ export class CHTMLmpadded extends CHTMLWrapper {
             style.margin = this.em(dh) + ' 0 ' + this.em(dd);
         }
         //
-        // If there is a horizotnal or vertical shift,
-        //   use relative poisitioning to move the contents
+        // If there is a horizontal or vertical shift,
+        //   use relative positioning to move the contents
         //
         if (x || y) {
             style.position = 'relative';
@@ -112,7 +105,7 @@ export class CHTMLmpadded extends CHTMLWrapper {
     protected dimen(length: Property, bbox: BBox, d: string = '', m: number = null) {
         length = String(length);
         const match = length.match(/width|height|depth/);
-        const size = (match ? (bbox as IBBox)[match[0].charAt(0)] : (d ? (bbox as IBBox)[d] : 0)) as number;
+        const size = (match ? bbox[match[0].charAt(0) as (keyof BBox)] : (d ? bbox[d as (keyof BBox)] : 0)) as number;
         let dimen = (this.length2em(length, size) || 0);
         if (length.match(/^[-+]/) && d) {
             dimen += size;

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -1,0 +1,138 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmpadded wrapper for the MmlMpadded object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper, StringMap} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+import {MmlMpadded} from '../../../core/MmlTree/MmlNodes/mpadded.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {Property} from '../../../core/Tree/Node.js';
+
+/*
+ * Needed in order to access BBox properties by variable
+ */
+interface iBBox extends BBox {
+    [name: string]: number | string | Function;
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLmpadded wrapper for the MmlMpadded object
+ */
+
+export class CHTMLmpadded extends CHTMLWrapper {
+    public static kind = MmlMpadded.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        let chtml = this.standardCHTMLnode(parent);
+        const content: HTMLElement[] = [];
+        const style: StringMap = {};
+        const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
+        //
+        // If the width changed, set the width explicitly
+        //
+        if (dw) {
+            style.width = this.em(W + dw);
+        }
+        //
+        // If the height or depth changed, use margin to make the change
+        //
+        if (dh || dd) {
+            style.margin = this.em(dh) + ' 0 ' + this.em(dd);
+        }
+        //
+        // If there is a horizotnal or vertical shift,
+        //   use relative poisitioning to move the contents
+        //
+        if (x || y) {
+            style.position = 'relative';
+            content.push(this.html('mjx-rbox', {style: {left: this.em(x), top: this.em(-y)}}));
+        }
+        //
+        //  Create the HTML with the proper styles and content
+        //
+        chtml = chtml.appendChild(this.html('mjx-block', {style: style}, content));
+        for (const child of this.childNodes) {
+            child.toCHTML(chtml.firstChild as HTMLElement || chtml);
+        }
+    }
+
+    /*
+     * Get the content bounding box, and the change in size and offsets
+     *   as specified by the parameters
+     *
+     * @return{number[]}  The original height, depth, width, the changes in height, depth,
+     *                    and width, and the horizontal and vertical offsets of the content
+     */
+    getDimens() {
+        const values = this.node.attributes.getList('width', 'height', 'depth', 'lspace', 'voffset');
+        const bbox = (this.childNodes.length ? this.childNodes[0].getBBox() : BBox.zero());
+        let {w, h, d} = bbox;
+        let W = w, H = h, D = d, x = 0, y = 0;
+        if (values.width !== '')   w = this.dimen(values.width, bbox, 'w', 0);
+        if (values.height !== '')  h = this.dimen(values.height, bbox, 'h', 0);
+        if (values.depth !== '')   d = this.dimen(values.depth, bbox, 'd', 0);
+        if (values.voffset !== '') y = this.dimen(values.voffset, bbox);
+        if (values.lspace !== '')  x = this.dimen(values.lspace, bbox);
+        return [H, D, W, h - H, d - D, w - W, x, y];
+    }
+
+    /*
+     * Get a particular dimension, which can be relative to any of the BBox dimensions,
+     *   and can be an offset from the default size of the given dimension.
+     *
+     * @param{Property} length   The value to be converted to a length in ems
+     * @param{BBox} bbox         The bbox of the mpadded content
+     * @param{string} d          The default dimension to use for relative sizes ('w', 'h', or 'd')
+     * @param{number} m          The minimum value allowed for the dimension
+     * @return{number}           The final dimension in ems
+     */
+    dimen(length: Property, bbox: BBox, d: string = '', m: number = null) {
+        length = String(length);
+        const match = length.match(/width|height|depth/);
+        const size = (match ? (bbox as iBBox)[match[0].charAt(0)] : (d ? (bbox as iBBox)[d]: 0)) as number;
+        let dimen = (this.length2em(length, size) || 0);
+        if (length.match(/^[-+]/) && d) {
+            dimen += size;
+        }
+        if (m != null) {
+            dimen = Math.max(m, dimen);
+        }
+        return dimen;
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
+        const bbox = this.bbox;
+        bbox.w = W + dw;
+        bbox.h = H + dh;
+        bbox.d = D + dd;
+        return bbox;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -30,7 +30,7 @@ import {Property} from '../../../core/Tree/Node.js';
 /*
  * Needed in order to access BBox properties by variable
  */
-interface iBBox extends BBox {
+interface IBBox extends BBox {
     [name: string]: number | string | Function;
 }
 
@@ -86,7 +86,7 @@ export class CHTMLmpadded extends CHTMLWrapper {
      * @return{number[]}  The original height, depth, width, the changes in height, depth,
      *                    and width, and the horizontal and vertical offsets of the content
      */
-    getDimens() {
+    protected getDimens() {
         const values = this.node.attributes.getList('width', 'height', 'depth', 'lspace', 'voffset');
         const bbox = super.computeBBox();  // get unmodified bbox of children
         let {w, h, d} = bbox;
@@ -109,10 +109,10 @@ export class CHTMLmpadded extends CHTMLWrapper {
      * @param{number} m          The minimum value allowed for the dimension
      * @return{number}           The final dimension in ems
      */
-    dimen(length: Property, bbox: BBox, d: string = '', m: number = null) {
+    protected dimen(length: Property, bbox: BBox, d: string = '', m: number = null) {
         length = String(length);
         const match = length.match(/width|height|depth/);
-        const size = (match ? (bbox as iBBox)[match[0].charAt(0)] : (d ? (bbox as iBBox)[d]: 0)) as number;
+        const size = (match ? (bbox as IBBox)[match[0].charAt(0)] : (d ? (bbox as IBBox)[d] : 0)) as number;
         let dimen = (this.length2em(length, size) || 0);
         if (length.match(/^[-+]/) && d) {
             dimen += size;

--- a/mathjax3-ts/output/chtml/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mroot.ts
@@ -1,0 +1,99 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLMroot wrapper for the MmlMroot object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLmsqrt} from './msqrt.js';
+import {CHTMLmo} from './mo.js';
+import {BBox} from '../BBox.js';
+import {MmlMroot} from '../../../core/MmlTree/MmlNodes/mroot.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLMroot wrapper for the Mroot object (extends CHTMLmsqrt)
+ */
+
+export class CHTMLmroot extends CHTMLmsqrt {
+    public static kind = MmlMroot.prototype.kind;
+
+    /*
+     * @override
+     */
+    get surd() {
+        return 2;
+    }
+
+    /*
+     * @override
+     */
+    get root(): number {
+        return 1;
+    }
+
+    /*
+     * @override
+     */
+    protected addRoot(ROOT: HTMLElement, root: CHTMLWrapper, sbox: BBox) {
+        root.toCHTML(ROOT);
+        const [x, h, dx, scale] = this.getRootDimens(sbox);
+        const bbox = root.getBBox();
+        ROOT.style.verticalAlign = this.em(h / scale);
+        ROOT.style.width = this.em(x / scale);
+        if (dx) (ROOT.firstChild as HTMLElement).style.paddingLeft = this.em(dx);
+    }
+
+    /*
+     * @override
+     */
+    protected combineRootBBox(BBOX: BBox, sbox: BBox) {
+        const bbox = this.childNodes[this.root].getBBox();
+        const [x, h] = this.getRootDimens(sbox);
+        BBOX.combine(bbox, 0, h);
+    }
+
+    /*
+     * @override
+     */
+    protected getRootDimens(sbox: BBox) {
+        const surd = this.childNodes[this.surd] as CHTMLmo;
+        const offset = (surd.size < -1 ? .5 : .6) * sbox.w;
+        const bbox = this.childNodes[this.root].getBBox();
+        const {w, rscale} = bbox;
+        const W = Math.max(w, offset / rscale);
+        const dx = Math.max(0, W - w);
+        const h = this.rootHeight(bbox, sbox, offset);
+        const x = W * rscale - offset;
+        return [x, h, dx, rscale];
+    }
+
+    /*
+     * @param{BBox} bbox      The bbox of the root
+     * @param{BBox} sbox      The bbox of the surd
+     * @param{number} offset  The computed offset for the root within the surd
+     * @return{number}        The height of the root within the surd
+     */
+    protected rootHeight(bbox: BBox, sbox: BBox, offset: number) {
+        return .45 * (sbox.h + sbox.d - .9) + offset + Math.max(0, bbox.d - .075);
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -1,0 +1,66 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmspace wrapper for the MmlMs object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {MmlMs} from '../../../core/MmlTree/MmlNodes/ms.js';
+import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLms wrapper for the MmlMs object
+ */
+
+export class CHTMLms extends CHTMLWrapper {
+    public static kind = MmlMs.prototype.kind;
+
+    /*
+     * Add the quote characters to the wrapper children so they will be output
+     *
+     * @override
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        const attributes = this.node.attributes;
+        let quotes = attributes.getList('lquote','rquote');
+        if (this.variant !== 'monospace') {
+            if (!attributes.isSet('lquote') && quotes.lquote === '"') quotes.lquote = '\u201C';
+            if (!attributes.isSet('rquote') && quotes.rquote === '"') quotes.rquote = '\u201D';
+        }
+        this.childNodes.unshift(this.createText(quotes.lquote as string));
+        this.childNodes.push(this.createText(quotes.rquote as string));
+    }
+
+    /*
+     * Create a text wrapper with the given text;
+     *
+     * @param{string} text  The text for the wrapped element
+     */
+    createText(text: string) {
+        const mmlFactory = (this.node as AbstractMmlNode).factory;
+        const node = this.wrap((mmlFactory.create('text') as TextNode).setText(text));
+        node.parent = this;
+        return node;
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -58,8 +58,7 @@ export class CHTMLms extends CHTMLWrapper {
      * @return{CHTMLWrapper}   The wrapped text node
      */
     protected createText(text: string) {
-        const mmlFactory = (this.node as AbstractMmlNode).factory;
-        const node = this.wrap((mmlFactory.create('text') as TextNode).setText(text));
+        const node = this.wrap(this.mmlText(text));
         node.parent = this;
         return node;
     }

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -42,7 +42,7 @@ export class CHTMLms extends CHTMLWrapper {
     constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
         super(factory, node, parent);
         const attributes = this.node.attributes;
-        let quotes = attributes.getList('lquote','rquote');
+        let quotes = attributes.getList('lquote', 'rquote');
         if (this.variant !== 'monospace') {
             if (!attributes.isSet('lquote') && quotes.lquote === '"') quotes.lquote = '\u201C';
             if (!attributes.isSet('rquote') && quotes.rquote === '"') quotes.rquote = '\u201D';
@@ -55,8 +55,9 @@ export class CHTMLms extends CHTMLWrapper {
      * Create a text wrapper with the given text;
      *
      * @param{string} text  The text for the wrapped element
+     * @return{CHTMLWrapper}   The wrapped text node
      */
-    createText(text: string) {
+    protected createText(text: string) {
         const mmlFactory = (this.node as AbstractMmlNode).factory;
         const node = this.wrap((mmlFactory.create('text') as TextNode).setText(text));
         node.parent = this;

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -38,9 +38,12 @@ export class CHTMLmspace extends CHTMLWrapper {
      * @override
      */
     public toCHTML(parent: HTMLElement) {
-        let chtml = this.html('mjx-space');
+        let chtml = this.html('mjx-mspace');
         this.chtml = parent.appendChild(chtml);
         this.handleScale();
+        this.handleColor();
+        this.handleSpace();
+        this.handleAttributes();
         let {w, h, d} = this.getBBox();
         if (w < 0) {
             chtml.style.marginRight = this.em(w);

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -38,12 +38,7 @@ export class CHTMLmspace extends CHTMLWrapper {
      * @override
      */
     public toCHTML(parent: HTMLElement) {
-        let chtml = this.html('mjx-mspace');
-        this.chtml = parent.appendChild(chtml);
-        this.handleScale();
-        this.handleColor();
-        this.handleSpace();
-        this.handleAttributes();
+        let chtml = this.standardCHTMLnode(parent);
         let {w, h, d} = this.getBBox();
         if (w < 0) {
             chtml.style.marginRight = this.em(w);

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -1,0 +1,193 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLMsqrt wrapper for the MmlMsqrt object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {CHTMLmo} from './mo.js';
+import {BBox} from '../BBox.js';
+import {MmlMsqrt} from '../../../core/MmlTree/MmlNodes/msqrt.js';
+import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLMsqrt wrapper for the Msqrt object
+ */
+
+export class CHTMLmsqrt extends CHTMLWrapper {
+    public static kind = MmlMsqrt.prototype.kind;
+
+    /*
+     * @return{number}  The index of the base of the root in childNodes
+     */
+    get base() {
+        return 0;
+    }
+
+    /*
+     * @return{number}  The index of the surd in childNodes
+     */
+    get surd() {
+        return 1;
+    }
+
+    /*
+     * @return{number}  The index of the root in childNodes (or null if none)
+     */
+    get root(): number {
+        return null;
+    }
+
+    /*
+     * The requested height of the stretched surd character
+     */
+    protected surdH: number;
+
+    /*
+     * Add the surd character so we can display it later
+     *
+     * @override
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        const surd = this.createMo('\u221A');
+        this.childNodes.push(surd);
+        surd.canStretch('Vertical');
+        const {h, d} = this.childNodes[this.base].getBBox();
+        const t = this.font.params.rule_thickness;
+        const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
+        this.surdH = h + d + 2 * t + p / 4;
+        surd.getStretchedVariant([this.surdH, 0]);
+    }
+
+    /*
+     * Create an mo wrapper with the given text;
+     *
+     * @param{string} text  The text for the wrapped element
+     * @return{CHTMLWrapper}  The wrapped MmlMo node
+     */
+    protected createMo(text: string) {
+        const mmlFactory = (this.node as AbstractMmlNode).factory;
+        const node = this.wrap(mmlFactory.create('mo', {}, [(mmlFactory.create('text') as TextNode).setText(text)])) as CHTMLmo;
+        node.parent = this;
+        return node;
+    }
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        const surd = this.childNodes[this.surd];
+        const base = this.childNodes[this.base];
+        //
+        //  Get the parameters for the spacing of the parts
+        //
+        const sbox = surd.getBBox();
+        const bbox = base.getBBox();
+        const [p, q] = this.getPQ(sbox);
+        const [x] = this.getRootDimens(sbox);
+        const t = this.font.params.rule_thickness;
+        const T = this.font.params.surd_height;
+        //
+        //  Create the HTML structure for the root
+        //
+        const CHTML = this.standardCHTMLnode(parent);
+        let SURD, BASE, ROOT, root;
+        if (this.root != null) {
+            ROOT = CHTML.appendChild(this.html('mjx-root'));
+            root = this.childNodes[this.root];
+        }
+        const SQRT = CHTML.appendChild(this.html('mjx-box', {
+            style: {paddingTop: this.px(2 * t - T, 1)}
+        }, [
+            SURD = this.html('mjx-surd'),
+            BASE = this.html('mjx-box', {style: {
+                paddingTop: this.px(q, 1),
+                borderTop: this.px(T * bbox.scale, 1) + ' solid'
+            }})
+        ]));
+        //
+        //  Add the child content
+        //
+        this.addRoot(ROOT, root, sbox);
+        surd.toCHTML(SURD);
+        base.toCHTML(BASE);
+    }
+
+    /*
+     * Add root HTML (overridden in mroot)
+     *
+     * @param{HTMLElement} ROOT   The container for the root
+     * @param{CHTMLWrapper} root  The wreapped MML root content
+     * @param{BBox} sbox          The bounding box of the surd
+     */
+    protected addRoot(ROOT: HTMLElement, root: CHTMLWrapper, sbox: BBox) {
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const BBOX = BBox.empty();
+        const sbox = this.childNodes[this.surd].getBBox();
+        const bbox = new BBox(this.childNodes[this.base].getBBox());
+        const [p, q] = this.getPQ(sbox);
+        const [x] = this.getRootDimens(sbox);
+        const t = this.font.params.rule_thickness;
+        const H = bbox.h + q + t;
+        bbox.h += q + 2 * t;  // FIXME:  should take into accound minimums for this.px() used above
+        this.combineRootBBox(BBOX, sbox);
+        BBOX.combine(sbox, x, H - sbox.h);
+        BBOX.combine(bbox, x + sbox.w, 0);
+        BBOX.clean();
+        return BBOX;
+    }
+
+    /*
+     * Combine the bounding box of the root (overridden in mroot)
+     *
+     * @param{BBox} BBOX  The bounding box so far
+     * @param{BBox} sbox  The bounding box of the surd
+     */
+    protected combineRootBBox(BBOX: BBox, sbox: BBox) {
+    }
+
+    /*
+     * @param{BBox} sbox   The bounding box for the surd character
+     * @return{number[]}  The p, q, and x values for the TeX layout computations
+     */
+    protected getPQ(sbox: BBox) {
+        const t = this.font.params.rule_thickness;
+        const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
+        const q = (sbox.h + sbox.d > this.surdH ? ((sbox.h + sbox.d) - (this.surdH - t)) / 2 : t + p / 4);
+        return [p, q];
+    }
+
+    /*
+     * @param{BBox} sbox  The bounding box of the surd
+     * @return{number[]}  The x offset of the surd, and the height, x offset, and scale of the root
+     */
+    protected getRootDimens(sbox: BBox) {
+        return [0, 0, 0, 0];
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -86,8 +86,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * @return{CHTMLWrapper}  The wrapped MmlMo node
      */
     protected createMo(text: string) {
-        const mmlFactory = (this.node as AbstractMmlNode).factory;
-        const node = this.wrap(mmlFactory.create('mo', {}, [(mmlFactory.create('text') as TextNode).setText(text)])) as CHTMLmo;
+        const node = this.wrap(this.mmlNode('mo', {}, [this.mmlText(text)])) as CHTMLmo;
         node.parent = this;
         return node;
     }
@@ -137,7 +136,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * Add root HTML (overridden in mroot)
      *
      * @param{HTMLElement} ROOT   The container for the root
-     * @param{CHTMLWrapper} root  The wreapped MML root content
+     * @param{CHTMLWrapper} root  The wrapped MML root content
      * @param{BBox} sbox          The bounding box of the surd
      */
     protected addRoot(ROOT: HTMLElement, root: CHTMLWrapper, sbox: BBox) {
@@ -147,28 +146,28 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * @override
      */
     public computeBBox() {
-        const BBOX = BBox.empty();
+        const box = BBox.empty();
         const sbox = this.childNodes[this.surd].getBBox();
         const bbox = new BBox(this.childNodes[this.base].getBBox());
         const [p, q] = this.getPQ(sbox);
         const [x] = this.getRootDimens(sbox);
         const t = this.font.params.rule_thickness;
         const H = bbox.h + q + t;
-        bbox.h += q + 2 * t;  // FIXME:  should take into accound minimums for this.px() used above
-        this.combineRootBBox(BBOX, sbox);
-        BBOX.combine(sbox, x, H - sbox.h);
-        BBOX.combine(bbox, x + sbox.w, 0);
-        BBOX.clean();
-        return BBOX;
+        bbox.h += q + 2 * t;  // FIXME:  should take into account minimums for this.px() used above
+        this.combineRootBBox(box, sbox);
+        box.combine(sbox, x, H - sbox.h);
+        box.combine(bbox, x + sbox.w, 0);
+        box.clean();
+        return box;
     }
 
     /*
      * Combine the bounding box of the root (overridden in mroot)
      *
-     * @param{BBox} BBOX  The bounding box so far
+     * @param{BBox} box   The bounding box so far
      * @param{BBox} sbox  The bounding box of the surd
      */
-    protected combineRootBBox(BBOX: BBox, sbox: BBox) {
+    protected combineRootBBox(box: BBox, sbox: BBox) {
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -1,0 +1,139 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLsemantics wrapper for the Mmlsemantics object
+ *                and the associated wrappers for annotations
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from '../../../core/MmlTree/MmlNodes/semantics.js';
+import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLsemantics wrapper for the MmlSemantics object
+ */
+
+export class CHTMLsemantics extends CHTMLWrapper {
+    public static kind = MmlSemantics.prototype.kind;
+
+    /*
+     * Only the first child of <semantics> is displayed
+     *
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        const chtml = this.standardCHTMLnode(parent);
+        if (this.childNodes.length) {
+            this.childNodes[0].toCHTML(chtml);
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const bbox = this.bbox;
+        if (this.childNodes.length) {
+            const {w, h, d} = this.childNodes[0].getBBox();
+            bbox.w = w;
+            bbox.h = h;
+            bbox.d = d;
+        }
+        return bbox;
+    }
+
+}
+
+
+/*****************************************************************/
+/*
+ *  The CHTMLannotation wrapper for the MmlAnnotation object
+ */
+
+export class CHTMLannotation extends CHTMLWrapper {
+    public static kind = MmlAnnotation.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        // FIXME:  output as plain text
+        super.toCHTML(parent);
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        // FIXME:  compute using the DOM, if possible
+        return this.bbox;
+    }
+
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLannotationXML wrapper for the MmlAnnotationXML object
+ */
+
+export class CHTMLannotationXML extends CHTMLWrapper {
+    public static kind = MmlAnnotationXML.prototype.kind;
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLxml wrapper for the XMLNode object
+ */
+
+export class CHTMLxml extends CHTMLWrapper {
+    public static kind = XMLNode.prototype.kind;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        parent.appendChild(((this.node as XMLNode).getXML() as HTMLElement).cloneNode(true));
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        // FIXME:  compute using the DOM, if possible
+        return this.bbox;
+    }
+
+    /*
+     * @override
+     */
+    protected getStyles() {}
+
+    /*
+     * @override
+     */
+    protected getScale() {}
+
+    /*
+     * @override
+     */
+    protected getVariant() {}
+}

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -68,6 +68,7 @@ export class TeXFont extends FontData {
         0x7B: {dir: V, sizes: STDVSIZES, stretch: [0x23A7, 0x23AA, 0x23A9, 0x23A8], HDW: STDVHDW}, // {
         0x7C: {dir: V, sizes: [1], stretch: [0, 0x2223, 0], HDW: STDVHDW},                 // |
         0x7D: {dir: V, sizes: STDVSIZES, stretch: [0x23AB, 0x23AA, 0x23AD, 0x23AC], HDW: STDVHDW}, // }
+        0x221A: {dir: V, sizes: STDVSIZES, stretch: [0xE001, 0xE000, 0x23B7], HDW: STDVHDW}, // \surd
     };
 
     /*
@@ -174,6 +175,7 @@ export class TeXFont extends FontData {
             0x7B: [.75,   .25,  .5],       // LEFT CURLY BRACKET
             0x7C: [.75,   .249, .278],     // VERTICAL LINE
             0x7D: [.75,   .25,  .5],       // RIGHT CURLY BRACKET
+            0x221A: [.8,  .2,   .833],     // SQUARE ROOT
         }
     };
 

--- a/samples/mml-bbox.js
+++ b/samples/mml-bbox.js
@@ -6,14 +6,14 @@ import {MathML} from "mathjax3/input/mathml.js";
 import {CHTML} from "mathjax3/output/chtml.js";
 
 let html = MathJax.document("<html></html>", {
-  InputJax: new MathML(),
-  OutputJax: new CHTML()
+    InputJax: new MathML(),
+    OutputJax: new CHTML()
 });
 
 function showBBox(node, space) {
     const {h, d, w} = node.getBBox();
     console.log(space + node.node.toString(), [h, d, w], node.variant);
-    if (!node.node.isToken) {
+    if (!node.node.isToken && !node.node.isKind('annotation') && !node.node.isKind('annotation-xml')) {
         for (const child of node.childNodes) showBBox(child, space+'  ');
     }
 }

--- a/samples/mml-bbox.js
+++ b/samples/mml-bbox.js
@@ -14,13 +14,13 @@ function showBBox(node, space) {
     const {h, d, w} = node.getBBox();
     console.log(space + node.node.toString(), [h, d, w], node.variant);
     if (!node.node.isToken) {
-        for (const child of node.childNodes) showBBox(child, space+"  ");
+        for (const child of node.childNodes) showBBox(child, space+'  ');
     }
 }
 
 MathJax.handleRetriesFor(function () {
 
-    html.TestMath(process.argv[3] || '<math></math>').compile();
+    html.TestMath(process.argv[3] || '<math></math>').compile().typeset();
     let math = html.math.pop();
     let chtml = html.options.OutputJax;
     chtml.document = html;
@@ -28,7 +28,12 @@ MathJax.handleRetriesFor(function () {
     chtml.nodes.document(html.document);
     chtml.nodeMap = new Map();
     let wrap = chtml.factory.wrap(math.root);
-    showBBox(wrap, "");
+
+    console.log('');
+    showBBox(wrap, '');
+    console.log('');
+    console.log(math.typesetRoot.outerHTML);
+    
 
 }).catch(err => {
   console.log(err.message);


### PR DESCRIPTION
This PR implements several more MathML node types:  ms, mpadded, msqrt, mroot, semantics, annotation, annotation-xml, and (the MathJax-specific) TeXAtom nodes.  Note that some of the support for annotation-xml as the first element of semantics is not yet in place, and will be added later.