### PR TITLE
Create css styles for CommonHTML

### DIFF
--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -291,6 +291,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             factory.getNodeClass(this.kind).defaults,
             factory.getNodeClass('math').defaults
         );
+        this.attributes.setList(attributes);
     }
 
     /*

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -53,7 +53,7 @@ export class CHTML extends AbstractOutputJax {
     };
 
     /*
-     *  Used to store the HTMLNodes factory, the CHTMLWraper factory,
+     *  Used to store the HTMLNodes factory, the CHTMLWrapper factory,
      *  the FontData object, and the CssStyles object.
      */
     public nodes: HTMLNodes;

--- a/mathjax3-ts/output/chtml/CssStyles.ts
+++ b/mathjax3-ts/output/chtml/CssStyles.ts
@@ -1,24 +1,69 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CssStyles class for handling stylesheets
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+/*
+ * The data for a selector
+ */
 export type StyleData = {
     [property: string]: string | number;
 };
 
+/*
+ * A list of selectors and their data (basically a stylesheet)
+ */
 export type StyleList = {
     [selector: string]: StyleData;
 };
 
-export type StyleDef = StyleList | {[name: string]: StyleList};
+/******************************************************************************/
+/*
+ * The CssStyles class (for managing a collection oof CSS style definitions
+ */
 
 export class CssStyles {
+    /*
+     * The styles as they currently stand
+     */
     protected styles: StyleList = {};
 
+    /*
+     * @return{string}  The styles as a CSS string
+     */
     get cssText() {
         return this.getStyleString();
     }
 
+    /*
+     * @param{StyleList} styles  The initial styles to use, if any
+     * @constructor
+     */
     constructor(styles: StyleList = null) {
         this.addStyles(styles);
     }
 
+    /*
+     * @param{StyleList} styles  The styles to combine with the existing ones
+     */
     public addStyles(styles: StyleList) {
         if (!styles) return;
         for (const style of Object.keys(styles)) {
@@ -29,28 +74,35 @@ export class CssStyles {
         }
     }
 
+    /*
+     * @param{string[]} selectors  The selectors for the styles to remove
+     */
     public removeStyles(...selectors: string[]) {
         for (const selector of selectors) {
             delete this.styles[selector];
         }
     }
 
-    public getStyleString(styles: StyleList = null) {
-        if (!styles) {
-            styles = this.styles;
-        }
-        const selectors = Object.keys(styles);
+    /*
+     * @return{string} The CSS string for the style list
+     */
+    public getStyleString() {
+        const selectors = Object.keys(this.styles);
         const defs: string[] = new Array(selectors.length);
         let i = 0;
         for (const selector of selectors) {
-            defs[i++] = selector + ' {\n' + this.getStyleDefString(styles[selector]) + '\n}';
+            defs[i++] = selector + ' {\n' + this.getStyleDefString(this.styles[selector]) + '\n}';
         }
         return defs.join('\n\n');
     }
 
+    /*
+     * @param{StyleData} styles  The style data to be stringified
+     * @return{string}           The CSS string for the given data
+     */
     public getStyleDefString(styles: StyleData) {
         const properties = Object.keys(styles);
-        const values: string[] = [];
+        const values: string[] = new Array(properties.length);
         let i = 0;
         for (const property of properties) {
             values[i++] = '  ' + property + ': ' + styles[property] + ';';

--- a/mathjax3-ts/output/chtml/CssStyles.ts
+++ b/mathjax3-ts/output/chtml/CssStyles.ts
@@ -1,0 +1,61 @@
+export type StyleData = {
+    [property: string]: string | number;
+};
+
+export type StyleList = {
+    [selector: string]: StyleData;
+};
+
+export type StyleDef = StyleList | {[name: string]: StyleList};
+
+export class CssStyles {
+    protected styles: StyleList = {};
+
+    get cssText() {
+        return this.getStyleString();
+    }
+
+    constructor(styles: StyleList = null) {
+        this.addStyles(styles);
+    }
+
+    public addStyles(styles: StyleList) {
+        if (!styles) return;
+        for (const style of Object.keys(styles)) {
+            if (!this.styles[style]) {
+                this.styles[style] = {};
+            }
+            Object.assign(this.styles[style], styles[style]);
+        }
+    }
+
+    public removeStyles(...selectors: string[]) {
+        for (const selector of selectors) {
+            delete this.styles[selector];
+        }
+    }
+
+    public getStyleString(styles: StyleList = null) {
+        if (!styles) {
+            styles = this.styles;
+        }
+        const selectors = Object.keys(styles);
+        const defs: string[] = new Array(selectors.length);
+        let i = 0;
+        for (const selector of selectors) {
+            defs[i++] = selector + ' {\n' + this.getStyleDefString(styles[selector]) + '\n}';
+        }
+        return defs.join('\n\n');
+    }
+
+    public getStyleDefString(styles: StyleData) {
+        const properties = Object.keys(styles);
+        const values: string[] = [];
+        let i = 0;
+        for (const property of properties) {
+            values[i++] = '  ' + property + ': ' + styles[property] + ';';
+        }
+        return values.join('\n');
+    }
+
+}

--- a/mathjax3-ts/output/chtml/CssStyles.ts
+++ b/mathjax3-ts/output/chtml/CssStyles.ts
@@ -37,7 +37,7 @@ export type StyleList = {
 
 /******************************************************************************/
 /*
- * The CssStyles class (for managing a collection oof CSS style definitions
+ * The CssStyles class (for managing a collection of CSS style definitions)
  */
 
 export class CssStyles {

--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -42,7 +42,7 @@ export const enum CSS {
     width = 1 << 0,
     padding = 1 << 1,
     content = 1 << 2
-};
+}
 
 
 /*

--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -360,7 +360,7 @@ export class FontData {
     }
 
     /*
-     * @param{number} n  A unicode code point to be converred to a character reference for use with the
+     * @param{number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).
      * @return{string}  The character as a properly encoded string.

--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -22,7 +22,28 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {OptionList} from '../../util/Options.js';
+import {StringMap} from './Wrapper.js';
+
+/*
+ * The extra options allowed in a CharData array
+ */
+export type CharOptions = {
+    c?: string;                   // the content value (for css)
+    f?: string;                   // the font postfix (for css)
+    css?: number;                 // a bitmap for whether CSS is needed for content, padding, or width
+    ic?: number;                  // italic correction value
+    sk?: number;                  // skew value
+};
+
+/*
+ * The bit values for CharOptions.css
+ */
+export const enum CSS {
+    width = 1 << 0,
+    padding = 1 << 1,
+    content = 1 << 2
+};
+
 
 /*
  * Data about a character
@@ -30,9 +51,7 @@ import {OptionList} from '../../util/Options.js';
  */
 export type CharData =
     [number, number, number] |
-    [number, number, number, number] |
-    [number, number, number, number, number] |
-    [number, number, number, number, number, OptionList];
+    [number, number, number, CharOptions];
 
 export type CharMap = {
     [n: number]: CharData;
@@ -55,6 +74,10 @@ export type VariantData = {
      * The character data for this variant
      */
     chars: CharMap;
+    /*
+     * The classes to use for this variant
+     */
+    classes?: string;
 };
 
 export type VariantMap = {
@@ -68,9 +91,12 @@ export type DelimiterData = {
     dir: string;                 // 'V' or 'H' for vertcial or horizontal
     sizes?: number[];            // Array of fixed sizes for this character
     variants?: number[];         // The variants in which the different sizes can be found (if not the default)
+    schar?: number[];            // The character number to use for each size (if different from the default)
     stretch?: number[];          // The unicode character numbers for the parts of multi-character versions [beg, ext, end, mid?]
     HDW?: number[];              // [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
                                  //            for horizontal, h and d are the multi-character ones, w is for the normal size).
+    min?: number;                // The minimum size a multi-character version can be
+    c?: number;                   // The character number (for aliased delimiters)
 };
 
 export type DelimiterMap = {
@@ -198,6 +224,11 @@ export class FontData {
     protected static defaultSizeVariants: string[] = [];
 
     /*
+     * The default class names to use for each variant
+     */
+    protected static defaultVariantClasses: StringMap = {};
+
+    /*
      * The actual variant, delimiter, and size information for this font
      */
     protected variant: VariantMap = {};
@@ -222,6 +253,9 @@ export class FontData {
         this.defineDelimiters(CLASS.defaultDelimiters);
         for (const name of Object.keys(CLASS.defaultChars)) {
             this.defineChars(name, CLASS.defaultChars[name]);
+        }
+        for (const name of Object.keys(CLASS.defaultVariantClasses)) {
+            this.variant[name].classes = CLASS.defaultVariantClasses[name];
         }
     }
 
@@ -323,6 +357,17 @@ export class FontData {
      */
     public getVariant(name: string) {
         return this.variant[name];
+    }
+
+    /*
+     * @param{number} n  A unicode code point to be converred to a character reference for use with the
+     *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
+     *                   for higher values, or for the double quote and backslash characters).
+     * @return{string}  The character as a properly encoded string.
+     */
+    public char(n: number, escape: boolean = false) {
+        return (n >= 0x20 && n <= 0x7E && n !== 0x22 && n !== 0x27 && n !== 0x5C ?
+                String.fromCharCode(n) : (escape ? '\\' : '') + n.toString(16).toUpperCase());
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -44,33 +44,6 @@ import {StyleList} from './CssStyles.js';
 export type StringMap = {[key: string]: string};
 
 /*
- * The classes to use for each variant
- */
-export const VARIANT: StringMap = {
-    normal: 'mjx-n',
-    bold: 'mjx-b',
-    italic: 'mjx-i',
-    'bold-italic': 'mjx-b mjx-i',
-    'double-struck': 'mjx-ds',
-    'fraktur': 'mjx-fr',
-    'bold-fraktur': 'mjx-fr mjx-b',
-    'script': 'mjx-sc',
-    'bold-script': 'mjx-sc mjx-b',
-    'sans-serif': 'mjx-ss',
-    'bold-sans-serif': 'mjx-ss mjx-b',
-    'sans-serif-italic': 'mjx-ss mjx-i',
-    'bold-sans-serif-italic': 'mjx-ss mjx-b mjx-i',
-    monospace: 'mjx-ty',
-    '-tex-caligraphic': 'mjx-cal',
-    '-tex-oldstyle': 'mjx-os',
-    '-tex-mathit': 'mjx-mit',
-    '-smallop': 'mjx-sop',
-    '-largeop': 'mjx-lop',
-    '-size3': 'mjx-s3',
-    '-size4': 'mjx-s4',
-};
-
-/*
  * The value to use for each spacing size
  */
 export const SPACE: StringMap = {
@@ -516,7 +489,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      */
     protected handleVariant() {
         if (this.node.isToken && this.variant !== '-explicitFont') {
-            this.chtml.className = VARIANT[this.variant] || VARIANT.normal;
+            this.chtml.className = (this.font.getVariant(this.variant) || this.font.getVariant('normal')).classes;
         }
     }
 
@@ -691,8 +664,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * @return{string}  The character as a properly encoded string.
      */
     protected char(n: number, escape: boolean = false) {
-        return (n >= 0x20 && n <= 0x7E && n !== 0x22 && n !== 0x5C ?
-                String.fromCharCode(n) : (escape ? '\\' : '') + n.toString(16).toUpperCase());
+        return this.font.char(n, escape);
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -52,6 +52,9 @@ export const SPACE: StringMap = {
     thickmathspace: '3'
 };
 
+/*
+ * Some standard sizes to use in predefind CSS properties
+ */
 export const FONTSIZE: StringMap = {
     '70.7%': 's',
     '70%': 's',
@@ -81,11 +84,20 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
 
     public static kind: string = 'unknown';
 
+    /*
+     * If true, this causes a style for the node type to be generated automatically
+     * that sets display:inline-block (as needed for the output for MmlNodes).
+     */
     public static autoStyle = true;
+
+    /*
+     *  The default styles for CommonHTML
+     */
     public static styles: StyleList = {
         'mjx-chtml [space="1"]': {'margin-left': '.167em'},
         'mjx-chtml [space="2"]': {'margin-left': '.222em'},
         'mjx-chtml [space="3"]': {'margin-left': '.278em'},
+
         'mjx-chtml [size="s"]' : {'font-size': '70.7%'},
         'mjx-chtml [size="ss"]': {'font-size': '50%'},
         'mjx-chtml [size="Tn"]': {'font-size': '60%'},
@@ -115,6 +127,9 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         'mjx-mphantom': {visibility: 'hidden'},
 
         'mjx-math': {
+            //
+            //  There will be more here when the math wrapper is written
+            //
             display: 'inline-block',
             'line-height': '0px'
         }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -34,6 +34,7 @@ import {CHTMLWrapperFactory} from './WrapperFactory.js';
 import {CHTMLmo} from './Wrappers/mo.js';
 import {BBox, BBoxData} from './BBox.js';
 import {FontData} from './FontData.js';
+import {StyleList} from './CssStyles.js';
 
 /*****************************************************************/
 
@@ -106,6 +107,46 @@ interface CSSStyle extends CSSStyleDeclaration {
 export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
 
     public static kind: string = 'unknown';
+
+    public static autoStyle = true;
+    public static styles: StyleList = {
+        'mjx-chtml [space="1"]': {'margin-left': '.167em'},
+        'mjx-chtml [space="2"]': {'margin-left': '.222em'},
+        'mjx-chtml [space="3"]': {'margin-left': '.278em'},
+        'mjx-chtml [size="s"]' : {'font-size': '70.7%'},
+        'mjx-chtml [size="ss"]': {'font-size': '50%'},
+        'mjx-chtml [size="Tn"]': {'font-size': '60%'},
+        'mjx-chtml [size="sm"]': {'font-size': '85%'},
+        'mjx-chtml [size="lg"]': {'font-size': '120%'},
+        'mjx-chtml [size="Lg"]': {'font-size': '144%'},
+        'mjx-chtml [size="LG"]': {'font-size': '173%'},
+        'mjx-chtml [size="hg"]': {'font-size': '207%'},
+        'mjx-chtml [size="HG"]': {'font-size': '249%'},
+
+        'mjx-box': {display: 'inline-block'},
+        'mjx-block': {display: 'block'},
+        'mjx-itable': {display: 'inline-table'},
+
+        //
+        //  These don't have Wrapper subclasses, so add their styles here
+        //
+        'mjx-mi': {display: 'inline-block'},
+        'mjx-mn': {display: 'inline-block'},
+        'mjx-mtext': {display: 'inline-block'},
+        'mjx-merror': {
+            display: 'inline-block',
+            color: 'red',
+            'background-color': 'yellow'
+        },
+
+        'mjx-mphantom': {visibility: 'hidden'},
+
+        'mjx-math': {
+            display: 'inline-block',
+            'line-height': '0px'
+        }
+
+    };
 
     /*
      * Styles that should not be passed on from style attribute

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -33,6 +33,13 @@ import {TextNode} from '../../../core/MmlTree/MmlNode.js';
 export class CHTMLTextNode extends CHTMLWrapper {
     public static kind = TextNode.prototype.kind;
 
+    public static autoStyle = false;
+    public static styles = {
+        'mjx-c, mjx-c::before': {
+            display: 'inline-block'
+        }
+    };
+
     /*
      * @override
      */

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -25,6 +25,7 @@ import {CHTMLWrapper} from '../Wrapper.js';
 import {MmlMfrac} from '../../../core/MmlTree/MmlNodes/mfrac.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
+import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
 /*
@@ -33,6 +34,64 @@ import {BBox} from '../BBox.js';
 
 export class CHTMLmfrac extends CHTMLWrapper {
     public static kind = MmlMfrac.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-strut' {
+            display: 'inline-block',
+            height: '1em',
+            width: 0,
+            'vertical-align': '-.2em'
+        },
+        'mjx-hstrut': {
+            display: 'inline-block',
+            height: '.8em',
+            width: 0
+        },
+        'mjx-dstrut': {
+            display: 'inline-block',
+            height: '.2em',
+            width: 0,
+            'vertical-align': '-.2em'
+        },
+
+        'mjx-frac': {
+            display: 'inline-block',
+            'vertical-align': '0.145em',
+            padding: '0 3px'
+        },
+        'mjx-dtable': {
+            display: 'inline-table',
+            width: '100%'
+        },
+        'mjx-dtable > *': {
+            'font-size': '2000%'
+        },
+        'mjx-row': {
+            display: 'table-row'
+        },
+        'mjx-num': {
+            display: 'block',
+            'text-align': 'center'
+        },
+        'mjx-den': {
+            display: 'block',
+            'text-align': 'center'
+        },
+        'mjx-dbox': {
+            display: 'block',
+            'font-size': '5%'
+        },
+
+        'mjx-line': {
+            display: 'block',
+            'box-sizing': 'border-box',
+            'min-height': '1px',
+            height: '.07em',
+            'border-top': '.07em solid',
+            margin: '.07em -3px',
+            overflow: 'hidden'
+        }
+    };
 
     /*
      * @override

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -36,7 +36,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
     public static kind = MmlMfrac.prototype.kind;
 
     public static styles: StyleList = {
-        'mjx-strut' {
+        'mjx-strut': {
             display: 'inline-block',
             height: '1em',
             width: 0,

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -26,6 +26,7 @@ import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
 import {DelimiterData} from '../FontData.js';
+import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
 /*
@@ -33,6 +34,60 @@ import {DelimiterData} from '../FontData.js';
  */
 export class CHTMLmo extends CHTMLWrapper {
     public static kind = MmlMo.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-symmetric': {
+            'vertical-align': '.25em'
+        },
+        'mjx-symmetric > mjx-c': {
+            'vertical-align': 'middle'
+        },
+
+        'mjx-stretchy-h': {
+            display: 'inline-table',
+            width: '100%',
+            'min-width': '1.2em'
+        },
+        'mjx-stretchy-h > mjx-beg, mjx-stretchy-h > mjx-end': {
+            display: 'table-cell',
+            width: 0
+        },
+        'mjx-stretchy-h > mjx-ext': {
+            display: 'table-cell',
+            overflow: 'hidden',
+            width: '100%'
+        },
+        'mjx-stretchy-h > mjx-ext > mjx-c': {
+            transform: 'scalex(1000)',
+            margin: '0 -1em'
+        },
+
+        'mjx-stretchy-v': {
+            display: 'inline-block'
+        },
+        'mjx-stretchy-v > mjx-beg, mjx-stretchy-v> mjx-end': {
+            display: 'block',
+            height: 0
+        },
+        'mjx-stretchy-v > mjx-beg > mjx-c, mjx-stretchy-v > mjx-end > mjx-c': {
+            overflow: 'hidden'
+        },
+        'mjx-stretchy-v > mjx-ext': {
+            display: 'block',
+            height: '100%',
+            'box-sizing': 'border-box',
+            border: '0px solid transparent',
+            overflow: 'hidden'
+        },
+        'mjx-stretchy-v > mjx-ext > mjx-c': {
+            transform: 'scaley(1000)'
+        },
+        'mjx-mark': {
+            display: 'inline-block',
+            height: '0px'
+        }
+
+    };
 
     /*
      * The font size that a stretched operator uses.

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -65,9 +65,15 @@ export class CHTMLmo extends CHTMLWrapper {
         'mjx-stretchy-v': {
             display: 'inline-block'
         },
-        'mjx-stretchy-v > mjx-beg, mjx-stretchy-v> mjx-end': {
+        'mjx-stretchy-v > mjx-beg': {
             display: 'block',
             height: 0
+        },
+        'mjx-stretchy-v > mjx-end': {
+            display: 'block'
+        },
+        'mjx-stretchy-v > mjx-end > mjx-c': {
+            display: 'block'
         },
         'mjx-stretchy-v > mjx-beg > mjx-c, mjx-stretchy-v > mjx-end > mjx-c': {
             overflow: 'hidden'
@@ -80,7 +86,7 @@ export class CHTMLmo extends CHTMLWrapper {
             overflow: 'hidden'
         },
         'mjx-stretchy-v > mjx-ext > mjx-c': {
-            transform: 'scaley(1000)'
+            transform: 'scaleY(1000) translateY(.5em)'
         },
         'mjx-mark': {
             display: 'inline-block',

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -26,6 +26,7 @@ import {BBox} from '../BBox.js';
 import {MmlMpadded} from '../../../core/MmlTree/MmlNodes/mpadded.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {Property} from '../../../core/Tree/Node.js';
+import {StyleList} from '../CssStyles.js';
 
 /*
  * Needed in order to access BBox properties by variable
@@ -41,6 +42,16 @@ interface IBBox extends BBox {
 
 export class CHTMLmpadded extends CHTMLWrapper {
     public static kind = MmlMpadded.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mpadded': {
+            display: 'inline-block'
+        },
+        'mjx-rbox': {
+            display: 'inline-block',
+            position: 'relative'
+        }
+    };
 
     /*
      * @override

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -97,7 +97,8 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      */
     protected createMo(text: string) {
         const mmlFactory = (this.node as AbstractMmlNode).factory;
-        const node = this.wrap(mmlFactory.create('mo', {stretchy: true}, [(mmlFactory.create('text') as TextNode).setText(text)])) as CHTMLmo;
+        const textNode = (mmlFactory.create('text') as TextNode).setText(text);
+        const node = this.wrap(mmlFactory.create('mo', {stretchy: true}, [textNode])) as CHTMLmo;
         node.parent = this;
         this.childNodes.push(node);
         return node;

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -27,6 +27,7 @@ import {CHTMLmo} from './mo.js';
 import {BBox} from '../BBox.js';
 import {MmlMsqrt} from '../../../core/MmlTree/MmlNodes/msqrt.js';
 import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
+import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
 /*
@@ -35,6 +36,16 @@ import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.
 
 export class CHTMLmsqrt extends CHTMLWrapper {
     public static kind = MmlMsqrt.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-root': {
+            display: 'inline-block'
+        },
+        'mjx-surd': {
+            display: 'inline-block',
+            'vertical-align': 'top'
+        }
+    };
 
     /*
      * @return{number}  The index of the base of the root in childNodes
@@ -70,7 +81,6 @@ export class CHTMLmsqrt extends CHTMLWrapper {
     constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
         super(factory, node, parent);
         const surd = this.createMo('\u221A');
-        this.childNodes.push(surd);
         surd.canStretch('Vertical');
         const {h, d} = this.childNodes[this.base].getBBox();
         const t = this.font.params.rule_thickness;
@@ -87,8 +97,9 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      */
     protected createMo(text: string) {
         const mmlFactory = (this.node as AbstractMmlNode).factory;
-        const node = this.wrap(mmlFactory.create('mo', {}, [(mmlFactory.create('text') as TextNode).setText(text)])) as CHTMLmo;
+        const node = this.wrap(mmlFactory.create('mo', {stretchy: true}, [(mmlFactory.create('text') as TextNode).setText(text)])) as CHTMLmo;
         node.parent = this;
+        this.childNodes.push(node);
         return node;
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -107,6 +107,8 @@ export class CHTMLannotationXML extends CHTMLWrapper {
 export class CHTMLxml extends CHTMLWrapper {
     public static kind = XMLNode.prototype.kind;
 
+    public static autoStyle = false;
+
     /*
      * @override
      */

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -429,9 +429,15 @@ export class TeXFont extends FontData {
         const [h, d, w, options] = data as [number, number, number, CharOptions];
         const css: StyleData = {};
         if (options.css) {
-            if (options.css & CSS.width)   css.width = this.em(w);
-            if (options.css & CSS.padding) css.padding = this.em(h) + ' 0 ' + this.em(d);
-            if (options.css & CSS.content) css.content = '"' + (options.c || this.char(n, true)) + '"';
+            if (options.css & CSS.width) {
+                css.width = this.em(w);
+            }
+            if (options.css & CSS.padding) {
+                css.padding = this.em(h) + ' 0 ' + this.em(d);
+            }
+            if (options.css & CSS.content) {
+                css.content = '"' + (options.c || this.char(n, true)) + '"';
+            }
         }
         if (options.f !== undefined) css['font-family'] = 'MJXZERO, MJXTEX' + (options.f ? '-' + options.f : '');
         styles['.MJX-TEX' + vclass + ' mjx-c[c="' + this.char(n) + '"]::before'] = css;

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -389,13 +389,13 @@ export class TeXFont extends FontData {
             const He = this.addDelimiterVPart(styles, c, 'end', data.stretch[2]);
             const css: StyleData = {};
             if (Hb) {
-                css['border-top-width'] = this.em(Math.max(0, Hb-.03));
+                css['border-top-width'] = this.em(Math.max(0, Hb - .03));
             }
             if (He) {
-                css['border-bottom-width'] = this.em(Math.max(0, He-.03));
+                css['border-bottom-width'] = this.em(Math.max(0, He - .03));
                 css['margin-bottom'] = this.em(-He);
             }
-            styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-ext'] = css
+            styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-ext'] = css;
         } else {
             //  FIXME: still need to add this
         }

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -22,6 +22,7 @@
  */
 
 import {FontData, DelimiterMap, CharMapMap, V, H} from '../FontData.js';
+import {StyleList} from '../CssStyles.js';
 
 
 /*
@@ -68,6 +69,7 @@ export class TeXFont extends FontData {
         0x7B: {dir: V, sizes: STDVSIZES, stretch: [0x23A7, 0x23AA, 0x23A9, 0x23A8], HDW: STDVHDW}, // {
         0x7C: {dir: V, sizes: [1], stretch: [0, 0x2223, 0], HDW: STDVHDW},                 // |
         0x7D: {dir: V, sizes: STDVSIZES, stretch: [0x23AB, 0x23AA, 0x23AD, 0x23AC], HDW: STDVHDW}, // }
+        0x2191: {dir: V, sizes: STDVSIZES, stretch: [0x2191, 0x23D0, 0], HDW: STDVHDW}, // \uparrow
         0x221A: {dir: V, sizes: STDVSIZES, stretch: [0xE001, 0xE000, 0x23B7], HDW: STDVHDW}, // \surd
     };
 
@@ -179,4 +181,8 @@ export class TeXFont extends FontData {
         }
     };
 
+    get styles() {
+        // eventually put styles here
+        return null as StyleList;
+    }
 }

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -21,21 +21,37 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {FontData, DelimiterMap, CharMapMap, V, H} from '../FontData.js';
-import {StyleList} from '../CssStyles.js';
+import {FontData, DelimiterData, CharData, CharOptions, DelimiterMap, CharMapMap, CSS, V, H} from '../FontData.js';
+import {StyleList, StyleData} from '../CssStyles.js';
+import {em} from '../../../util/lengths.js';
+import {StringMap} from '../Wrapper.js';
 
+import {boldItalic} from './tex/bold-italic.js';
+import {bold} from './tex/bold.js';
+import {doubleStruck} from './tex/double-struck.js';
+import {frakturBold} from './tex/fraktur-bold.js';
+import {fraktur} from './tex/fraktur.js';
+import {italic} from './tex/italic.js';
+import {largeop} from './tex/largeop.js';
+import {monospace} from './tex/monospace.js';
+import {normal} from './tex/normal.js';
+import {sansSerifBoldItalic} from './tex/sans-serif-bold-italic.js';
+import {sansSerifBold} from './tex/sans-serif-bold.js';
+import {sansSerifItalic} from './tex/sans-serif-italic.js';
+import {sansSerif} from './tex/sans-serif.js';
+import {scriptBold} from './tex/script-bold.js';
+import {script} from './tex/script.js';
+import {smallop} from './tex/smallop.js';
+import {texCaligraphicBold} from './tex/tex-caligraphic-bold.js';
+import {texCaligraphic} from './tex/tex-caligraphic.js';
+import {texMathit} from './tex/tex-mathit.js';
+import {texOldstyleBold} from './tex/tex-oldstyle-bold.js';
+import {texOldstyle} from './tex/tex-oldstyle.js';
+import {texSize3} from './tex/tex-size3.js';
+import {texSize4} from './tex/tex-size4.js';
+import {texVariant} from './tex/tex-variant.js';
 
-/*
- * NOTE:  This is just a small amount of the needed data, which will be filled out
- *        further later.
- */
-
-/*
- * The standard heights of vertically stretchy delimiters (most are the same), and
- * the standard height, depth, width data for vertically stretchy delimiters
- */
-const STDVSIZES = [1, 1.2, 1.8, 2.4, 3];
-const STDVHDW = [.75, .25, .5];
+import {delimiters} from './tex/delimiters.js';
 
 /***********************************************************************************/
 /*
@@ -50,28 +66,48 @@ export class TeXFont extends FontData {
         ['-largeop', 'normal'],
         ['-size3', 'normal'],
         ['-size4', 'normal'],
-        ['-tex-caligraphic', 'normal'],
-        ['-tex-bold-caligraphic', 'bold', 'caligraphic'],
+        ['-tex-caligraphic', 'italic'],
+        ['-tex-bold-caligraphic', 'bold-italic'],
         ['-tex-oldstyle', 'normal'],
-        ['-tex-mathit', 'italic']
+        ['-tex-bold-oldstyle', 'bold'],
+        ['-tex-mathit', 'italic'],
+        ['-tex-variant', 'normal']
     ]);
+
+    /*
+     * The classes to use for each variant
+     */
+    protected static defaultVariantClasses: StringMap = {
+        'normal': 'mjx-n',
+        'bold': 'mjx-b',
+        'italic': 'mjx-i',
+        'bold-italic': 'mjx-b mjx-i',
+        'double-struck': 'mjx-ds',
+        'fraktur': 'mjx-fr',
+        'bold-fraktur': 'mjx-fr mjx-b',
+        'script': 'mjx-sc',
+        'bold-script': 'mjx-sc mjx-b',
+        'sans-serif': 'mjx-ss',
+        'bold-sans-serif': 'mjx-ss mjx-b',
+        'sans-serif-italic': 'mjx-ss mjx-i',
+        'bold-sans-serif-italic': 'mjx-ss mjx-b mjx-i',
+        'monospace': 'mjx-ty',
+        '-smallop': 'mjx-sop',
+        '-largeop': 'mjx-lop',
+        '-size3': 'mjx-s3',
+        '-size4': 'mjx-s4',
+        '-tex-caligraphic': 'mjx-cal',
+        '-tex-bold-caligraphic': 'mjx-cal mjx-b',
+        '-tex-mathit': 'mjx-mit',
+        '-tex-oldstyle': 'mjx-os',
+        '-tex-bold-oldstyle': 'mjx-os mjx-b',
+        '-tex-variant': 'mjx-v'
+    };
 
     /*
      *  The stretchy delimiter data (incomplete at the moment)
      */
-    protected static defaultDelimiters: DelimiterMap = {
-        0x28: {dir: V, sizes: STDVSIZES, stretch: [0x239B, 0x239C, 0x239D], HDW: STDVHDW}, // (
-        0x29: {dir: V, sizes: STDVSIZES, stretch: [0x239E, 0x239F, 0x23A0], HDW: STDVHDW}, // )
-        0x2F: {dir: V, sizes: STDVSIZES},                                                  // /
-        0x5B: {dir: V, sizes: STDVSIZES, stretch: [0x23A1, 0x23A2, 0x23A3], HDW: STDVHDW}, // [
-        0x5C: {dir: V, sizes: STDVSIZES},                                                  // \
-        0x5D: {dir: V, sizes: STDVSIZES, stretch: [0x23A4, 0x23A5, 0x23A6], HDW: STDVHDW}, // ]
-        0x7B: {dir: V, sizes: STDVSIZES, stretch: [0x23A7, 0x23AA, 0x23A9, 0x23A8], HDW: STDVHDW}, // {
-        0x7C: {dir: V, sizes: [1], stretch: [0, 0x2223, 0], HDW: STDVHDW},                 // |
-        0x7D: {dir: V, sizes: STDVSIZES, stretch: [0x23AB, 0x23AA, 0x23AD, 0x23AC], HDW: STDVHDW}, // }
-        0x2191: {dir: V, sizes: STDVSIZES, stretch: [0x2191, 0x23D0, 0], HDW: STDVHDW}, // \uparrow
-        0x221A: {dir: V, sizes: STDVSIZES, stretch: [0xE001, 0xE000, 0x23B7], HDW: STDVHDW}, // \surd
-    };
+    protected static defaultDelimiters: DelimiterMap = delimiters;
 
     /*
      *  The default variants for the standard stretchy sizes
@@ -82,107 +118,332 @@ export class TeXFont extends FontData {
      *  The character data by variant
      */
     protected static defaultChars: CharMapMap = {
-        'normal': {
-            0x20: [   0,     0, .25],      // SPACE
-            0x21: [.716,     0, .278],     // EXCLAMATION MARK
-            0x22: [.694, -.379, .5],       // QUOTATION MARK
-            0x23: [.694,  .194, .833],     // NUMBER SIGN
-            0x24: [.75,   .056, .5],       // DOLLAR SIGN
-            0x25: [.75,   .056, .833],     // PERCENT SIGN
-            0x26: [.716,  .022, .778],     // AMPERSAND
-            0x27: [.694, -.379, .278],     // APOSTROPHE
-            0x28: [.75,   .25,  .389],     // LEFT PARENTHESIS
-            0x29: [.75,   .25,  .389],     // RIGHT PARENTHESIS
-            0x2A: [.75,  -.32,  .5],       // ASTERISK
-            0x2B: [.583,  .082, .778],     // PLUS SIGN
-            0x2C: [.121,  .194, .278],     // COMMA
-            0x2D: [.252, -.179, .333],     // HYPHEN-MINUS
-            0x2E: [.12,      0, .278],     // FULL STOP
-            0x2F: [.75,   .25,  .5],       // SOLIDUS
-            0x30: [.666,  .022, .5],       // DIGIT ZERO
-            0x31: [.666,     0, .5],       // DIGIT ONE
-            0x32: [.666,     0, .5],       // DIGIT TWO
-            0x33: [.665,  .022, .5],       // DIGIT THREE
-            0x34: [.677,     0, .5],       // DIGIT FOUR
-            0x35: [.666,  .022, .5],       // DIGIT FIVE
-            0x36: [.666,  .022, .5],       // DIGIT SIX
-            0x37: [.676,  .022, .5],       // DIGIT SEVEN
-            0x38: [.666,  .022, .5],       // DIGIT EIGHT
-            0x39: [.666,  .022, .5],       // DIGIT NINE
-            0x3A: [.43,      0, .278],     // COLON
-            0x3B: [.43,   .194, .278],     // SEMICOLON
-            0x3C: [.54,   .04,  .778],     // LESS-THAN SIGN
-            0x3D: [.367, -.133, .778],     // EQUALS SIGN
-            0x3E: [.54,   .04,  .778],     // GREATER-THAN SIGN
-            0x3F: [.705,     0, .472],     // QUESTION MARK
-            0x40: [.705,  .011, .778],     // COMMERCIAL AT
-            0x41: [.716,     0, .75],      // LATIN CAPITAL LETTER A
-            0x42: [.683,     0, .708],     // LATIN CAPITAL LETTER B
-            0x43: [.705,  .021, .722],     // LATIN CAPITAL LETTER C
-            0x44: [.683,     0, .764],     // LATIN CAPITAL LETTER D
-            0x45: [.68,      0, .681],     // LATIN CAPITAL LETTER E
-            0x46: [.68,      0, .653],     // LATIN CAPITAL LETTER F
-            0x47: [.705,  .022, .785],     // LATIN CAPITAL LETTER G
-            0x48: [.683,     0, .750],     // LATIN CAPITAL LETTER H
-            0x49: [.683,     0, .361],     // LATIN CAPITAL LETTER I
-            0x4A: [.683,  .022, .514],     // LATIN CAPITAL LETTER J
-            0x4B: [.683,     0, .778],     // LATIN CAPITAL LETTER K
-            0x4C: [.683,     0, .625],     // LATIN CAPITAL LETTER L
-            0x4D: [.683,     0, .917],     // LATIN CAPITAL LETTER M
-            0x4E: [.683,     0, .75],      // LATIN CAPITAL LETTER N
-            0x4F: [.705,  .022, .778],     // LATIN CAPITAL LETTER O
-            0x50: [.683,     0, .681],     // LATIN CAPITAL LETTER P
-            0x51: [.705,  .193, .778],     // LATIN CAPITAL LETTER Q
-            0x52: [.683,  .022, .736],     // LATIN CAPITAL LETTER R
-            0x53: [.705,  .022, .556],     // LATIN CAPITAL LETTER S
-            0x54: [.677,     0, .722],     // LATIN CAPITAL LETTER T
-            0x55: [.683,  .022, .75],      // LATIN CAPITAL LETTER U
-            0x56: [.683,  .022, .75],      // LATIN CAPITAL LETTER V
-            0x57: [.683,  .022, .1028],    // LATIN CAPITAL LETTER W
-            0x58: [.683,     0, .75],      // LATIN CAPITAL LETTER X
-            0x59: [.683,     0, .75],      // LATIN CAPITAL LETTER Y
-            0x5A: [.683,     0, .611],     // LATIN CAPITAL LETTER Z
-            0x5B: [.75,   .25,  .278],     // LEFT SQUARE BRACKET
-            0x5C: [.75,   .25,  .5],       // REVERSE SOLIDUS
-            0x5D: [.75,   .25,  .278],     // RIGHT SQUARE BRACKET
-            0x5E: [.694, -.531, .5],       // CIRCUMFLEX ACCENT
-            0x5F: [-.025, .062, .5],       // LOW LINE
-            0x60: [.699, -.505, .5],       // GRAVE ACCENT
-            0x61: [.448,  .011, .5],       // LATIN SMALL LETTER A
-            0x62: [.694,  .011, .556],     // LATIN SMALL LETTER B
-            0x63: [.448,  .011, .444],     // LATIN SMALL LETTER C
-            0x64: [.694,  .011, .556],     // LATIN SMALL LETTER D
-            0x65: [.448,  .011, .444],     // LATIN SMALL LETTER E
-            0x66: [.705,     0, .306],     // LATIN SMALL LETTER F
-            0x67: [.453,  .206, .5],       // LATIN SMALL LETTER G
-            0x68: [.694,     0, .556],     // LATIN SMALL LETTER H
-            0x69: [.669,     0, .278],     // LATIN SMALL LETTER I
-            0x6A: [.669,  .205, .306],     // LATIN SMALL LETTER J
-            0x6B: [.694,     0, .528],     // LATIN SMALL LETTER K
-            0x6C: [.694,     0, .278],     // LATIN SMALL LETTER L
-            0x6D: [.442,     0, .833],     // LATIN SMALL LETTER M
-            0x6E: [.442,     0, .556],     // LATIN SMALL LETTER N
-            0x6F: [.448,  .010, .5],       // LATIN SMALL LETTER O
-            0x70: [.442,  .194, .556],     // LATIN SMALL LETTER P
-            0x71: [.442,  .194, .528],     // LATIN SMALL LETTER Q
-            0x72: [.442,     0, .392],     // LATIN SMALL LETTER R
-            0x73: [.448,  .011, .394],     // LATIN SMALL LETTER S
-            0x74: [.615,  .010, .389],     // LATIN SMALL LETTER T
-            0x75: [.442,  .011, .556],     // LATIN SMALL LETTER U
-            0x76: [.431,  .011, .528],     // LATIN SMALL LETTER V
-            0x77: [.431,  .011, .722],     // LATIN SMALL LETTER W
-            0x78: [.431,     0, .528],     // LATIN SMALL LETTER X
-            0x79: [.431,  .204, .528],     // LATIN SMALL LETTER Y
-            0x7A: [.431,     0, .444],     // LATIN SMALL LETTER Z
-            0x7B: [.75,   .25,  .5],       // LEFT CURLY BRACKET
-            0x7C: [.75,   .249, .278],     // VERTICAL LINE
-            0x7D: [.75,   .25,  .5],       // RIGHT CURLY BRACKET
-            0x221A: [.8,  .2,   .833],     // SQUARE ROOT
-        }
+        'normal': normal,
+        'bold': bold,
+        'italic': italic,
+        'bold-italic': boldItalic,
+        'double-struck': doubleStruck,
+        'fraktur': fraktur,
+        'bold-fraktur': frakturBold,
+        'script': script,
+        'bold-script': scriptBold,
+        'sans-serif': sansSerif,
+        'bold-sans-serif': sansSerifBold,
+        'sans-serif-italic': sansSerifItalic,
+        'bold-sans-serif-italic': sansSerifBoldItalic,
+        'monospace': monospace,
+        '-smallop': smallop,
+        '-largeop': largeop,
+        '-size3': texSize3,
+        '-size4': texSize4,
+        '-tex-caligraphic': texCaligraphic,
+        '-tex-bold-caligraphic': texCaligraphicBold,
+        '-tex-mathit': texMathit,
+        '-tex-oldstyle': texOldstyle,
+        '-tex-bold-oldstyle': texOldstyleBold,
+        '-tex-variant': texVariant
     };
 
+    /*
+     * The CSS styles needed for this font.
+     */
+    protected static defaultStyles = {
+        '.MJX-TEX .mjx-n mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-i mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-b.mjx-i mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-BI, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-cal mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-C, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-cal.mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-BI, MJXTEX-B, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-ds mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-A, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1'
+        },
+
+        '.MJX-TEX .mjx-fr mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-FR, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-fr.mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-FR-B, MJXTEX-FR, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-sc mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SC, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-sc.mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SC-B, MJXTEX-SC, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-ss mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SS, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-ss.mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-ss.mjx-i mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SS-I, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-ss.mjx-b.mjx-i mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS-I, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-ty mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-T, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-var mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-A, MJXTEX, MJXTEX-I, MJXTEX-S1'
+        },
+
+        '.MJX-TEX .mjx-os mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-C, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+        '.MJX-TEX .mjx-os.mjx-b mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-mit mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-MI, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-lop mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-S2, MJXTEX-S1, MJXTEX, MJXTEX-I, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-sop mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-S1, MJXTEX, MJXTEX-I, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-s3 mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-S3, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX .mjx-s4 mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX-S4, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+        },
+
+        '.MJX-TEX': {
+            'font-family': 'MJXZERO'
+        },
+
+        '.MJX-TEX mjx-stretchy-v mjx-c, .MJX-TEX mjx-stretchy-h mjx-c': {
+            'font-family': 'MJXZERO, MJXTEX, MJXTEX-S4 ! important'
+        },
+
+        '@font-face /* 0 */': {
+            'font-family': 'MJXZERO',
+            src: 'url("mathjax2/css/otf/MathJax_Zero.otf") format("opentype")'
+        },
+
+        '@font-face /* 1 */': {
+            'font-family': 'MJXTEX',
+            src: 'url("mathjax2/css/woff/MathJax_Main-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 2 */': {
+            'font-family': 'MJXTEX-B',
+            src: 'url("mathjax2/css/woff/MathJax_Main-Bold.woff") format("woff")'
+        },
+
+        '@font-face /* 3 */': {
+            'font-family': 'MJXTEX-MI',
+            src: 'url("mathjax2/css/woff/MathJax_Main-Italic.woff") format("woff")'
+        },
+
+        '@font-face /* 4 */': {
+            'font-family': 'MJXTEX-I',
+            src: 'url("mathjax2/css/woff/MathJax_Math-Italic.woff") format("woff")'
+        },
+
+        '@font-face /* 5 */': {
+            'font-family': 'MJXTEX-BI',
+            src: 'url("mathjax2/css/woff/MathJax_Math-BoldItalic.woff") format("woff")'
+        },
+
+        '@font-face /* 6 */': {
+            'font-family': 'MJXTEX-S1',
+            src: 'url("mathjax2/css/woff/MathJax_Size1-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 7 */': {
+            'font-family': 'MJXTEX-S2',
+            src: 'url("mathjax2/css/woff/MathJax_Size2-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 8 */': {
+            'font-family': 'MJXTEX-S3',
+            src: 'url("mathjax2/css/woff/MathJax_Size3-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 9 */': {
+            'font-family': 'MJXTEX-S4',
+            src: 'url("mathjax2/css/woff/MathJax_Size4-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 10 */': {
+            'font-family': 'MJXTEX-A',
+            src: 'url("mathjax2/css/woff/MathJax_AMS-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 11 */': {
+            'font-family': 'MJXTEX-C',
+            src: 'url("mathjax2/css/woff/MathJax_Caligraphic-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 12 */': {
+            'font-family': 'MJXTEX-C-B',
+            src: 'url("mathjax2/css/woff/MathJax_Caligraphic-Bold.woff") format("woff")'
+        },
+
+        '@font-face /* 13 */': {
+            'font-family': 'MJXTEX-FR',
+            src: 'url("mathjax2/css/woff/MathJax_Fraktur-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 14 */': {
+            'font-family': 'MJXTEX-FR-B',
+            src: 'url("mathjax2/css/woff/MathJax_Fraktur-Bold.woff") format("woff")'
+        },
+
+        '@font-face /* 15 */': {
+            'font-family': 'MJXTEX-SS',
+            src: 'url("mathjax2/css/woff/MathJax_SansSerif-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 16 */': {
+            'font-family': 'MJXTEX-SS-B',
+            src: 'url("mathjax2/css/woff/MathJax_SansSerif-Bold.woff") format("woff")'
+        },
+
+        '@font-face /* 17 */': {
+            'font-family': 'MJXTEX-SS-I',
+            src: 'url("mathjax2/css/woff/MathJax_SansSerif-Italic.woff") format("woff")'
+        },
+
+        '@font-face /* 18 */': {
+            'font-family': 'MJXTEX-SC',
+            src: 'url("mathjax2/css/woff/MathJax_Script-Regular.woff") format("woff")'
+        },
+
+        '@font-face /* 19 */': {
+            'font-family': 'MJXTEX-T',
+            src: 'url("mathjax2/css/woff/MathJax_Typewriter-Regular.woff") format("woff")'
+        },
+    };
+
+    /*
+     * @return{StyleList}  The (computed) styles for this font
+     *                     (could be used to limit styles to those actually used, for example)
+     */
     get styles() {
-        // eventually put styles here
-        return null as StyleList;
+        //
+        //  Include the default styles
+        //
+        let styles: StyleList = {...(this.constructor as typeof TeXFont).defaultStyles};
+        //
+        //  Create styles needed for the delimiters
+        //
+        for (const n of Object.keys(this.delimiters)) {
+            const N = parseInt(n);
+            this.addDelimiterStyles(styles, N, this.delimiters[N]);
+        }
+        //
+        //  Create styles needed for the characters in each variant
+        //
+        for (const name of Object.keys(this.variant)) {
+            const variant = this.variant[name];
+            const vclass = (name === 'normal' ? '' : ' .' + variant.classes.replace(/ /g, '.'));
+            for (const n of Object.keys(variant.chars)) {
+                const N = parseInt(n);
+                if (variant.chars[N].length === 4) {
+                    this.addCharStyles(styles, vclass, N, variant.chars[N]);
+                }
+            }
+        }
+        return styles;
     }
+
+    /*
+     * @param{StyleList} styles    The style object to add styles to
+     * @param{number} n            The unicode character number of the delimiter
+     * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
+     */
+    protected addDelimiterStyles(styles: StyleList, n: number, data: DelimiterData) {
+        if (!data.stretch) return;
+        if (data.dir === 'V') {
+            const c = this.char(n);
+            const Hb = this.addDelimiterVPart(styles, c, 'beg', data.stretch[0]);
+            this.addDelimiterVPart(styles, c, 'ext', data.stretch[1]);
+            const He = this.addDelimiterVPart(styles, c, 'end', data.stretch[2]);
+            const css: StyleData = {};
+            if (Hb) {
+                css['border-top-width'] = this.em(Math.max(0, Hb-.03));
+            }
+            if (He) {
+                css['border-bottom-width'] = this.em(Math.max(0, He-.03));
+                css['margin-bottom'] = this.em(-He);
+            }
+            styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-ext'] = css
+        } else {
+            //  FIXME: still need to add this
+        }
+    }
+
+    /*
+     * @param{StyleList} styles  The style object to add styles to
+     * @param{string} c          The vertical character whose part is being added
+     * @param{string} part       The name of the part (beg, ext, end, mid) that is being added
+     * @param{number} n          The unicode character to use for the part
+     * @return{number}           The total height of the character
+     */
+    protected addDelimiterVPart(styles: StyleList, c: string, part: string, n: number) {
+        if (!n) return 0;
+        const data = this.getChar('normal', n) || this.getChar('-size4', n);
+        const css: StyleData = {content: '"' + this.char(n, true) + '"'};
+        if (part !== 'ext') {
+            css.padding = this.em(data[0]) + ' 0 ' + this.em(data[1]);
+        }
+        styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-' + part + ' mjx-c::before'] = css;
+        return data[0] + data[1];
+    }
+
+    /*
+     * @param{StyleList} styles  The style object to add styles to
+     * @param{string} vclass     The variant class string (e.g., .mjx-b) where this character is being defined
+     * @param{number} n          The unicode character being defined
+     * @param{CharData} data     The bounding box data and options for the character
+     */
+    protected addCharStyles(styles: StyleList, vclass: string, n: number, data: CharData) {
+        const [h, d, w, options] = data as [number, number, number, CharOptions];
+        const css: StyleData = {};
+        if (options.css) {
+            if (options.css & CSS.width)   css.width = this.em(w);
+            if (options.css & CSS.padding) css.padding = this.em(h) + ' 0 ' + this.em(d);
+            if (options.css & CSS.content) css.content = '"' + (options.c || this.char(n, true)) + '"';
+        }
+        if (options.f !== undefined) css['font-family'] = 'MJXZERO, MJXTEX' + (options.f ? '-' + options.f : '');
+        styles['.MJX-TEX' + vclass + ' mjx-c[c="' + this.char(n) + '"]::before'] = css;
+    }
+
+    /*
+     * @param{number} n  The number of ems
+     * @return{string}   The string representing the number with units of "em"
+     */
+    protected em(n: number) {
+        return em(n);
+    }
+
 }
+


### PR DESCRIPTION
This pull request adds support for generating the CSS styles needed for CHTML output.

The various Wrapper classes each can add their own CSS, and the main Wrapper class includes some generic CSS used by CHTML.  The TeX font object now creates the CSS for the characters and delimiters automatically (in `tex.ts`), and some font data was moved from `Wrapper.ts` and `FontData.ts` to `tex.ts`.

I took Volker's suggestion of moving the skew and italic-correction data from the `CharData` array to the options object, and have made a `CharOptions` for that, now that the data needed for the CSS creation has been worked out.  The `DelimiterData` has been updated to include some additional information that was needed for the CSS as well.  (There is still a bit more to come, as there need to be some additional offset values for the multi-character delimiters, but that is for the future).

The character and delimiter data itself has been moved from `tex.js` into separate files for the various math variants, and the data files have been generated (programmatically from the v2 CommonHTML data files).  Eventually, the v2 fonts will be replaced by new ones for v3 (based on LatinModern, I expect), and the data files will change, but for now, they use the old fonts.

The data files are in a separate PR, in order to make this PR easier to work with.  The data files are just data files, so should not need a review.