### PR TITLE
Update TeX input jax to latest v2 develop version

### DIFF
--- a/mathjax2/legacy/jax/input/TeX/jax.js
+++ b/mathjax2/legacy/jax/input/TeX/jax.js
@@ -2285,8 +2285,14 @@
     fenced: function (open,mml,close) {
       var mrow = MML.mrow().With({open:open, close:close, texClass:MML.TEXCLASS.INNER});
       mrow.Append(
-        MML.mo(open).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.OPEN}),
-        mml,
+        MML.mo(open).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.OPEN})
+      );
+      if (mml.type === "mrow" && mml.inferred) {
+        mrow.Append.apply(mrow, mml.data);
+      } else {
+        mrow.Append(mml);
+      }
+      mrow.Append(
         MML.mo(close).With({fence:true, stretchy:true, symmetric:true, texClass:MML.TEXCLASS.CLOSE})
       );
       return mrow;


### PR DESCRIPTION
This moves the fix from mathjax/MathJax#1829 to the mathjax2 directory.