### PR TITLE
Convert stretchy directions to an enum

### DIFF
--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -87,8 +87,12 @@ export type VariantMap = {
 /*
  * Stretchy delimiter data
  */
+export const enum DIRECTION {None, Vertical, Horizontal}
+export const V = DIRECTION.Vertical;
+export const H = DIRECTION.Horizontal;
+
 export type DelimiterData = {
-    dir: string;                 // 'V' or 'H' for vertcial or horizontal
+    dir: DIRECTION;              // vertical or horizontal direction
     sizes?: number[];            // Array of fixed sizes for this character
     variants?: number[];         // The variants in which the different sizes can be found (if not the default)
     schar?: number[];            // The character number to use for each size (if different from the default)
@@ -140,12 +144,6 @@ export type FontParameters = {
 
     min_rule_thickness: number
 };
-
-/*
- * The stretch direction
- */
-export const V = 'V';
-export const H = 'H';
 
 /****************************************************************************/
 /*

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -33,7 +33,7 @@ import {CHTML} from '../chtml.js';
 import {CHTMLWrapperFactory} from './WrapperFactory.js';
 import {CHTMLmo} from './Wrappers/mo.js';
 import {BBox, BBoxData} from './BBox.js';
-import {FontData} from './FontData.js';
+import {FontData, DIRECTION} from './FontData.js';
 import {StyleList} from './CssStyles.js';
 
 /*****************************************************************/
@@ -234,7 +234,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     /*
      * Direction this node can be stretched (null means not yet determined)
      */
-    public stretch: string = null;
+    public stretch: DIRECTION = DIRECTION.None;
 
     /*
      * Easy access to the font parameters
@@ -604,20 +604,20 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     }
 
     /*
-     * @param{string} direction  The direction to stretch this node
-     * @return{boolean}  Whether the node can stretch in that direction
+     * @param{DIRECTION} direction  The direction to stretch this node
+     * @return{boolean}             Whether the node can stretch in that direction
      */
-    public canStretch(direction: string): boolean {
-        this.stretch = '';
+    public canStretch(direction: DIRECTION): boolean {
+        this.stretch = DIRECTION.None;
         if (this.node.isEmbellished) {
             let core = this.core();
             if (core && core.node !== this.node) {
                 if (core.canStretch(direction)) {
-                    this.stretch = direction.substr(0,1);
+                    this.stretch = direction;
                 }
             }
         }
-        return this.stretch !== '';
+        return this.stretch !== DIRECTION.None;
     }
 
     /*******************************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -26,6 +26,7 @@ import {MmlMfrac} from '../../../core/MmlTree/MmlNodes/mfrac.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
 import {StyleList} from '../CssStyles.js';
+import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
 /*
@@ -135,7 +136,7 @@ export class CHTMLmfrac extends CHTMLWrapper {
     /*
      * @override
      */
-    public canStretch(direction: string) {
+    public canStretch(direction: DIRECTION) {
         return false;
     }
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -27,6 +27,15 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
 import {DelimiterData} from '../FontData.js';
 import {StyleList} from '../CssStyles.js';
+import {DIRECTION} from '../FontData.js';
+
+/*
+ * Convert direction to letter
+ */
+const DirectionVH: {[n: number]: string} = {
+    [DIRECTION.Vertical]: 'v',
+    [DIRECTION.Horizontal]: 'h'
+};
 
 /*****************************************************************/
 /*
@@ -158,7 +167,7 @@ export class CHTMLmo extends CHTMLWrapper {
         //
         const styles: StringMap = {};
         const {h, d, w} = this.bbox;
-        if (this.stretch === 'V') {
+        if (this.stretch === DIRECTION.Vertical) {
             //
             //  Vertical needs an extra (empty) element to get vertical position right
             //  in some browsers (e.g., Safari)
@@ -172,8 +181,8 @@ export class CHTMLmo extends CHTMLWrapper {
         //
         //  Make the main element and add it to the parent
         //
-        const html = this.html('mjx-stretchy-' + this.stretch.toLowerCase(),
-                               {c: this.char(c), style: styles}, content);
+        const dir = DirectionVH[this.stretch];
+        const html = this.html('mjx-stretchy-' + dir, {c: this.char(c), style: styles}, content);
         chtml.appendChild(html);
     }
 
@@ -213,14 +222,14 @@ export class CHTMLmo extends CHTMLWrapper {
     /*
      * @override
      */
-    public canStretch(direction: string) {
+    public canStretch(direction: DIRECTION) {
         const attributes = this.node.attributes;
         if (!attributes.get('stretchy')) return false;
         const c = this.getText();
         if (c.length !== 1) return false;
-        const C = this.font.getDelimiter(c.charCodeAt(0));
-        this.stretch = (C && C.dir === direction.substr(0, 1) ? C.dir : '');
-        return this.stretch !== '';
+        const delim = this.font.getDelimiter(c.charCodeAt(0));
+        this.stretch = (delim && delim.dir === direction ? delim.dir : DIRECTION.None);
+        return this.stretch !== DIRECTION.None;
     }
 
     /*
@@ -298,7 +307,7 @@ export class CHTMLmo extends CHTMLWrapper {
      */
     protected getStretchBBox(WHD: number[], D: number, C: DelimiterData) {
         let [h, d, w] = C.HDW;
-        if (this.stretch === 'V') {
+        if (this.stretch === DIRECTION.Vertical) {
             [h, d] = this.getBaseline(WHD, D, C);
         } else {
             w = D;

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -26,6 +26,7 @@ import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {MmlMrow, MmlInferredMrow} from '../../../core/MmlTree/MmlNodes/mrow.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
+import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
 /*
@@ -80,7 +81,7 @@ export class CHTMLmrow extends CHTMLWrapper {
         //  Locate and count the stretchy children
         //
         for (const child of this.childNodes) {
-            if (child.canStretch('Vertical')) {
+            if (child.canStretch(DIRECTION.Vertical)) {
                 stretchy.push(child);
             }
         }

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -28,6 +28,7 @@ import {BBox} from '../BBox.js';
 import {MmlMsqrt} from '../../../core/MmlTree/MmlNodes/msqrt.js';
 import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../CssStyles.js';
+import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
 /*
@@ -81,7 +82,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
     constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
         super(factory, node, parent);
         const surd = this.createMo('\u221A');
-        surd.canStretch('Vertical');
+        surd.canStretch(DIRECTION.Vertical);
         const {h, d} = this.childNodes[this.base].getBBox();
         const t = this.font.params.rule_thickness;
         const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -25,6 +25,7 @@ import {FontData, DelimiterData, CharData, CharOptions, DelimiterMap, CharMapMap
 import {StyleList, StyleData} from '../CssStyles.js';
 import {em} from '../../../util/lengths.js';
 import {StringMap} from '../Wrapper.js';
+import {DIRECTION} from '../FontData.js';
 
 import {boldItalic} from './tex/bold-italic.js';
 import {bold} from './tex/bold.js';
@@ -155,7 +156,7 @@ export class TeXFont extends FontData {
             'font-family': 'MJXZERO, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-b.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-BI, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
@@ -165,38 +166,38 @@ export class TeXFont extends FontData {
             'font-family': 'MJXZERO, MJXTEX-C, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-cal.mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-BI, MJXTEX-B, MJXTEX, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
         '.MJX-TEX .mjx-ds mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-A, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1'
+            'font-family': 'MJXZERO, MJXTEX-A, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1'
         },
 
         '.MJX-TEX .mjx-fr mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-FR, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-fr.mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-FR-B, MJXTEX-FR, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-FR-B, MJXTEX-FR, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
         '.MJX-TEX .mjx-sc mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SC, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-sc.mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-SC-B, MJXTEX-SC, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-SC-B, MJXTEX-SC, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
         '.MJX-TEX .mjx-ss mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-ss.mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS, MJXTEX-B, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-ss.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS-I, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-ss.mjx-b.mjx-i mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS-I, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS-I, MJXTEX-BI, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
         '.MJX-TEX .mjx-ty mjx-c': {
@@ -211,7 +212,7 @@ export class TeXFont extends FontData {
             'font-family': 'MJXZERO, MJXTEX-C, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
         '.MJX-TEX .mjx-os.mjx-b mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
+            'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
         '.MJX-TEX .mjx-mit mjx-c': {
@@ -382,7 +383,7 @@ export class TeXFont extends FontData {
      */
     protected addDelimiterStyles(styles: StyleList, n: number, data: DelimiterData) {
         if (!data.stretch) return;
-        if (data.dir === 'V') {
+        if (data.dir === DIRECTION.Vertical) {
             const c = this.char(n);
             const Hb = this.addDelimiterVPart(styles, c, 'beg', data.stretch[0]);
             this.addDelimiterVPart(styles, c, 'ext', data.stretch[1]);


### PR DESCRIPTION
This PR converts the stretchy directions to an `enum` (as per Volker's earlier request), and adds the missing `bold-italic` css to some bold variants (needed for lower-case greek to fallback to bold-italic greek in those cases).  Sorry for combining the two unrelated things, I missed it when I was committing, and it was too late afterwords.