### PR TITLE
Update v2 files to v2.7.2 versions

### DIFF
--- a/mathjax2/legacy/jax/element/mml/jax.js
+++ b/mathjax2/legacy/jax/element/mml/jax.js
@@ -11,7 +11,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2009-2015 The MathJax Consortium
+ *  Copyright (c) 2009-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ MathJax.ElementJax.mml = MathJax.ElementJax({
   mimeType: "jax/mml"
 },{
   id: "mml",
-  version: "2.6.0",
+  version: "2.7.2",
   directory: MathJax.ElementJax.directory + "/mml",
   extensionDir: MathJax.ElementJax.extensionDir + "/mml",
   optableDir: MathJax.ElementJax.directory + "/mml/optable"
@@ -376,7 +376,7 @@ MathJax.ElementJax.mml.Augment({
       if (prev === MML.TEXCLASS.VCENTER) {prev = MML.TEXCLASS.ORD}
       if (tex  === MML.TEXCLASS.VCENTER) {tex  = MML.TEXCLASS.ORD}
       var space = this.TEXSPACE[prev][tex];
-      if (this.prevLevel > 0 && this.Get("scriptlevel") > 0 && space >= 0) {return ""}
+      if ((this.prevLevel > 0 || this.Get("scriptlevel") > 0) && space >= 0) {return ""}
       return this.TEXSPACELENGTH[Math.abs(space)];
     },
     TEXSPACELENGTH:[
@@ -1463,6 +1463,7 @@ MathJax.ElementJax.mml.Augment({
   
   MML.TeXAtom = MML.mbase.Subclass({
     type: "texatom",
+    linebreakContainer: true,
     inferRow: true, notParent: true,
     texClass: MML.TEXCLASS.ORD,
     Core: MML.mbase.childCore,

--- a/mathjax2/legacy/jax/element/mml/optable/Arrows.js
+++ b/mathjax2/legacy/jax/element/mml/optable/Arrows.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/Arrows.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/BasicLatin.js
+++ b/mathjax2/legacy/jax/element/mml/optable/BasicLatin.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/BasicLatin.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/CombDiacritMarks.js
+++ b/mathjax2/legacy/jax/element/mml/optable/CombDiacritMarks.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/CombDiacritMarks.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/CombDiactForSymbols.js
+++ b/mathjax2/legacy/jax/element/mml/optable/CombDiactForSymbols.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/CombDiactForSymbols.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/Dingbats.js
+++ b/mathjax2/legacy/jax/element/mml/optable/Dingbats.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/Dingbats.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/GeneralPunctuation.js
+++ b/mathjax2/legacy/jax/element/mml/optable/GeneralPunctuation.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/GeneralPunctuation.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/GeometricShapes.js
+++ b/mathjax2/legacy/jax/element/mml/optable/GeometricShapes.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/GeometricShapes.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/GreekAndCoptic.js
+++ b/mathjax2/legacy/jax/element/mml/optable/GreekAndCoptic.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/GreekAndCoptic.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/Latin1Supplement.js
+++ b/mathjax2/legacy/jax/element/mml/optable/Latin1Supplement.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/Latin1Supplement.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/LetterlikeSymbols.js
+++ b/mathjax2/legacy/jax/element/mml/optable/LetterlikeSymbols.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/LetterlikeSymbols.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/MathOperators.js
+++ b/mathjax2/legacy/jax/element/mml/optable/MathOperators.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/MathOperators.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/MiscMathSymbolsA.js
+++ b/mathjax2/legacy/jax/element/mml/optable/MiscMathSymbolsA.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/MiscMathSymbolsA.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/MiscMathSymbolsB.js
+++ b/mathjax2/legacy/jax/element/mml/optable/MiscMathSymbolsB.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/MiscMathSymbolsB.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/MiscSymbolsAndArrows.js
+++ b/mathjax2/legacy/jax/element/mml/optable/MiscSymbolsAndArrows.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/MiscSymbolsAndArrows.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/MiscTechnical.js
+++ b/mathjax2/legacy/jax/element/mml/optable/MiscTechnical.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/MiscTechnical.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/SpacingModLetters.js
+++ b/mathjax2/legacy/jax/element/mml/optable/SpacingModLetters.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/SpacingModLetters.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/SuppMathOperators.js
+++ b/mathjax2/legacy/jax/element/mml/optable/SuppMathOperators.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/SuppMathOperators.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/SupplementalArrowsA.js
+++ b/mathjax2/legacy/jax/element/mml/optable/SupplementalArrowsA.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/SupplementalArrowsA.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/element/mml/optable/SupplementalArrowsB.js
+++ b/mathjax2/legacy/jax/element/mml/optable/SupplementalArrowsB.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/optable/SupplementalArrowsB.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/AsciiMath/config.js
+++ b/mathjax2/legacy/jax/input/AsciiMath/config.js
@@ -13,7 +13,7 @@
  *  
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2012-2016 The MathJax Consortium
+ *  Copyright (c) 2012-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
 
 MathJax.InputJax.AsciiMath = MathJax.InputJax({
   id: "AsciiMath",
-  version: "2.7.0",
+  version: "2.7.2",
   directory: MathJax.InputJax.directory + "/AsciiMath",
   extensionDir: MathJax.InputJax.extensionDir + "/AsciiMath",
   

--- a/mathjax2/legacy/jax/input/AsciiMath/jax.js
+++ b/mathjax2/legacy/jax/input/AsciiMath/jax.js
@@ -24,7 +24,7 @@
  *  
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2012-2016 The MathJax Consortium
+ *  Copyright (c) 2012-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/config.js
+++ b/mathjax2/legacy/jax/input/MathML/config.js
@@ -10,7 +10,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2009-2016 The MathJax Consortium
+ *  Copyright (c) 2009-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
 MathJax.InputJax.MathML = MathJax.InputJax({
   id: "MathML",
-  version: "2.7.0",
+  version: "2.7.2",
   directory: MathJax.InputJax.directory + "/MathML",
   extensionDir: MathJax.InputJax.extensionDir + "/MathML",
   entityDir: MathJax.InputJax.directory + "/MathML/entities",

--- a/mathjax2/legacy/jax/input/MathML/entities/a.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/a.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/a.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/b.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/b.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/b.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/c.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/c.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/c.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/d.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/d.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/d.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/e.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/e.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/e.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/f.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/f.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/f.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/fr.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/fr.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/fr.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/g.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/g.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/g.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/h.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/h.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/h.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/i.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/i.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/i.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/j.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/j.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/j.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/k.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/k.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/k.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/l.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/l.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/l.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/m.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/m.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/m.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/n.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/n.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/n.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/o.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/o.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/o.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/opf.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/opf.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/opf.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/p.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/p.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/p.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/q.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/q.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/q.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/r.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/r.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/r.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/s.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/s.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/s.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/scr.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/scr.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/scr.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/t.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/t.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/t.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/u.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/u.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/u.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/v.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/v.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/v.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/w.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/w.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/w.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/x.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/x.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/x.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/y.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/y.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/y.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/entities/z.js
+++ b/mathjax2/legacy/jax/input/MathML/entities/z.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/entities/z.js
  *
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/MathML/jax.js
+++ b/mathjax2/legacy/jax/input/MathML/jax.js
@@ -11,7 +11,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2010-2016 The MathJax Consortium
+ *  Copyright (c) 2010-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/input/TeX/config.js
+++ b/mathjax2/legacy/jax/input/TeX/config.js
@@ -1,3 +1,6 @@
+/* -*- Mode: Javascript; indent-tabs-mode:nil; js-indent-level: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+
 /*************************************************************
  *
  *  MathJax/jax/input/TeX/config.js
@@ -7,7 +10,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2009-2015 The MathJax Consortium
+ *  Copyright (c) 2009-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,7 +27,7 @@
 
 MathJax.InputJax.TeX = MathJax.InputJax({
   id: "TeX",
-  version: "2.6.1",
+  version: "2.7.2",
   directory: MathJax.InputJax.directory + "/TeX",
   extensionDir: MathJax.InputJax.extensionDir + "/TeX",
   
@@ -39,10 +42,12 @@ MathJax.InputJax.TeX = MathJax.InputJax({
       formatNumber: function (n) {return n},
       formatTag:    function (n) {return '('+n+')'},
       formatID:     function (n) {return 'mjx-eqn-'+String(n).replace(/[:"'<>&]/g,"")},
-      formatURL:    function (id) {return '#'+escape(id)},
+      formatURL:    function (id,base) {return base+'#'+escape(id)},
       useLabelIds:  true
     }
-  }
+  },
+  
+  resetEquationNumbers: function () {}  // filled in by AMSmath extension
 });
 MathJax.InputJax.TeX.Register("math/tex");
 

--- a/mathjax2/legacy/jax/input/TeX/jax.js
+++ b/mathjax2/legacy/jax/input/TeX/jax.js
@@ -11,7 +11,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2009-2015 The MathJax Consortium
+ *  Copyright (c) 2009-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@
     return MathJax.Localization._.apply(MathJax.Localization,
       [["TeX", id]].concat([].slice.call(arguments,1)));
   };
+  
+  var isArray = MathJax.Object.isArray;
 
   var STACK = MathJax.Object.Subclass({
     Init: function (env,inner) {
@@ -53,8 +55,10 @@
         else if (top) {
           this.data.push(item);
           if (item.env) {
-            for (var id in this.env)
-              {if (this.env.hasOwnProperty(id)) {item.env[id] = this.env[id]}}
+            if (item.copyEnv !== false) {
+              for (var id in this.env)
+                {if (this.env.hasOwnProperty(id)) {item.env[id] = this.env[id]}}
+            }
             this.env = item.env;
           } else {item.env = this.env}
         }
@@ -256,9 +260,9 @@
   });
   
   STACKITEM.array = STACKITEM.Subclass({
-    type: "array", isOpen: true, arraydef: {},
+    type: "array", isOpen: true, copyEnv: false, arraydef: {},
     Init: function () {
-      this.table = []; this.row = []; this.env = {}; this.frame = []; this.hfill = [];
+      this.table = []; this.row = []; this.frame = []; this.hfill = [];
       this.SUPER(arguments).Init.apply(this,arguments);
     },
     checkItem: function (item) {
@@ -363,7 +367,7 @@
       if (item.type === "open" || item.type === "left") {return true}
       if (item.type === "mml" && item.data[0].type.match(/^(mo|mi|mtext)$/)) {
         mml = item.data[0], c = mml.data.join("");
-        if (c.length === 1 && !mml.movesupsub) {
+        if (c.length === 1 && !mml.movesupsub && mml.data.length === 1) {
           c = STACKITEM.not.remap[c.charCodeAt(0)];
           if (c) {mml.SetData(0,MML.chars(String.fromCharCode(c)))}
             else {mml.Append(MML.chars("\u0338"))}
@@ -412,7 +416,7 @@
     Add: function (src,dst,nouser) {
       if (!dst) {dst = this}
       for (var id in src) {if (src.hasOwnProperty(id)) {
-        if (typeof src[id] === 'object' && !(src[id] instanceof Array) &&
+        if (typeof src[id] === 'object' && !isArray(src[id]) &&
            (typeof dst[id] === 'object' || typeof dst[id] === 'function')) 
              {this.Add(src[id],dst[id],src[id],nouser)}
           else if (!dst[id] || !dst[id].isUser || !nouser) {dst[id] = src[id]}
@@ -712,8 +716,8 @@
         '\\arrowvert':      '23D0',
         '\\Arrowvert':      '2016',
         '\\bracevert':      '23AA',  // non-standard
-        '\\Vert':           ['2225',{texClass:MML.TEXCLASS.ORD}],
-        '\\|':              ['2225',{texClass:MML.TEXCLASS.ORD}],
+        '\\Vert':           ['2016',{texClass:MML.TEXCLASS.ORD}],
+        '\\|':              ['2016',{texClass:MML.TEXCLASS.ORD}],
         '\\vert':           ['|',{texClass:MML.TEXCLASS.ORD}],
         '\\uparrow':        '2191',
         '\\downarrow':      '2193',
@@ -864,6 +868,7 @@
         mskip:              'Hskip',
         mspace:             'Hskip',
         mkern:              'Hskip',
+        rule:               'rule',
         Rule:              ['Rule'],
         Space:             ['Rule','blank'],
     
@@ -1101,7 +1106,7 @@
     ControlSequence: function (c) {
       var name = this.GetCS(), macro = this.csFindMacro(name);
       if (macro) {
-        if (!(macro instanceof Array)) {macro = [macro]}
+        if (!isArray(macro)) {macro = [macro]}
         var fn = macro[0]; if (!(fn instanceof Function)) {fn = this[fn]}
         fn.apply(this,[c+name].concat(macro.slice(1)));
       } else if (TEXDEF.mathchar0mi[name])            {this.csMathchar0mi(name,TEXDEF.mathchar0mi[name])}
@@ -1120,7 +1125,7 @@
     //
     csMathchar0mi: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.ITALIC};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1128,7 +1133,7 @@
     //
     csMathchar0mo: function (name,mchar) {
       var def = {stretchy: false};
-      if (mchar instanceof Array) {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mo(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1136,7 +1141,7 @@
     //
     csMathchar7: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.NORMAL};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; mchar = mchar[0]}
       if (this.stack.env.font) {def.mathvariant = this.stack.env.font}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
@@ -1145,7 +1150,7 @@
     //
     csDelimiter: function (name,delim) {
       var def = {};
-      if (delim instanceof Array) {def = delim[1]; delim = delim[0]}
+      if (isArray(delim)) {def = delim[1]; delim = delim[0]}
       if (delim.length === 4) {delim = MML.entity('#x'+delim)} else {delim = MML.chars(delim)}
       this.Push(this.mmlToken(MML.mo(delim).With({fence: false, stretchy: false}).With(def)));
     },
@@ -1292,7 +1297,7 @@
       if (this.stack.env.font) {def = {mathvariant: this.stack.env.font}}
       if (TEXDEF.remap[c]) {
         c = TEXDEF.remap[c];
-        if (c instanceof Array) {def = c[1]; c = c[0]}
+        if (isArray(c)) {def = c[1]; c = c[0]}
         mo = MML.mo(MML.entity('#x'+c)).With(def);
       } else {
         mo = MML.mo(c).With(def);
@@ -1335,9 +1340,11 @@
     
     Middle: function (name) {
       var delim = this.GetDelimiter(name);
+      this.Push(MML.TeXAtom().With({texClass:MML.TEXCLASS.CLOSE}));
       if (this.stack.Top().type !== "left")
         {TEX.Error(["MisplacedMiddle","%1 must be within \\left and \\right",name])}
       this.Push(MML.mo(delim).With({stretchy:true}));
+      this.Push(MML.TeXAtom().With({texClass:MML.TEXCLASS.OPEN}));
     },
     
     NamedFn: function (name,id) {
@@ -1433,6 +1440,8 @@
       var def = {accent: true}; if (this.stack.env.font) {def.mathvariant = this.stack.env.font}
       var mml = this.mmlToken(MML.mo(MML.entity("#x"+accent)).With(def));
       mml.stretchy = (stretchy ? true : false);
+      var mo = (c.isEmbellished() ? c.CoreMO() : c);
+      if (mo.isa(MML.mo)) mo.movablelimits = false;
       this.Push(MML.TeXAtom(MML.munderover(c,null,mml).With({accent: true})));
     },
     
@@ -1572,13 +1581,28 @@
       var w = this.GetDimen(name),
           h = this.GetDimen(name),
           d = this.GetDimen(name);
-      var mml, def = {width:w, height:h, depth:d};
+      var def = {width:w, height:h, depth:d};
       if (style !== 'blank') {
-        if (parseFloat(w) && parseFloat(h)+parseFloat(d))
-          {def.mathbackground = (this.stack.env.color || "black")}
-        mml = MML.mpadded(MML.mrow()).With(def);
-      } else {
-        mml = MML.mspace().With(def);
+        def.mathbackground = (this.stack.env.color || "black");
+      }
+      this.Push(MML.mspace().With(def));
+    },
+    rule: function (name) {
+      var v = this.GetBrackets(name),
+          w = this.GetDimen(name),
+          h = this.GetDimen(name);
+      var mml = MML.mspace().With({
+        width: w, height:h,
+        mathbackground: (this.stack.env.color || "black")
+      });
+      if (v) {
+        mml = MML.mpadded(mml).With({voffset: v});
+        if (v.match(/^\-/)) {
+          mml.height = v;
+          mml.depth = '+' + v.substr(1);
+        } else {
+          mml.height = '+' + v;
+        }
       }
       this.Push(mml);
     },
@@ -1677,20 +1701,68 @@
     Entry: function (name) {
       this.Push(STACKITEM.cell().With({isEntry: true, name: name}));
       if (this.stack.Top().isCases) {
+        //
+        //  Make second column be in \text{...} (unless it is already
+        //  in a \text{...}, for backward compatibility).
+        //
         var string = this.string;
-        var braces = 0, i = this.i, m = string.length;
+        var braces = 0, close = -1, i = this.i, m = string.length;
+        //
+        //  Look through the string character by character...
+        //
         while (i < m) {
           var c = string.charAt(i);
-          if (c === "{") {braces++; i++}
-          else if (c === "}") {if (braces === 0) {m = 0} else {braces--; i++}}
-          else if (c === "&" && braces === 0) {
+          if (c === "{") {
+            //
+            //  Increase the nested brace count and go on
+            //
+            braces++;
+            i++;
+          } else if (c === "}") {
+            //
+            //  If there are too many close braces, just end (we will get an
+            //    error message later when the rest of the string is parsed)
+            //  Otherwise
+            //    decrease the nested brace count,
+            //    if it is now zero and we haven't already marked the end of the
+            //      first brace group, record the position (use to check for \text{} later)
+            //    go on to the next character.
+            //
+            if (braces === 0) {
+              m = 0;
+            } else {
+              braces--;
+              if (braces === 0 && close < 0) {
+                close = i - this.i;
+              }
+              i++;
+            }
+          } else if (c === "&" && braces === 0) {
+            //
+            //  Extra alignment tabs are not allowed in cases
+            //
             TEX.Error(["ExtraAlignTab","Extra alignment tab in \\cases text"]);
           } else if (c === "\\") {
+            //
+            //  If the macro is \cr or \\, end the search, otherwise skip the macro
+            //  (multi-letter names don't matter, as we will skip the rest of the
+            //   characters in the main loop)
+            //
             if (string.substr(i).match(/^((\\cr)[^a-zA-Z]|\\\\)/)) {m = 0} else {i += 2}
-          } else {i++}
+          } else {
+            //
+            //  Go on to the next character
+            //
+            i++;
+          }
         }
+        //
+        //  Check if the second column text is already in \text{},
+        //  If not, process the second column as text and continue parsing from there,
+        //    (otherwise process the second column as normal, since it is in \text{}
+        //
         var text = string.substr(this.i,i-this.i);
-        if (!text.match(/^\s*\\text[^a-zA-Z]/)) {
+        if (!text.match(/^\s*\\text[^a-zA-Z]/) || close !== text.replace(/\s+$/,'').length - 1) {
           this.Push.apply(this,this.InternalMath(text,0));
           this.i = i;
         }
@@ -1783,11 +1855,11 @@
       if (env.match(/\\/i)) {TEX.Error(["InvalidEnv","Invalid environment name '%1'",env])}
       var cmd = this.envFindName(env);
       if (!cmd) {TEX.Error(["UnknownEnv","Unknown environment '%1'",env])}
-      if (!(cmd instanceof Array)) {cmd = [cmd]}
-      var end = (cmd[1] instanceof Array ? cmd[1][0] : cmd[1]);
+      if (!isArray(cmd)) {cmd = [cmd]}
+      var end = (isArray(cmd[1]) ? cmd[1][0] : cmd[1]);
       var mml = STACKITEM.begin().With({name: env, end: end, parse:this});
       if (name === "\\end") {
-        if (!isEnd && cmd[1] instanceof Array && this[cmd[1][1]]) {
+        if (!isEnd && isArray(cmd[1]) && this[cmd[1][1]]) {
           mml = this[cmd[1][1]].apply(this,[mml].concat(cmd.slice(2)));
         } else {
           mml = STACKITEM.end().With({name: env});
@@ -1861,7 +1933,7 @@
     convertDelimiter: function (c) {
       if (c) {c = TEXDEF.delimiter[c]}
       if (c == null) {return null}
-      if (c instanceof Array) {c = c[0]}
+      if (isArray(c)) {c = c[0]}
       if (c.length === 4) {c = String.fromCharCode(parseInt(c,16))}
       return c;
     },
@@ -1871,7 +1943,9 @@
      */
     trimSpaces: function (text) {
       if (typeof(text) != 'string') {return text}
-      return text.replace(/^\s+|\s+$/g,'');
+      var TEXT = text.replace(/^\s+|\s+$/g,'');
+      if (TEXT.match(/\\$/) && text.match(/ $/)) TEXT += " ";
+      return TEXT;
     },
 
     /*
@@ -2193,7 +2267,7 @@
       //
       //  Translate message if it is ["id","message",args]
       //
-      if (message instanceof Array) {message = _.apply(_,message)}
+      if (isArray(message)) {message = _.apply(_,message)}
       throw HUB.Insert(Error(message),{texError: true});
     },
     
@@ -2210,9 +2284,11 @@
      */
     fenced: function (open,mml,close) {
       var mrow = MML.mrow().With({open:open, close:close, texClass:MML.TEXCLASS.INNER});
-      mrow.Append(MML.mo(open).With({fence:true, stretchy:true, texClass:MML.TEXCLASS.OPEN}));
-      if (mml.type === "mrow") {mrow.Append.apply(mrow,mml.data)} else {mrow.Append(mml)}
-      mrow.Append(MML.mo(close).With({fence:true, stretchy:true, texClass:MML.TEXCLASS.CLOSE}));
+      mrow.Append(
+        MML.mo(open).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.OPEN}),
+        mml,
+        MML.mo(close).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.CLOSE})
+      );
       return mrow;
     },
     /*

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/annotation-xml.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/annotation-xml.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML;
 

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/maction.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/maction.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML;
   

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/menclose.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/menclose.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML;
   

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/mglyph.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/mglyph.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML,
       LOCALE = MathJax.Localization;

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/mmultiscripts.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/mmultiscripts.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML;
 

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/ms.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/ms.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CHTML = MathJax.OutputJax.CommonHTML;
   

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/mtable.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/mtable.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CONFIG = MathJax.Hub.config,
       CHTML = MathJax.OutputJax.CommonHTML,
@@ -201,6 +201,11 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         //
         B = RSPACE[i]/2; border = null; L = "0";
         if (RLINES[i] !== MML.LINES.NONE && RLINES[i] !== "") border = state.t+" "+RLINES[i];
+        if (border || (CLINES[j] !== MML.LINES.NONE && CLINES[j] !== "")) {
+          while (row.length <= state.J) {
+            row.push(CHTML.addElement(row.node,"mjx-mtd",null,[['span']]));
+          }
+        }
         state.RH[i] = lastB + state.H[i];                 // distance to baseline in row
         lastB = Math.max(0,B);
         state.RHD[i] = state.RH[i] + lastB + state.D[i];  // total height of row
@@ -214,7 +219,8 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         //
         for (var j = 0, M = row.length; j < M; j++) {
           var s = (rdata.type === "mtr" ? 0 : LABEL);
-          cell = row[j].style; cbox = rdata.data[j-s].CHTML;
+          var mtd = rdata.data[j-s] || {CHTML: CHTML.BBOX.zero()};
+          var cell = row[j].style; cbox = mtd.CHTML;
           //
           //  Space and borders between columns
           //
@@ -230,7 +236,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           //
           //  Handle vertical alignment
           //
-          align = (rdata.data[j-s].rowalign||this.data[i].rowalign||RALIGN[i]);
+          align = (mtd.rowalign||(this.data[i]||{}).rowalign||RALIGN[i]);
           var H = Math.max(1,cbox.h), D = Math.max(.2,cbox.d),
               HD = (state.H[i]+state.D[i]) - (H+D),
               child = row[j].firstChild.style;
@@ -249,7 +255,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           //
           //  Handle horizontal alignment
           //
-          align = (rdata.data[j-s].columnalign||RCALIGN[i][j]||CALIGN[j]);
+          align = (mtd.columnalign||RCALIGN[i][j]||CALIGN[j]);
           if (align !== MML.ALIGN.CENTER) cell.textAlign = align;
         }
         row.node.style.height = CHTML.Em(state.RHD[i]);

--- a/mathjax2/legacy/jax/output/CommonHTML/autoload/multiline.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/autoload/multiline.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   var MML = MathJax.ElementJax.mml,
       CONFIG = MathJax.Hub.config,
       CHTML = MathJax.OutputJax.CommonHTML;

--- a/mathjax2/legacy/jax/output/CommonHTML/config.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/config.js
@@ -10,7 +10,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2013-2016 The MathJax Consortium
+ *  Copyright (c) 2013-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
 MathJax.OutputJax.CommonHTML = MathJax.OutputJax({
   id: "CommonHTML",
-  version: "2.7.0",
+  version: "2.7.2",
   directory: MathJax.OutputJax.directory + "/CommonHTML",
   extensionDir: MathJax.OutputJax.extensionDir + "/CommonHTML",
   autoloadDir: MathJax.OutputJax.directory + "/CommonHTML/autoload",

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/AMS-Regular.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/AMS-Regular.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/AMS-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Caligraphic-Bold.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Caligraphic-Bold.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Caligraphic-Bold.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Fraktur-Bold.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Fraktur-Bold.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Fraktur-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Fraktur-Regular.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Fraktur-Regular.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Fraktur-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Main-Bold.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Main-Bold.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Main-Bold.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Math-BoldItalic.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Math-BoldItalic.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/HTML-CSS/fonts/TeX/Math/BoldItalic/Main.js
  *
- *  Copyright (c) 2009-2016 The MathJax Consortium
+ *  Copyright (c) 2009-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Bold.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Bold.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/SansSerif-Bold.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Italic.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Italic.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/SansSerif-Italic.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Regular.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/SansSerif-Regular.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/SansSerif-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Script-Regular.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Script-Regular.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Script-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Typewriter-Regular.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/Typewriter-Regular.js
@@ -2,7 +2,7 @@
  *
  *  MathJax/jax/output/CommonHTML/fonts/TeX/Typewriter-Regular.js
  *
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/fontdata-extra.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/fontdata-extra.js
@@ -9,7 +9,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  */
 
 (function (CHTML) {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   
   var DELIMITERS = CHTML.FONTDATA.DELIMITERS;
 

--- a/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/fontdata.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/fonts/TeX/fontdata.js
@@ -10,7 +10,7 @@
  *
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2015-2016 The MathJax Consortium
+ *  Copyright (c) 2015-2017 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
  */
 
 (function (CHTML,MML,AJAX) {
-  var VERSION = "2.7.0";
+  var VERSION = "2.7.2";
   
   var MAIN   = "MathJax_Main",
       BOLD   = "MathJax_Main-Bold",
@@ -95,9 +95,10 @@
                  remap: {0x391:0x41, 0x392:0x42, 0x395:0x45, 0x396:0x5A, 0x397:0x48,
                          0x399:0x49, 0x39A:0x4B, 0x39C:0x4D, 0x39D:0x4E, 0x39F:0x4F,
                          0x3A1:0x50, 0x3A4:0x54, 0x3A7:0x58,
+                         0xE160:[0x2192, "-TeX-vec"],  // HACK for \vec (#1709)
                          0x2016:0x2225,
-                         0x2216:[0x2216,"-TeX-variant"],  // \smallsetminus
-                         0x210F:[0x210F,"-TeX-variant"],  // \hbar
+                         0x2216:[0x2216,"-TeX-variant",true],  // \smallsetminus
+                         0x210F:[0x210F,"-TeX-variant",true],  // \hbar
                          0x2032:[0x27,"sans-serif-italic"],  // HACK: a smaller prime
                          0x29F8:[0x002F,MML.VARIANT.ITALIC]}},
       "bold":   {fonts:[BOLD], bold:true, cache: {}, chain:"normal",
@@ -105,6 +106,7 @@
                  remap: {0x391:0x41, 0x392:0x42, 0x395:0x45, 0x396:0x5A, 0x397:0x48,
                          0x399:0x49, 0x39A:0x4B, 0x39C:0x4D, 0x39D:0x4E, 0x39F:0x4F,
                          0x3A1:0x50, 0x3A4:0x54, 0x3A7:0x58, 0x29F8:[0x002F,"bold-italic"],
+                         0xE160:[0x2192, "-TeX-vec-bold"],  // HACK for \vec (#1709)
                          0x2016:0x2225,
                          0x219A:"\u2190\u0338", 0x219B:"\u2192\u0338", 0x21AE:"\u2194\u0338",
                          0x21CD:"\u21D0\u0338", 0x21CE:"\u21D4\u0338", 0x21CF:"\u21D2\u0338",
@@ -151,9 +153,11 @@
                    0x2A87: 0xE010, 0x2A88: 0xE00F, 0x2224: 0xE006, 0x2226: 0xE007,
                    0x2288: 0xE016, 0x2289: 0xE018, 0x228A: 0xE01A, 0x228B: 0xE01B,
                    0x2ACB: 0xE017, 0x2ACC: 0xE019, 0x03DC: 0xE008, 0x03F0: 0xE009,
-                   0x2216:[0x2216,MML.VARIANT.NORMAL], // \setminus
-                   0x210F:[0x210F,MML.VARIANT.NORMAL]  // \hslash
+                   0x2216:[0x2216,MML.VARIANT.NORMAL,true], // \setminus
+                   0x210F:[0x210F,MML.VARIANT.NORMAL,true]  // \hslash
                  }},
+      "-TeX-vec": {fonts: ["MathJax_Vector"], cache:{}},  // HACK: non-combining \vec
+      "-TeX-vec-bold": {fonts: ["MathJax_Vector-Bold"], cache:{}},  // HACK: non-combining \vec
       "-largeOp": {fonts:[SIZE2,SIZE1,MAIN,AMS],cache:{}},
       "-smallOp": {fonts:[SIZE1,MAIN,AMS], cache:{}},
       "-tex-caligraphic-bold": {fonts:["MathJax_Caligraphic-Bold","MathJax_Main-Bold"], bold:true, cache:{}, chain:"normal",
@@ -167,15 +171,9 @@
       {name: "greek", low: 0x03B1, high: 0x03F6, offset: "G"}
     ],
       
-    RULECHAR: 0x2212,
-      
     REMAP: {
+      0xA: 0x20,                      // newline
       0x203E: 0x2C9,                  // overline
-      0x20D0: 0x21BC, 0x20D1: 0x21C0, // combining left and right harpoons
-      0x20D6: 0x2190, 0x20E1: 0x2194, // combining left arrow and lef-right arrow
-      0x20EC: 0x21C1, 0x20ED: 0x21BD, // combining low right and left harpoons
-      0x20EE: 0x2190, 0x20EF: 0x2192, // combining low left and right arrows
-      0x20F0: 0x2A,                   // combining asterisk
       0xFE37: 0x23DE, 0xFE38: 0x23DF, // OverBrace, UnderBrace
 
       0xB7: 0x22C5,                   // center dot
@@ -254,16 +252,34 @@
       0x2036: "\u2035\u2035",        // double back prime
       0x2037: "\u2035\u2035\u2035",  // trile back prime
       0x2057: "\u2032\u2032\u2032\u2032",  // quadruple prime
-      0x20DB: "...",                 // combining three dots above (only works with mover/under)
-      0x20DC: "...."                 // combining four dots above (only works with mover/under)
     },
       
     REMAPACCENT: {
-      "\u2192":"\u20D7",
+      "\u0300":"\u02CB",  // grave accent
+      "\u0301":"\u02CA",  // acute accent
+      "\u0302":"\u02C6",  // curcumflex
+      "\u0303":"\u02DC",  // tilde accent
+      "\u0304":"\u02C9",  // macron
+      "\u0306":"\u02D8",  // breve
+      "\u0307":"\u02D9",  // dot
+      "\u0308":"\u00A8",  // diaresis
+      "\u030A":"\u02DA",  // ring above
+      "\u030C":"\u02C7",  // caron
+      "\u20D7":"\uE160",  // HACK: for non-combining \vec (#1709)
+      "\u2192":"\uE160",
       "\u2032":"'",
-      "\u2035":"`"
+      "\u2035":"`",
+      "\u20D0":"\u21BC", "\u20D1":"\u21C0", // combining left and right harpoons
+      "\u20D6":"\u2190", "\u20E1":"\u2194", // combining left arrow and lef-right arrow
+      "\u20F0":"*",                         // combining asterisk
+      "\u20DB":"...",      // combining three dots above
+      "\u20DC":"...."       // combining four dots above
     },
     REMAPACCENTUNDER: {
+      "\u20EC":"\u21C1", "\u20ED":"\u21BD", // combining low right and left harpoons
+      "\u20EE":"\u2190", "\u20EF":"\u2192", // combining low left and right arrows
+      "\u20DB":"...",      // combining three dots above
+      "\u20DC":"...."       // combining four dots above
     },
 
     PLANE1MAP: [
@@ -388,6 +404,10 @@
       0x02DC: // wide tilde
       {
         dir: H, HW: [[.333+.25,MAIN],[.555+.25,SIZE1],[1+.33,SIZE2],[1.443+.33,SIZE3],[1.887,SIZE4]]
+      },
+      0x2013: // en-dash
+      {
+        dir: H, HW: [[.5,MAIN]], stretch: {rep:[0x2013,MAIN]}
       },
       0x2016: // vertical arrow extension
       {
@@ -531,22 +551,23 @@
       },
       0x002D: {alias: 0x2212, dir:H}, // minus
       0x005E: {alias: 0x02C6, dir:H}, // wide hat
-      0x005F: {alias: 0x2212, dir:H}, // low line
+      0x005F: {alias: 0x2013, dir:H}, // low line
       0x007E: {alias: 0x02DC, dir:H}, // wide tilde
       0x02C9: {alias: 0x00AF, dir:H}, // macron
       0x0302: {alias: 0x02C6, dir:H}, // wide hat
       0x0303: {alias: 0x02DC, dir:H}, // wide tilde
       0x030C: {alias: 0x02C7, dir:H}, // wide caron
-      0x0332: {alias: 0x2212, dir:H}, // combining low line
-      0x2015: {alias: 0x2212, dir:H}, // horizontal line
-      0x2017: {alias: 0x2212, dir:H}, // horizontal line
+      0x0332: {alias: 0x2013, dir:H}, // combining low line
+      0x2014: {alias: 0x2013, dir:H}, // em-dash
+      0x2015: {alias: 0x2013, dir:H}, // horizontal line
+      0x2017: {alias: 0x2013, dir:H}, // horizontal line
       0x203E: {alias: 0x00AF, dir:H}, // overline
-      0x20D7: {alias: 0x2192, dir:H}, // combinining over right arrow (vector arrow)
+      0x20D7: {alias: 0x2192, dir:H}, // combining over right arrow (vector arrow)
       0x2215: {alias: 0x002F, dir:V}, // division slash
       0x2329: {alias: 0x27E8, dir:V}, // langle
       0x232A: {alias: 0x27E9, dir:V}, // rangle
-      0x23AF: {alias: 0x2212, dir:H}, // horizontal line extension
-      0x2500: {alias: 0x2212, dir:H}, // horizontal line
+      0x23AF: {alias: 0x2013, dir:H}, // horizontal line extension
+      0x2500: {alias: 0x2013, dir:H}, // horizontal line
       0x2758: {alias: 0x2223, dir:V}, // vertical separator
       0x3008: {alias: 0x27E8, dir:V}, // langle
       0x3009: {alias: 0x27E9, dir:V}, // rangle
@@ -604,7 +625,8 @@
       0x27FB: {alias: 0x21A4, dir:H}, // long left arrow from bar
       0x27FC: {alias: 0x21A6, dir:H}, // long right arrow from bar
       0x27FD: {alias: 0x2906, dir:H}, // long left double arrow from bar
-      0x27FE: {alias: 0x2907, dir:H}  // long right double arrow from bar
+      0x27FE: {alias: 0x2907, dir:H}, // long right double arrow from bar
+      0xE160: {alias: 0x2190, dir:H}, // replacement vector arrow
     }
   };
   
@@ -1590,6 +1612,16 @@
     0xE153: [333,0,450,-10,474],       // stix-horizontal brace, upper right piece
     0xE154: [120,0,400,-10,410]        // stix-oblique open face capital letter A
   };
+  
+  CHTML.FONTDATA.FONTS['MathJax_Vector'] = {
+    centerline: 257, ascent: 714, descent: 200,
+    0x2192: [714,-516,500,29,471]      // vector arrow
+  };
+
+  CHTML.FONTDATA.FONTS['MathJax_Vector-Bold'] = {
+    centerline: 256, ascent: 723, descent: 210,
+    0x2192: [723,-513,575,33,542]      // vector arrow
+  };
 
   CHTML.FONTDATA.FONTS[MAIN][0x2212][0] = CHTML.FONTDATA.FONTS[MAIN][0x002B][0]; // minus is sized as plus
   CHTML.FONTDATA.FONTS[MAIN][0x2212][1] = CHTML.FONTDATA.FONTS[MAIN][0x002B][1]; // minus is sized as plus
@@ -1614,6 +1646,21 @@
   //  Add some spacing characters
   //
   MathJax.Hub.Insert(CHTML.FONTDATA.FONTS[MAIN],{
+    remapCombining: {
+      0x300: 0x2CB,                   // grave accent
+      0x301: 0x2CA,                   // acute accent
+      0x302: 0x2C6,                   // curcumflex
+      0x303: 0x2DC,                   // tilde accent
+      0x304: 0x2C9,                   // macron
+      0x306: 0x2D8,                   // breve
+      0x307: 0x2D9,                   // dot
+      0x308: 0xA8,                    // diaresis
+      0x30A: 0x2DA,                   // ring above
+//    0x30B: ??                       // double acute accent
+      0x30C: 0x2C7,                   // caron
+      0x338: [0x2F, ITALIC],              // \not
+      0x20D7: [0x2192, 'MathJax_Vector']  // \vec
+    },
     0x2000: [0,0,500,0,0,{space:1}],  // en space
     0x2001: [0,0,1000,0,0,{space:1}], // em quad
     0x2002: [0,0,500,0,0,{space:1}],  // en quad
@@ -1633,7 +1680,39 @@
     0xEEE1: [0,0,-300,0,0,{space:1}],
     0xEEE8: [0,0,25,0,0,{space:1}]
   });
-
+  MathJax.Hub.Insert(CHTML.FONTDATA.FONTS['MathJax_Main-Italic'],{
+    remapCombining: {
+      0x300: [0x2CB, MAIN],           // grave accent
+      0x301: [0x2CA, MAIN],           // acute accent
+      0x302: [0x2C6, MAIN],           // curcumflex
+      0x303: [0x2DC, MAIN],           // tilde accent
+      0x304: [0x2C9, MAIN],           // macron
+      0x306: [0x2D8, MAIN],           // breve
+      0x307: [0x2D9, MAIN],           // dot
+      0x308: [0xA8,  MAIN],           // diaresis
+      0x30A: [0x2DA, MAIN],           // ring above
+//    0x30B: ??                       // double acute accent
+      0x30C: [0x2C7, MAIN],           // caron
+      0x338: [0x2F,  'MathJax_Vector']  // \not
+    }
+  });
+  MathJax.Hub.Insert(CHTML.FONTDATA.FONTS['MathJax_Main-Bold'],{
+    remapCombining: {
+      0x300: 0x2CB,                   // grave accent
+      0x301: 0x2CA,                   // acute accent
+      0x302: 0x2C6,                   // curcumflex
+      0x303: 0x2DC,                   // tilde accent
+      0x304: 0x2C9,                   // macron
+      0x306: 0x2D8,                   // breve
+      0x307: 0x2D9,                   // dot
+      0x308: 0xA8,                    // diaresis
+      0x30A: 0x2DA,                   // ring above
+//    0x30B: ??                       // double acute accent
+      0x30C: 0x2C7,                   // caron
+      0x338: [0x2F, 'MathJax_Math-BoldItalic'], // \not
+      0x20D7: [0x2192, 'MathJax_Vector-Bold']   // \vec
+    }
+  });
       
   //
   //  Create @font-face stylesheet for the declared fonts
@@ -1641,7 +1720,7 @@
   CHTML.FONTDATA.familyName = function (font) {
     font = font.replace(/^MathJax_/,"");
     var names = (font+"-Regular").split(/-/);
-    var suffix = names[0].toLowerCase().replace(/(?:igraphic|serif|writer|tur)$/,"") 
+    var suffix = names[0].toLowerCase().replace(/(?:igraphic|serif|writer|tur|tor)$/,"") 
                + "-" + names[1].replace(/[^A-Z]/g,"");
     return "MJXc-TeX-"+suffix;
   };

--- a/mathjax2/legacy/jax/output/CommonHTML/jax.js
+++ b/mathjax2/legacy/jax/output/CommonHTML/jax.js
@@ -8,11 +8,11 @@
  *  Implements the CommonHTML OutputJax that displays mathematics
  *  using HTML and CSS to position the characters from math fonts
  *  in their proper locations.  Unlike the HTML-CSS output jax,
- *  this HTML is browswer and OS independent.
+ *  this HTML is browser and OS independent.
  *  
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2013-2016 The MathJax Consortium
+ *  Copyright (c) 2013-2017 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 (function (AJAX,HUB,HTML,CHTML) {
   var MML;
   var isArray = MathJax.Object.isArray;
-  
+
   var EVENT, TOUCH, HOVER; // filled in later
 
   var STRUTHEIGHT = 1,
@@ -81,7 +81,7 @@
     ".mjx-math":   {
       "display":         "inline-block",
       "border-collapse": "separate",
-      "border-spacing":  0,
+      "border-spacing":  0
     },
     ".mjx-math *": {
       display:"inline-block",
@@ -179,7 +179,8 @@
       height:            "1px"
     },
     ".mjx-ex-box-test": {
-      position:  "absolute",
+      position: "absolute",
+      overflow: "hidden",
       width:"1px", height:"60ex"
     },
     ".mjx-line-box-test": {display: "table!important"},
@@ -195,7 +196,7 @@
       border: "1px solid black",
       "box-shadow": "2px 2px 5px #AAAAAA",         // Opera 10.5
       "-webkit-box-shadow": "2px 2px 5px #AAAAAA", // Safari 3 and Chrome
-      "-moz-box-shadow": "2px 2px 5px #AAAAAA",    // Forefox 3.5
+      "-moz-box-shadow": "2px 2px 5px #AAAAAA",    // Firefox 3.5
       "-khtml-box-shadow": "2px 2px 5px #AAAAAA",  // Konqueror
       padding: "3px 4px",
       "z-index": 401,
@@ -210,6 +211,7 @@
   /************************************************************/
   
   var BIGDIMEN = 1000000;
+  var MAXREMAP = 5;
   var LINEBREAKS = {}, CONFIG = MathJax.Hub.config;
 
   CHTML.Augment({
@@ -375,12 +377,16 @@
     //
     getNode: function (node,type) {
       var name = RegExp("\\b"+type+"\\b");
+      var nodes = [];
       while (node) {
         for (var i = 0, m = node.childNodes.length; i < m; i++) {
           var child = node.childNodes[i];
-          if (name.test(child.className)) return child;
+          if (child) {
+            if (name.test(child.className)) return child;
+            if (child.id === "") nodes.push(child);
+          }
         }
-        node = (node.firstChild && (node.firstChild.id||"") === "" ? node.firstChild : null);
+        node = nodes.shift();
       }
       return null;
     },
@@ -389,7 +395,7 @@
     
     preTranslate: function (state) {
       var scripts = state.jax[this.id], i, m = scripts.length,
-          script, prev, node, test, span, jax, ex, em;
+          script, prev, node, test, span, jax, ex, em, scale;
       //
       //  Get linebreaking information
       //
@@ -770,7 +776,7 @@
     //  require looking through the data again.
     //
     getCharList: function (variant,n) {
-      var id, M, list = [], cache = variant.cache, nn = n;
+      var id, M, cache = variant.cache, nn = n;
       if (cache[n]) return cache[n];
       if (n > 0xFFFF && this.FONTDATA.RemapPlane1) {
         var nv = this.FONTDATA.RemapPlane1(n,variant);
@@ -794,13 +800,21 @@
           }
         }
       }
+      cache[nn] = this.remapChar(variant,n,0);
+      return cache[nn];
+    },
+    remapChar: function (variant,n,N) {
+      var list = [], VARIANT = this.FONTDATA.VARIANT;
       if (variant.remap && variant.remap[n]) {
         n = variant.remap[n];
         if (variant.remap.variant) {variant = VARIANT[variant.remap.variant]}
       } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
         n = this.FONTDATA.REMAP[n];
       }
-      if (isArray(n)) {variant = VARIANT[n[1]]; n = n[0]} 
+      if (isArray(n)) {
+        if (n[2]) N = MAXREMAP; // stop remapping
+        variant = VARIANT[n[1]]; n = n[0];
+      } 
       if (typeof(n) === "string") {
         var string = {text:n, i:0, length:n.length};
         while (string.i < string.length) {
@@ -810,9 +824,8 @@
         }
       } else {
         if (variant.cache[n]) {list = variant.cache[n]}
-          else {variant.cache[n] = list = [this.lookupChar(variant,n)]}
+          else {variant.cache[n] = list = this.lookupChar(variant,n,N)}
       }
-      cache[nn] = list;
       return list;
     },
     //
@@ -821,7 +834,7 @@
     //  variants as needed.  Return an undefined character if
     //  it isnt' found in the given variant.
     //
-    lookupChar: function (variant,n) {
+    lookupChar: function (variant,n,N) {
       var VARIANT = variant;
       while (variant) {
         for (var i = 0, m = variant.fonts.length; i < m; i++) {
@@ -829,20 +842,27 @@
           if (typeof(font) === "string") this.loadFont(font);
           var C = font[n];
           if (C) {
-            if (C.length === 5) C[5] = {};
-            if (C.c == null) {
-              C[0] /= 1000; C[1] /= 1000; C[2] /= 1000; C[3] /= 1000; C[4] /= 1000;
-              C.c = this.unicodeChar(n);
-            }
-            if (C[5].space) return {type:"space", w:C[2], font:font};
-            return {type:"char", font:font, n:n};
+            this.fixChar(C,n);
+            if (C[5].space) return [{type:"space", w:C[2], font:font}];
+            return [{type:"char", font:font, n:n}];
           } else if (font.Extra) {
             this.findBlock(font,n);
           }
         }
         variant = this.FONTDATA.VARIANT[variant.chain];
+        if (variant && variant.remap && variant.remap[n] && N++ < MAXREMAP) {
+          return this.remapChar(variant,n,N);
+        }
       }
-      return this.unknownChar(VARIANT,n);
+      return [this.unknownChar(VARIANT,n)];
+    },
+    fixChar: function (C,n) {
+      if (C.length === 5) C[5] = {};
+      if (C.c == null) {
+        C[0] /= 1000; C[1] /= 1000; C[2] /= 1000; C[3] /= 1000; C[4] /= 1000;
+        C.c = this.unicodeChar(n);
+      }
+      return C;
     },
     findBlock: function (font,n) {
       var extra = font.Extra, name = font.file, file;
@@ -951,19 +971,45 @@
       //  Character from the known fonts
       //
       "char": function (item,node,bbox,state,m) {
-        var font = item.font;
-        if (state.className && font.className !== state.className) this.flushText(node,state);
+        var font = item.font, remap = (font.remapCombining||{})[item.n];
+        if (font.className === state.className) {
+          remap = null;
+        } else if (state.className || (remap && state.text !== "")) {
+          this.flushText(node,state);
+        }
         if (!state.a) state.a = font.centerline/1000;
         if (state.a > (bbox.a||0)) bbox.a = state.a;
+        state.className = font.className;
         var C = font[item.n];
-        state.text += C.c; state.className = font.className;
+        if (remap) {
+          var FONT = font;
+          if (isArray(remap)) {
+            FONT = CHTML.FONTDATA.FONTS[remap[1]];
+            remap = remap[0];
+            if (typeof(FONT) === 'string') CHTML.loadFont(FONT);
+          }
+          if (FONT[item.n]) CHTML.fixChar(FONT[item.n],item.n);
+          C = CHTML.fixChar(FONT[remap],remap);
+          state.className = FONT.className;
+        }
+        state.text += C.c;
         if (bbox.h < C[0]+HFUZZ) bbox.t = bbox.h = C[0]+HFUZZ;
         if (bbox.d < C[1]+DFUZZ) bbox.b = bbox.d = C[1]+DFUZZ;
         if (bbox.l > bbox.w+C[3]) bbox.l = bbox.w+C[3];
         if (bbox.r < bbox.w+C[4]) bbox.r = bbox.w+C[4];
         bbox.w += C[2] * (item.rscale||1);
         if (m == 1 && font.skew && font.skew[item.n]) bbox.skew = font.skew[item.n];
-        if (C[5].rfix) this.flushText(node,state).style.marginRight = CHTML.Em(C[5].rfix/1000);
+        if (C[5] && C[5].rfix) this.flushText(node,state).style.marginRight = CHTML.Em(C[5].rfix/1000);
+        if (remap) {
+          //
+          //  Remap combining characters to non-combining versions since Safari
+          //  handles them differently from everyone else.  (#1709)
+          //
+          var chr = this.flushText(node,state);
+          var r = (FONT[item.n]||font[item.n])[4] - (C[4] - C[2]);
+          chr.style.marginLeft = CHTML.Em(-C[2]-r);
+          if (r < 0) chr.style.marginRight = CHTML.Em(-r);
+        }
       },
       //
       //  Space characters (not actually in the fonts)
@@ -986,7 +1032,7 @@
           if (bbox.a == null || state.a > bbox.a) bbox.a = state.a;
         }
         node = this.flushText(node,state,item.style);
-        node.style.width = CHTML.Em(C[2]);
+        if (C[2] < 3) node.style.width = CHTML.Em(C[2]); // only force width if not too large (#1718)
       },
       //
       //  Put the pending text into a box of the class, and
@@ -1308,7 +1354,7 @@
     },
     combine: function (cbox,x,y) {
       cbox.X = x; cbox.Y = y;  // save for use with line breaking
-      scale = cbox.rscale;
+      var scale = cbox.rscale;
       if (x + scale*cbox.r > this.r) this.r = x + scale*cbox.r;
       if (x + scale*cbox.l < this.l) this.l = x + scale*cbox.l;
       if (x + scale*(cbox.w+(cbox.L||0)+(cbox.R||0)) > this.w)
@@ -1321,7 +1367,7 @@
       if (scale*cbox.b - y > this.b) this.b = scale*cbox.b - y;
     },
     append: function (cbox) {
-      scale = cbox.rscale; var x = this.w;
+      var scale = cbox.rscale; var x = this.w;
       if (x + scale*cbox.r > this.r) this.r = x + scale*cbox.r;
       if (x + scale*cbox.l < this.l) this.l = x + scale*cbox.l;
       this.w += scale*(cbox.w+(cbox.L||0)+(cbox.R||0)) ;
@@ -1414,8 +1460,13 @@
           if (!options.noBBox) {
             var bbox = this.CHTML, cbox = child.CHTML;
             bbox.append(cbox);
-            if (cbox.ic) {bbox.ic = cbox.ic} else {delete bbox.ic}
-            if (cbox.skew) bbox.skew = cbox.skew;
+            if (this.data.length === 1) {
+              if (cbox.ic) bbox.ic = cbox.ic;
+              if (cbox.skew) bbox.skew = cbox.skew;
+            } else {
+              delete bbox.ic;
+              delete bbox.skew;
+            }
             if (cbox.pwidth) bbox.pwidth = cbox.pwidth;
           }
         } else if (options.forceChild) {
@@ -1466,6 +1517,10 @@
           }
         }
       },
+      CHTMLupdateFrom: function (bbox) {
+        this.CHTML.updateFrom(bbox);
+        if (this.inferRow) this.data[0].CHTML.updateFrom(bbox);
+      },
 
       CHTMLcanStretch: function (direction,H,D) {
         var stretch = false;
@@ -1477,11 +1532,11 @@
         return stretch;
       },
       CHTMLstretchV: function (h,d) {
-        this.CHTML.updateFrom(this.Core().CHTMLstretchV(h,d));
+        this.CHTMLupdateFrom(this.Core().CHTMLstretchV(h,d));
         return this.CHTML;
       },
       CHTMLstretchH: function (node,w) {
-        this.CHTML.updateFrom(this.CHTMLstretchCoreH(node,w));
+        this.CHTMLupdateFrom(this.CHTMLstretchCoreH(node,w));
         return this.CHTML;
       },
       CHTMLstretchCoreH: function (node,w) {
@@ -1720,7 +1775,7 @@
         return this.CHTML;
       },
       CHTMLstretchH: function (node,w) {
-        this.CHTMLstretchCoreH(node,w);
+        this.CHTMLupdateFrom(this.CHTMLstretchCoreH(node,w));
         this.toCommonHTML(node,{stretch:true});
         return this.CHTML;
       }      
@@ -1877,8 +1932,7 @@
       },
       CHTMLadjustAccent: function (data) {
         var parent = this.CoreParent(); data.parent = parent;
-        if (data.text.length === 1 && parent && parent.isa(MML.munderover) && 
-            this.CoreText(parent.data[parent.base]).length === 1) {
+        if (data.text.length === 1 && parent && parent.isa(MML.munderover)) {
           var over = parent.data[parent.over], under = parent.data[parent.under];
           if (over && this === over.CoreMO() && parent.Get("accent")) {
             data.remapchars = CHTML.FONTDATA.REMAPACCENT;
@@ -2144,6 +2198,22 @@
         var boxes = [], W = this.CHTMLgetBBoxes(boxes,nodes,values);
         var bbox = boxes[this.base], BBOX = this.CHTML;
         BBOX.w = W; BBOX.h = bbox.h; BBOX.d = bbox.d; // modified below
+        //
+        // Adjust for bases shorter than the center line (#1657)
+        // (the center line really depends on the surrounding font, so
+        //  it should be measured along with ems and exs, but currently isn't.
+        //  so this value is an approximation that is reasonable for most fonts.)
+        //
+        if (bbox.h < .35) base.style.marginTop = CHTML.Em(bbox.h - .35);
+        //
+        //  Use a minimum height for accents (#1706)
+        //  (same issues with the center line as above)
+        //
+        if (values.accent && bbox.h < CHTML.TEX.x_height) {
+          BBOX.h += CHTML.TEX.x_height - bbox.h;
+          base.style.marginTop = CHTML.Em(CHTML.TEX.x_height - Math.max(bbox.h,.35));
+          bbox.h = CHTML.TEX.x_height;
+        }
         //
         //  Add over- and under-scripts
         //  
@@ -2520,7 +2590,7 @@
         //  Add nulldelimiterspace around the fraction
         //  (TeXBook pg 150 and Appendix G rule 15e)
         //
-        if (!this.texWithDelims && !this.useMMLspacing) {
+        if (!this.texWithDelims) {
           var space = CHTML.TEX.nulldelimiterspace;
           frac.style.padding = "0 "+CHTML.Em(space);
           BBOX.l += space; BBOX.r += space; BBOX.w += 2*space;
@@ -2680,12 +2750,12 @@
         return node;
       },
       CHTMLstretchV: function (h,d) {
-        this.CHTML.updateFrom(this.Core().CHTMLstretchV(h,d));
+        this.CHTMLupdateFrom(this.Core().CHTMLstretchV(h,d));
         this.toCommonHTML(this.CHTMLnodeElement(),{stretch:true});
         return this.CHTML;
       },
       CHTMLstretchH: function (node,w) {
-        this.CHTML.updateFrom(this.CHTMLstretchCoreH(node,w));
+        this.CHTMLupdateFrom(this.CHTMLstretchCoreH(node,w));
         this.toCommonHTML(node,{stretch:true});
         return this.CHTML;
       }
@@ -2698,7 +2768,7 @@
         node = this.CHTMLcreateNode(node);
 	if (this.data[0]) {
 	  this.data[0].toCommonHTML(node);
-	  this.CHTML.updateFrom(this.data[0].CHTML);
+	  this.CHTMLupdateFrom(this.data[0].CHTML);
           this.CHTMLhandleBBox(node);
 	}
         return node;


### PR DESCRIPTION
This updates the files in the `mathjax2` directory to be the current 2.7.2 versions (some where as old as 2.6).  In particular, this brings the legacy TeX input jax up to date (as well as the other input jax, the mml element jax, and the CHTML output jax).

There is no need for review of this, as the changes are all v2.x changes.