### PR TITLE
Add drawBBox() method, and fix a number of BBox problems.

### DIFF
--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -97,6 +97,16 @@ export class BBox {
     }
 
     /*
+     * Set up a bbox for append() and combine() operations
+     * @return{BBOX}  the boox itself (for chaining calls)
+     */
+    public empty() {
+        this.w = 0;
+        this.h = this.d = -BIGDIMEN;
+        return this;
+    }
+
+    /*
      * Convert any unspecified values into zeros
      */
     public clean () {
@@ -123,15 +133,12 @@ export class BBox {
         cbox.x = x;
         cbox.x = y;
         let rscale = cbox.rscale;
-        if (x + rscale * (cbox.w + cbox.L + cbox.R) > this.w) {
-            this.w  = x + rscale * (cbox.w + cbox.L + cbox.R);
-        }
-        if (y + rscale * cbox.h > this.h) {
-            this.h = y + rscale * cbox.h;
-        }
-        if (rscale * cbox.d - y > this.d) {
-            this.d = rscale * cbox.d - y;
-        }
+        let w = x + rscale * (cbox.w + cbox.L + cbox.R);
+        let h = y + rscale * cbox.h;
+        let d = rscale * cbox.d - y;
+        if (w > this.w) this.w = w;
+        if (h > this.h) this.h = h;
+        if (d > this.d) this.d = d;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -41,24 +41,24 @@ export class CHTMLmfrac extends CHTMLWrapper {
             display: 'inline-block',
             height: '1em',
             width: 0,
-            'vertical-align': '-.2em'
+            'vertical-align': '-.25em'
         },
         'mjx-hstrut': {
             display: 'inline-block',
-            height: '.8em',
+            height: '.75em',
             width: 0
         },
         'mjx-dstrut': {
             display: 'inline-block',
-            height: '.2em',
+            height: '.25em',
             width: 0,
-            'vertical-align': '-.2em'
+            'vertical-align': '-.25em'
         },
 
         'mjx-frac': {
             display: 'inline-block',
             'vertical-align': '0.145em',
-            padding: '0 3px'
+            padding: '0 .1em'
         },
         'mjx-dtable': {
             display: 'inline-table',
@@ -87,9 +87,9 @@ export class CHTMLmfrac extends CHTMLWrapper {
             display: 'block',
             'box-sizing': 'border-box',
             'min-height': '1px',
-            height: '.07em',
-            'border-top': '.07em solid',
-            margin: '.07em -3px',
+            height: '.06em',
+            'border-top': '.06em solid',
+            margin: '.06em -.1em',
             overflow: 'hidden'
         }
     };
@@ -120,15 +120,15 @@ export class CHTMLmfrac extends CHTMLWrapper {
      * @override
      */
     public computeBBox() {
-        const bbox = BBox.empty();
+        const bbox = this.bbox.empty();
         const nbox = this.childNodes[0].getBBox();
         const dbox = this.childNodes[1].getBBox();
         const pad = (this.node.getProperty('withDelims') as boolean ? this.font.params.nulldelimiterspace : 0);
         const a = this.font.params.axis_height;
         const t = this.font.params.rule_thickness;
-        bbox.combine(dbox, pad, a + 1.5 * t + nbox.d);
-        bbox.combine(nbox, pad, a - 1.5 * t - dbox.h);
-        bbox.w += pad;
+        bbox.combine(nbox, pad, a + 1.5 * t + Math.max(nbox.d, .25));
+        bbox.combine(dbox, pad, a - 1.5 * t - Math.max(dbox.h, .75));
+        bbox.w += pad + .2;
         bbox.clean();
         return bbox;
     }

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -236,8 +236,9 @@ export class CHTMLmo extends CHTMLWrapper {
      * Determint variant for vertically/horizontally stretched character
      *
      * @param{number[]} WH  size to stretch to, either [W] or [H, D]
+     * @param{boolean} exact  True if not allowed to use delimiter factor and shortfall
      */
-    public getStretchedVariant(WH: number[]) {
+    public getStretchedVariant(WH: number[], exact: boolean = false) {
         if (this.stretch) {
             let D = this.getWH(WH);
             const min = this.getSize('minsize', 0);
@@ -247,8 +248,8 @@ export class CHTMLmo extends CHTMLWrapper {
             //  then get the minimum size via TeX rules
             //
             D = Math.max(min, Math.min(max, D));
-            const m = (min ? D : Math.max(D * this.font.params.delimiterfactor / 1000,
-                                          D - this.font.params.delimitershortfall));
+            const m = (min || exact ? D : Math.max(D * this.font.params.delimiterfactor / 1000,
+                                                   D - this.font.params.delimitershortfall));
             //
             //  Look through the delimiter sizes for one that matches
             //

--- a/mathjax3-ts/output/chtml/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mroot.ts
@@ -55,10 +55,10 @@ export class CHTMLmroot extends CHTMLmsqrt {
      */
     protected addRoot(ROOT: HTMLElement, root: CHTMLWrapper, sbox: BBox) {
         root.toCHTML(ROOT);
-        const [x, h, dx, scale] = this.getRootDimens(sbox);
+        const [x, h, dx] = this.getRootDimens(sbox);
         const bbox = root.getBBox();
-        ROOT.style.verticalAlign = this.em(h / scale);
-        ROOT.style.width = this.em(x / scale);
+        ROOT.style.verticalAlign = this.em(h);
+        ROOT.style.width = this.em(x);
         if (dx) (ROOT.firstChild as HTMLElement).style.paddingLeft = this.em(dx);
     }
 
@@ -76,24 +76,26 @@ export class CHTMLmroot extends CHTMLmsqrt {
      */
     protected getRootDimens(sbox: BBox) {
         const surd = this.childNodes[this.surd] as CHTMLmo;
-        const offset = (surd.size < -1 ? .5 : .6) * sbox.w;
         const bbox = this.childNodes[this.root].getBBox();
+        const offset = (surd.size < 0 ? .5 : .6) * sbox.w;
         const {w, rscale} = bbox;
         const W = Math.max(w, offset / rscale);
         const dx = Math.max(0, W - w);
-        const h = this.rootHeight(bbox, sbox, offset);
+        const h = this.rootHeight(bbox, sbox, surd.size);
         const x = W * rscale - offset;
-        return [x, h, dx, rscale];
+        return [x, h, dx];
     }
 
     /*
-     * @param{BBox} bbox      The bbox of the root
+     * @param{BBox} rbox      The bbox of the root
      * @param{BBox} sbox      The bbox of the surd
-     * @param{number} offset  The computed offset for the root within the surd
+     * @param{number} size    The size of the surd
      * @return{number}        The height of the root within the surd
      */
-    protected rootHeight(bbox: BBox, sbox: BBox, offset: number) {
-        return .45 * (sbox.h + sbox.d - .9) + offset + Math.max(0, bbox.d - .075);
+    protected rootHeight(rbox: BBox, sbox: BBox, size: number) {
+        const H = sbox.h + sbox.d;
+        const b = (size < 0 ? 2 + .3 * (H - 4) : .55 * H) - sbox.d;
+        return b + Math.max(0, rbox.d * rbox.rscale);
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -49,7 +49,7 @@ export class CHTMLmspace extends CHTMLWrapper {
         }
         h = Math.max(0, h + d);
         if (h) {
-            chtml.style.height = this.em(Math.max(0, h + d));
+            chtml.style.height = this.em(Math.max(0, h));
         }
         if (d) {
             chtml.style.verticalAlign = this.em(-d);

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -26,7 +26,7 @@ import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {CHTMLmo} from './mo.js';
 import {BBox} from '../BBox.js';
 import {MmlMsqrt} from '../../../core/MmlTree/MmlNodes/msqrt.js';
-import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
+import {MmlNode, AbstractMmlNode, TextNode, AttributeList} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../CssStyles.js';
 import {DIRECTION} from '../FontData.js';
 
@@ -40,11 +40,19 @@ export class CHTMLmsqrt extends CHTMLWrapper {
 
     public static styles: StyleList = {
         'mjx-root': {
-            display: 'inline-block'
+            display: 'inline-block',
+            'white-space': 'nowrap'
         },
         'mjx-surd': {
             display: 'inline-block',
             'vertical-align': 'top'
+        },
+        'mjx-sqrt': {
+            display: 'inline-block',
+            'padding-top': '.07em'
+        },
+        'mjx-sqrt > mjx-box': {
+            'border-top': '.07em solid'
         }
     };
 
@@ -87,11 +95,12 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         const t = this.font.params.rule_thickness;
         const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
         this.surdH = h + d + 2 * t + p / 4;
-        surd.getStretchedVariant([this.surdH, 0]);
+        surd.getStretchedVariant([this.surdH - d, d], true);
     }
 
     /*
-     * Create an mo wrapper with the given text;
+     * Create an mo wrapper with the given text,
+     *   link it in, and give it the right defaults.
      *
      * @param{string} text  The text for the wrapped element
      * @return{CHTMLWrapper}  The wrapped MmlMo node
@@ -99,7 +108,15 @@ export class CHTMLmsqrt extends CHTMLWrapper {
     protected createMo(text: string) {
         const mmlFactory = (this.node as AbstractMmlNode).factory;
         const textNode = (mmlFactory.create('text') as TextNode).setText(text);
-        const node = this.wrap(mmlFactory.create('mo', {stretchy: true}, [textNode])) as CHTMLmo;
+        const mml = mmlFactory.create('mo', {stretchy: true}, [textNode]);
+        const attributes = this.node.attributes;
+        const display = attributes.get('display') as boolean;
+        const scriptlevel = attributes.get('scriptlevel') as number;
+        const defaults: AttributeList = {
+            mathsize: ['math', attributes.get('mathsize')]
+        };
+        mml.setInheritedAttributes(defaults, display, scriptlevel, false);
+        const node = this.wrap(mml) as CHTMLmo;
         node.parent = this;
         this.childNodes.push(node);
         return node;
@@ -117,9 +134,6 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         const sbox = surd.getBBox();
         const bbox = base.getBBox();
         const [p, q] = this.getPQ(sbox);
-        const [x] = this.getRootDimens(sbox);
-        const t = this.font.params.rule_thickness;
-        const T = this.font.params.surd_height;
         //
         //  Create the HTML structure for the root
         //
@@ -129,14 +143,9 @@ export class CHTMLmsqrt extends CHTMLWrapper {
             ROOT = CHTML.appendChild(this.html('mjx-root'));
             root = this.childNodes[this.root];
         }
-        const SQRT = CHTML.appendChild(this.html('mjx-box', {
-            style: {paddingTop: this.px(2 * t - T, 1)}
-        }, [
+        const SQRT = CHTML.appendChild(this.html('mjx-sqrt', {}, [
             SURD = this.html('mjx-surd'),
-            BASE = this.html('mjx-box', {style: {
-                paddingTop: this.px(q, 1),
-                borderTop: this.px(T * bbox.scale, 1) + ' solid'
-            }})
+            BASE = this.html('mjx-box', {style: {paddingTop: this.em(q)}})
         ]));
         //
         //  Add the child content
@@ -160,14 +169,14 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * @override
      */
     public computeBBox() {
-        const BBOX = BBox.empty();
+        const BBOX = this.bbox.empty();
         const sbox = this.childNodes[this.surd].getBBox();
         const bbox = new BBox(this.childNodes[this.base].getBBox());
         const [p, q] = this.getPQ(sbox);
         const [x] = this.getRootDimens(sbox);
         const t = this.font.params.rule_thickness;
         const H = bbox.h + q + t;
-        bbox.h += q + 2 * t;  // FIXME:  should take into accound minimums for this.px() used above
+        bbox.h = H + t;
         this.combineRootBBox(BBOX, sbox);
         BBOX.combine(sbox, x, H - sbox.h);
         BBOX.combine(bbox, x + sbox.w, 0);
@@ -185,7 +194,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
     }
 
     /*
-     * @param{BBox} sbox   The bounding box for the surd character
+     * @param{BBox} sbox  The bounding box for the surd character
      * @return{number[]}  The p, q, and x values for the TeX layout computations
      */
     protected getPQ(sbox: BBox) {


### PR DESCRIPTION
Add `drawBBox()` method (for debugging), and fix a number of bounding box problems that it was able to demonstrate.

It turns out we don't want to replace the original bbox created for a wrapper (as it can cause loss of other data, like the `L` property), so we don't use `BBOX.empty()` in `computeBBox()` but instead add an `empty()` method to the bbox to set the `w`, `h`, and `d` values appropriately in the already existing BBoxes.

We use a new `getSpace()` method to compute `bbox.L` (the left spacing) when the object is created (since some bbox computations need it).

Since the `bbox.L` value is already computed, we use that to set the `space` attribute rather than the old `SPACE` array (which is no longer needed).

The rest of the changes are tweaks to get the bounding boxes or placement of things correct.