### PR TITLE
Fixes the superfluous mrow problem for \left \right fences.

### DIFF
--- a/mathjax2/legacy/jax/input/TeX/jax.js
+++ b/mathjax2/legacy/jax/input/TeX/jax.js
@@ -2285,8 +2285,9 @@
     fenced: function (open,mml,close) {
       var mrow = MML.mrow().With({open:open, close:close, texClass:MML.TEXCLASS.INNER});
       mrow.Append(
-        MML.mo(open).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.OPEN}),
-        mml,
+        MML.mo(open).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.OPEN}));
+      if (mml.type === "mrow") {mrow.Append.apply(mrow,mml.data);} else {mrow.Append(mml);};
+      mrow.Append(
         MML.mo(close).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.CLOSE})
       );
       return mrow;


### PR DESCRIPTION
This reverts to the original way of appending elements to the mrow that contains the required case split.    
The case split has been removed between the following two commits:

      git diff 6b217c70629b1adc1f5fbb23e9b23dd4a56dcf37 3394af4c6ed4c7adb45f315acdcadf886521cd69 mathjax2/legacy/jax/input/TeX/jax.js