### PR TITLE
Misc fixes

### DIFF
--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -23,14 +23,13 @@
     toMmlNode: function (factory) {
       var kind = this.type;
       if (kind === 'texatom') kind = 'TeXAtom';
-      if (this.inferred) kind = 'inferredMrow';
       var node = this.nodeMake(factory, kind);
       if ("texClass" in this) node.texClass = this.texClass;
       return node;
     },
     nodeMake: function (factory,kind) {
       var node = factory.MML[kind]();
-      var data = (this.data[0] && this.data[0].inferred ? this.data[0].data : this.data);
+      var data = (this.data[0] && this.data[0].inferred && this.inferRow ? this.data[0].data : this.data);
       for (var i = 0, m = data.length; i < m; i++) {
         var child = data[i];
         if (child) node.appendChild(child.toMmlNode(factory));

--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -2,6 +2,7 @@
   var MML = MathJax.ElementJax.mml;
   
   var PROPERTY = [
+    'texWithDelims',
     'movesupsub',
     'subsupOK',
     'primes',
@@ -14,6 +15,9 @@
     'variantForm',
     'autoOP'
   ];
+  var RENAME = {
+      texWithDelims: 'withDelims'
+  };
 
   MML.mbase.Augment({
     toMmlNode: function (factory) {
@@ -62,7 +66,7 @@
         var name = PROPERTY[i];
         if (this[name] != null &&
             (this.defaults[name] == null || this.defaults[name] === MML.AUTO)) {
-          node.setProperty(name, this[name]);
+          node.setProperty(RENAME[name] || name, this[name]);
         }
       }
     }

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -500,7 +500,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
                            display: boolean = false, level: number = 0, prime: boolean = false) {
         let defaults = this.attributes.getAllDefaults();
         for (const key of Object.keys(attributes)) {
-            if (key in defaults) {
+            if (defaults.hasOwnProperty(key)) {
                 let [node, value] = attributes[key];
                 let noinherit = (AbstractMmlNode.noInherit[node] || {})[this.kind] || {};
                 if (!noinherit[key]) {

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -222,22 +222,6 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             mpadded: {width: true, height: true, depth: true, lspace: true, voffset: true},
             mtable:  {width: true, height: true, depth: true, align: true}
         },
-        mtable: {
-            mover: {align: true},
-            munder: {align: true},
-            munderover: {align: true},
-            mtable: {
-                align: true, rowalign: true, columnalign: true, groupalign: true,
-                alignmentscope: true, columnwidth: true, width: true, rowspacing: true,
-                columnspacing: true, rowlines: true, columnlines: true, frame: true,
-                framespacing: true, equalrows: true, equalcolumns: true, displaystyle: true,
-                side: true, minlabelspacing: true
-            }
-        },
-        mtr: {
-            mrow: {rowalign: true, columnalign: true, groupalign: true},
-            mtable: {rowalign: true, columnalign: true, groupalign: true}
-        },
         maligngroup: {
             mrow: {groupalign: true},
             mtable: {groupalign: true}

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -207,6 +207,8 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
     public static defaults: PropertyList = {
         mathbackground: INHERIT,
         mathcolor: INHERIT,
+        mathsize: INHERIT,  // technically only for token elements, but <mstyle mathsize="..."> should
+                            //    scale all spaces, fractions, etc.
         dir: INHERIT
     };
     /*

--- a/mathjax3-ts/core/MmlTree/MmlNodes/math.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/math.ts
@@ -90,6 +90,7 @@ export class MmlMath extends AbstractMmlLayoutNode {
         attributes = this.addInheritedAttributes(attributes, this.attributes.getAllAttributes());
         display = (!!this.attributes.get('displaystyle') ||
                    (!this.attributes.get('displaystyle') && this.attributes.get('display') === 'block'));
+        this.attributes.setInherited('displaystyle', display);
         level = (this.attributes.get('scriptlevel') ||
                  (this.constructor as typeof MmlMath).defaults['scriptlevel']) as number;
         super.setChildInheritedAttributes(attributes, display, level, prime);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -65,9 +65,9 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
                 level = parseInt(scriptlevel);
             }
         }
-        let displaystyle = this.attributes.getExplicit('displaystyle') as string;
+        let displaystyle = this.attributes.getExplicit('displaystyle') as boolean;
         if (displaystyle != null) {
-            display = (displaystyle === 'true');
+            display = (displaystyle === true);
         }
         attributes = this.addInheritedAttributes(attributes, this.attributes.getAllAttributes());
         this.childNodes[0].setInheritedAttributes(attributes, display, level, prime);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -84,7 +84,6 @@ export class MmlMtable extends AbstractMmlNode {
             }
         }
         display = !!(this.attributes.getExplicit('displaystyle') || this.attributes.getDefault('displaystyle'));
-        attributes = this.addInheritedAttributes(attributes, this.attributes.getAllAttributes());
         super.setChildInheritedAttributes(attributes, display, level, prime);
     }
 

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
@@ -64,7 +64,6 @@ export class MmlMtr extends AbstractMmlNode {
                     .appendChild(child);
             }
         }
-        attributes = this.addInheritedAttributes(attributes, this.attributes.getAllAttributes());
         super.setChildInheritedAttributes(attributes, display, level, prime);
     }
 

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -304,24 +304,21 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         if (this.bboxComputed) {
             return this.bbox;
         }
-        let bbox = this.computeBBox();
-        if (save) {
-            this.bbox = bbox;
-            this.bboxComputed = true;
-        }
+        const bbox = (save ? this.bbox : BBox.zero());
+        this.computeBBox(bbox);
+        this.bboxComputed = save;
         return bbox;
     }
 
     /*
-     * @return{BBox}  The computed bounding box for the wrapped node
+     * @param{BBox} bbox  The bounding box to modify (either this.bbox, or an empty one)
      */
-    protected computeBBox() {
-        const bbox = this.bbox.empty();
+    protected computeBBox(bbox: BBox) {
+        bbox.empty();
         for (const child of this.childNodes) {
             bbox.append(child.getBBox());
         }
         bbox.clean();
-        return bbox;
     }
 
     /*******************************************************************/
@@ -635,7 +632,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     public drawBBox() {
         const bbox = this.getBBox();
         const box = this.html('mjx-box', {style: {
-            opacity: .25, 'margin-left': this.em(-bbox.w-bbox.R)
+            opacity: .25, 'margin-left': this.em(-bbox.w - bbox.R)
         }}, [
             this.html('mjx-box', {style: {
                 height: this.em(bbox.h),

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -405,7 +405,8 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         let attributes = this.node.attributes;
         let scriptlevel = Math.min(attributes.get('scriptlevel') as number, 2);
         let fontsize = attributes.get('fontsize');
-        let mathsize = (parent && !this.node.isToken ? parent : this).node.attributes.get('mathsize');
+        let mathsize = (this.node.isToken || this.node.isKind('mstyle') ?
+                        attributes.get('mathsize') : attributes.getInherited('mathsize'));
         //
         // If scriptsize is non-zero, set scale based on scriptsizemultiplier
         //

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -507,15 +507,25 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
      * Set the (relative) scaling factor for the node
      */
     protected handleScale() {
-        const scale = (Math.abs(this.bbox.rscale - 1) < .001 ? 1 : this.bbox.rscale);
-        if (this.chtml && scale !== 1) {
+        this.setScale(this.chtml, this.bbox.rscale);
+    }
+
+    /*
+     * @param{HTMLElement} chtml  The HTML node to scale
+     * @param{number} rscale      The relatie scale to apply
+     * @return{HTMLElement}       The HTML node (for chaining)
+     */
+    setScale(chtml: HTMLElement, rscale: number) {
+        const scale = (Math.abs(rscale - 1) < .001 ? 1 : rscale);
+        if (chtml && scale !== 1) {
             const size = this.percent(scale);
             if (FONTSIZE[size]) {
-                this.chtml.setAttribute('size', FONTSIZE[size]);
+                chtml.setAttribute('size', FONTSIZE[size]);
             } else {
-                this.chtml.style.fontSize = size;
+                chtml.style.fontSize = size;
             }
         }
+        return chtml;
     }
 
     /*
@@ -624,7 +634,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
     public drawBBox() {
         const bbox = this.getBBox();
         const box = this.html('mjx-box', {style: {
-            opacity: .25, 'margin-left': this.em(-bbox.w)
+            opacity: .25, 'margin-left': this.em(-bbox.w-bbox.R)
         }}, [
             this.html('mjx-box', {style: {
                 height: this.em(bbox.h),
@@ -640,7 +650,7 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
             }})
         ]);
         const node = this.chtml || this.parent.chtml;
-        node.appendChild(box);
+        node.parentNode.appendChild(box);
         node.style.backgroundColor = '#FFEE00';
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -30,6 +30,9 @@ import {CHTMLmrow, CHTMLinferredMrow} from './Wrappers/mrow.js';
 import {CHTMLmfrac} from './Wrappers/mfrac.js';
 import {CHTMLmsqrt} from './Wrappers/msqrt.js';
 import {CHTMLmroot} from './Wrappers/mroot.js';
+import {CHTMLmtable} from './Wrappers/mtable.js';
+import {CHTMLmtr, CHTMLmlabeledtr} from './Wrappers/mtr.js';
+import {CHTMLmtd} from './Wrappers/mtd.js';
 import {CHTMLsemantics, CHTMLannotation, CHTMLannotationXML, CHTMLxml} from './Wrappers/semantics.js';
 import {CHTMLTeXAtom} from './Wrappers/TeXAtom.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
@@ -44,6 +47,10 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmfrac.kind]: CHTMLmfrac,
     [CHTMLmsqrt.kind]: CHTMLmsqrt,
     [CHTMLmroot.kind]: CHTMLmroot,
+    [CHTMLmtable.kind]: CHTMLmtable,
+    [CHTMLmtr.kind]: CHTMLmtr,
+    [CHTMLmlabeledtr.kind]: CHTMLmlabeledtr,
+    [CHTMLmtd.kind]: CHTMLmtd,
     [CHTMLsemantics.kind]: CHTMLsemantics,
     [CHTMLannotation.kind]: CHTMLannotation,
     [CHTMLannotationXML.kind]: CHTMLannotationXML,

--- a/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
@@ -43,7 +43,7 @@ export class CHTMLTeXAtom extends CHTMLWrapper {
         // Center VCENTER atoms vertically
         //
         if (this.node.texClass === TEXCLASS.VCENTER) {
-            const bbox = super.computeBBox();  // get unmodified bbox of children
+            const bbox = this.childNodes[0].getBBox();  // get unmodified bbox of children
             const {h, d} = bbox;
             const a = this.font.params.axis_height;
             const dh = ((h + d) / 2 + a) - h;  // new height minus old height
@@ -54,8 +54,8 @@ export class CHTMLTeXAtom extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
-        const bbox = super.computeBBox();
+    public computeBBox(bbox: BBox) {
+        super.computeBBox(bbox);
         //
         // Center VCENTER atoms vertically
         //
@@ -66,7 +66,6 @@ export class CHTMLTeXAtom extends CHTMLWrapper {
             bbox.h += dh;
             bbox.d += dh;
         }
-        return bbox;
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -57,9 +57,8 @@ export class CHTMLTextNode extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
+    public computeBBox(bbox: BBox) {
         const variant = this.parent.variant;
-        let bbox = this.bbox;
         if (variant === '-explicitFont') {
             // FIXME:  measure this using DOM, if possible
         } else {
@@ -75,7 +74,6 @@ export class CHTMLTextNode extends CHTMLWrapper {
                 if (d > bbox.d) bbox.d = d;
             }
         }
-        return bbox;
     }
 
     /******************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -119,8 +119,8 @@ export class CHTMLmfrac extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
-        const bbox = this.bbox.empty();
+    public computeBBox(bbox: BBox) {
+        bbox.empty();
         const nbox = this.childNodes[0].getBBox();
         const dbox = this.childNodes[1].getBBox();
         const pad = (this.node.getProperty('withDelims') as boolean ? this.font.params.nulldelimiterspace : 0);
@@ -130,7 +130,6 @@ export class CHTMLmfrac extends CHTMLWrapper {
         bbox.combine(dbox, pad, a - 1.5 * t - Math.max(dbox.h, .75));
         bbox.w += pad + .2;
         bbox.clean();
-        return bbox;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ * @fileoverview  Implements the CHTMLmo wrapper for the MmlMo object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -189,22 +189,17 @@ export class CHTMLmo extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
-        const attributes = this.node.attributes;
-        const symmetric = attributes.get('symmetric');
+    public computeBBox(bbox: BBox) {
+        const symmetric = this.node.attributes.get('symmetric');
         if (this.stretch && this.size === null) {
             this.getStretchedVariant([0]);
         }
-        if (this.stretch && this.size < 0) {
-            return this.bbox;
-        } else {
-            const bbox = super.computeBBox();
-            if (symmetric) {
-                const d = ((bbox.h + bbox.d) / 2 + this.font.params.axis_height) - bbox.h;
-                bbox.h += d;
-                bbox.d += d;
-            }
-            return bbox;
+        if (this.stretch && this.size < 0) return;
+        super.computeBBox(bbox);
+        if (symmetric) {
+            const d = ((bbox.h + bbox.d) / 2 + this.font.params.axis_height) - bbox.h;
+            bbox.h += d;
+            bbox.d += d;
         }
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -99,7 +99,7 @@ export class CHTMLmpadded extends CHTMLWrapper {
      */
     protected getDimens() {
         const values = this.node.attributes.getList('width', 'height', 'depth', 'lspace', 'voffset');
-        const bbox = super.computeBBox();  // get unmodified bbox of children
+        const bbox = this.childNodes[0].getBBox();  // get unmodified bbox of children
         let {w, h, d} = bbox;
         let W = w, H = h, D = d, x = 0, y = 0;
         if (values.width !== '')   w = this.dimen(values.width, bbox, 'w', 0);
@@ -137,13 +137,11 @@ export class CHTMLmpadded extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
+    public computeBBox(bbox: BBox) {
         const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
-        const bbox = this.bbox;
         bbox.w = W + dw;
         bbox.h = H + dh;
         bbox.d = D + dd;
-        return bbox;
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mroot.ts
@@ -30,7 +30,7 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
 /*
- *  The CHTMLMroot wrapper for the Mroot object (extends CHTMLmsqrt)
+ *  The CHTMLmroot wrapper for the MmlMroot object (extends CHTMLmsqrt)
  */
 
 export class CHTMLmroot extends CHTMLmsqrt {

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLmfracr wrapper for the MmlMrow object
+ * @fileoverview  Implements the CHTMLmrow wrapper for the MmlMrow object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLmspace wrapper for the MmlMs object
+ * @fileoverview  Implements the CHTMLms wrapper for the MmlMs object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -59,13 +59,11 @@ export class CHTMLmspace extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
+    public computeBBox(bbox: BBox) {
         const attributes = this.node.attributes;
-        const bbox = this.bbox;
         bbox.w = this.length2em(attributes.get('width'), 0);
         bbox.h = this.length2em(attributes.get('height'), 0);
         bbox.d = this.length2em(attributes.get('depth'), 0);
-        return bbox;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -168,29 +168,27 @@ export class CHTMLmsqrt extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
-        const BBOX = this.bbox.empty();
-        const sbox = this.childNodes[this.surd].getBBox();
-        const bbox = new BBox(this.childNodes[this.base].getBBox());
-        const [p, q] = this.getPQ(sbox);
-        const [x] = this.getRootDimens(sbox);
+    public computeBBox(bbox: BBox) {
+        const surdbox = this.childNodes[this.surd].getBBox();
+        const basebox = new BBox(this.childNodes[this.base].getBBox());
+        const [p, q] = this.getPQ(surdbox);
+        const [x] = this.getRootDimens(surdbox);
         const t = this.font.params.rule_thickness;
         const H = bbox.h + q + t;
         bbox.h = H + t;
-        this.combineRootBBox(BBOX, sbox);
-        BBOX.combine(sbox, x, H - sbox.h);
-        BBOX.combine(bbox, x + sbox.w, 0);
-        BBOX.clean();
-        return BBOX;
+        this.combineRootBBox(bbox, surdbox);
+        bbox.combine(surdbox, x, H - surdbox.h);
+        bbox.combine(basebox, x + surdbox.w, 0);
+        bbox.clean();
     }
 
     /*
      * Combine the bounding box of the root (overridden in mroot)
      *
-     * @param{BBox} BBOX  The bounding box so far
+     * @param{BBox} bbox  The bounding box so far
      * @param{BBox} sbox  The bounding box of the surd
      */
-    protected combineRootBBox(BBOX: BBox, sbox: BBox) {
+    protected combineRootBBox(bbox: BBox, sbox: BBox) {
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLMsqrt wrapper for the MmlMsqrt object
+ * @fileoverview  Implements the CHTMLmsqrt wrapper for the MmlMsqrt object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */
@@ -32,7 +32,7 @@ import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
 /*
- *  The CHTMLMsqrt wrapper for the Msqrt object
+ *  The CHTMLmsqrt wrapper for the MmlMsqrt object
  */
 
 export class CHTMLmsqrt extends CHTMLWrapper {

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -1,0 +1,387 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmtable wrapper for the MmlMtable object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {CHTMLmtr} from './mtr.js';
+import {BBox} from '../BBox.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {MmlMtable} from '../../../core/MmlTree/MmlNodes/mtable.js';
+import {StyleList} from '../CssStyles.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmtable wrapper for the MmlMtable object
+ */
+
+export class CHTMLmtable extends CHTMLWrapper {
+    public static kind = MmlMtable.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mtable': {
+            'vertical-align': '.25em'
+        },
+        'mjx-mtable > mjx-itable': {
+            'vertical-align': 'middle'
+        }
+    };
+
+    /*
+     * The number of columns and rows in the table
+     */
+    protected numCols: number = 0;
+    protected numRows: number = 0;
+
+
+    /******************************************************************/
+
+    /*
+     * @override
+     * @constructor
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        //
+        // Determine the number of columns and rows
+        //
+        this.numCols = this.childNodes.map(row => (row as CHTMLmtr).numCells).reduce((a, b) => Math.max(a, b));
+        this.numRows = this.childNodes.length;
+    }
+
+    /******************************************************************/
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        //
+        //  Create the rows inside an mjx-itable (which will be used to center the table on the math axis)
+        //
+        let chtml = this.standardCHTMLnode(parent);
+        const table = chtml.appendChild(this.html('mjx-itable'));
+        for (const child of this.childNodes) {
+            child.toCHTML(table);
+        }
+        //
+        //  Check if there is a frame or lines, and get the frame spacing, if so
+        //
+        const attributes = this.node.attributes;
+        const frame = attributes.get('frame') !== 'none';
+        const lines = frame || attributes.get('columnlines') !== 'none' || attributes.get('rowlines') !== 'none';
+        const fspacing = (lines ? this.convertLengths(this.getAttributeArray('framespacing')) : ['0', '0']);
+        //
+        //  Pad the rows of the table, if needed
+        //  Then set the column and row attributes for alignment, spacing, and lines
+        //  Finally, add the frame, if needed
+        //
+        this.padRows();
+        this.handleColumnAlign();
+        this.handleColumnSpacing(lines, fspacing[0]);
+        this.handleColumnLines();
+        this.handleRowAlign();
+        this.handleRowSpacing(lines, fspacing[1]);
+        this.handleRowLines();
+        this.handleFrame(frame);
+    }
+
+    /******************************************************************/
+
+    /*
+     * @override
+     */
+    public computeBBox() {
+        const H = new Array(this.numRows).fill(0);
+        const D = new Array(this.numRows).fill(0);
+        const W = new Array(this.numCols).fill(0);
+        for (let j = 0; j < this.numRows; j++) {
+            const row = this.childNodes[j] as CHTMLmtr;
+            for (let i = 0; i < row.childNodes.length; i++) {
+                const bbox = row.childNodes[i].getBBox();
+                const h = Math.max(bbox.h, .75);
+                const d = Math.max(bbox.d, .25);
+                if (h > H[j]) H[j] = h;
+                if (d > D[j]) D[j] = d;
+                if (bbox.w > W[i]) W[i] = bbox.w;
+            }
+        }
+        const cMax = Math.max(0, this.numCols - 1);
+        const rMax = Math.max(0, this.numRows - 1);
+        const cSpace = this.convertLengths(this.getColumnAttributes('columnspacing')).slice(0, cMax);
+        const rSpace = this.convertLengths(this.getRowAttributes('rowspacing')).slice(0, rMax);
+        const frame = this.node.attributes.get('frame') !== 'none';
+        const fSpace = (frame ? this.convertLengths(this.getAttributeArray('framespacing')) : ['0', '0']);
+        const cLines = this.getColumnAttributes('columnlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
+        const rLines = this.getColumnAttributes('rowlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
+        const a = this.font.params.axis_height;
+        const h = H.concat(D,rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
+            rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
+        this.bbox.h = h / 2 + a;
+        this.bbox.d = h / 2 - a;
+        this.bbox.w = W.concat(cLines).reduce((a, b) => a + b) +
+            cSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
+        return this.bbox;
+    }
+
+    /******************************************************************/
+
+    /*
+     * Pad any short rows with extra cells
+     */
+    protected padRows() {
+        for (const row of Array.from(this.chtml.childNodes)) {
+            while (row.childNodes.length < this.numCols) {
+                row.appendChild(this.html('mjx-mtd'));
+            }
+        }
+    }
+
+    /*
+     * Set the cell aligmentsbased on the table, row, or cell columnalign attributes
+     */
+    protected handleColumnAlign() {
+        const colAlign = this.getColumnAttributes('columnalign') || [];
+        for (const row of this.childNodes) {
+            const aligns = this.getColumnAttributes('columnalign', row) || colAlign;
+            let i = 0;
+            for (const cell of row.childNodes) {
+                let align = (cell.node.attributes.get('columnalign') as string) || aligns[i++];
+                if (align !== 'center') {
+                    cell.chtml.style.textAlign = align;
+                }
+            }
+        }
+    }
+
+    /*
+     * Set the inter-column spacing for all columns
+     *  (Use frame spacing on the outsides, if needed, and use half the column spacing on each
+     *   neighboring column, so that if column lines are needed, they fall in the middle
+     *   of the column space.)
+     *
+     * @param{boolean} frame  Whether to include frame spacing on the left and right or not
+     * @param{string} fspace  The frame spacing to use, if any
+     */
+    protected handleColumnSpacing(frame: boolean, fspace: string) {
+        //
+        //  Get the column spacing values, and add the frame spacing values at the left and right
+        //
+        const spacing = this.convertLengths(this.getColumnAttributes('columnspacing'), 2);
+        if (!spacing) return;
+        spacing.unshift(fspace);
+        spacing[this.numCols] = fspace;
+        //
+        //  For each row...
+        //
+        for (const row of this.childNodes) {
+            let i = 0;
+            //
+            //  For each cell in the row...
+            //
+            for (const cell of row.childNodes) {
+                //
+                //  Get the left and right-hand spacing
+                //
+                const lspace = spacing[i++];
+                const rspace = spacing[i];
+                //
+                //  Set the style for the spacing, if it is needed, and isn't the
+                //  default already set in the mtd styles
+                //
+                const style = (cell ? cell.chtml : row.chtml.childNodes[i] as HTMLElement).style;
+                if ((i > 1 || frame) && lspace !== '.5em') {
+                    style.paddingLeft = lspace;
+                }
+                if ((i < this.numCols || frame) && rspace !== '.5em') {
+                    style.paddingRight = rspace;
+                }
+            }
+        }
+    }
+
+    /*
+     * Add borders to the left of cells to make the column lines
+     */
+    protected handleColumnLines() {
+        if (this.node.attributes.get('columnlines') === 'none') return;
+        const lines = this.getColumnAttributes('columnlines');
+        if (!lines) return;
+        for (const row of this.childNodes) {
+            let i = 0;
+            for (const cell of (Array.from(row.chtml.childNodes) as HTMLElement[]).slice(1)) {
+                const line = lines[i++];
+                if (line === 'none') continue;
+                cell.style.borderLeft = '.07em ' + line;
+            }
+        }
+    }
+
+    /*
+     * Add vertical alignment to rows, and override in the cells, if needed
+     */
+    protected handleRowAlign() {
+        const rowAlign = this.getRowAttributes('rowalign') || [];
+        let i = 0;
+        for (const row of this.childNodes) {
+            const align = (row.node.attributes.get('rowalign') as string) || rowAlign[i++];
+            if (align !== 'baseline') {
+                row.chtml.style.verticalAlign = align;
+            }
+            for (const cell of row.childNodes) {
+                const calign = cell.node.attributes.get('rowalign') as string;
+                if (calign && calign !== align) {
+                    cell.chtml.style.verticalAlign = calign;
+                }
+            }
+        }
+    }
+
+    /*
+     * Set the inter-row spacing for all rows
+     *  (Use frame spacing on the outsides, if needed, and use half the row spacing on each
+     *   neighboring row, so that if row lines are needed, they fall in the middle
+     *   of the row space.)
+     *
+     * @param{boolean} frame  Whether to include frame spacing on the top and bottom or not
+     * @param{string} fspace  The frame spacing to use, if any
+     */
+    protected handleRowSpacing(frame: boolean, fspacing: string) {
+        //
+        //  Get the row spacing values, and add the frame spacing values at the left and right
+        //
+        const spacing = this.convertLengths(this.getRowAttributes('rowspacing'), 2);
+        if (!spacing) return;
+        spacing.unshift(fspacing);
+        spacing[this.numRows] = fspacing;
+        //
+        //  For each row...
+        //
+        let i = 0;
+        for (const row of this.childNodes) {
+            //
+            //  Get the top and bottom spacing
+            //
+            const tspace = spacing[i++];
+            const bspace = spacing[i];
+            //
+            //  For each cell in the row...
+            //
+            for (const cell of row.childNodes) {
+                //
+                //  Set the style for the spacing, if it is needed, and isn't the
+                //  default already set in the mtd styles
+                //
+                const style = cell.chtml.style;
+                if ((i > 1 || frame) && tspace !== '.125em') {
+                    style.paddingTop = tspace;
+                }
+                if ((i < this.numRows || frame) && bspace !== '.125em') {
+                    style.paddingBottom = bspace;
+                }
+            }
+        }
+    }
+
+    /*
+     * Add borders to the tops of cells to make the row lines
+     */
+    protected handleRowLines() {
+        if (this.node.attributes.get('rowlines') === 'none') return;
+        const lines = this.getRowAttributes('rowlines');
+        if (!lines) return;
+        let i = 0;
+        for (const row of this.childNodes.slice(1)) {
+            const line = lines[i++];
+            if (line === 'none') continue;
+            for (const cell of Array.from(row.chtml.childNodes) as HTMLElement[]) {
+                cell.style.borderTop = '.07em ' + line;
+            }
+        }
+    }
+
+    /*
+     * Add a frame to the mjx-itable, if needed
+     */
+    protected handleFrame(frame: boolean) {
+        if (frame) {
+            (this.chtml.firstChild as HTMLElement).style.border = '.07em ' + this.node.attributes.get('frame');
+        }
+    }
+
+    /******************************************************************/
+
+    /*
+     * @param{string} name           The name of the attribute to get as an array
+     * @param{CHTMLWrapper} wrapper  The wrapper whose attribute is to be used
+     * @return{string[]}             The array of values in the given attribute, split at spaces,
+     *                                 padded to the number of table columns by repeating the last entry
+     */
+    protected getColumnAttributes(name: string, wrapper: CHTMLWrapper = null) {
+        const columns = this.getAttributeArray(name, wrapper);
+        if (columns.length === 0) return;
+        while (columns.length < this.numCols) {
+            columns.push(columns[columns.length - 1]);
+        }
+        return columns;
+    }
+
+    /*
+     * @param{string} name           The name of the attribute to get as an array
+     * @param{CHTMLWrapper} wrapper  The wrapper whose attribute is to be used
+     * @return{string[]}             The array of values in the given attribute, split at spaces,
+     *                                 padded to the number of table rows by repeating the last entry
+     */
+    protected getRowAttributes(name: string, wrapper: CHTMLWrapper = null) {
+        const rows = this.getAttributeArray(name, wrapper);
+        if (rows.length === 0) return;
+        while (rows.length < this.numRows) {
+            rows.push(rows[rows.length - 1]);
+        }
+        return rows;
+    }
+
+    /*
+     * @param{string} name           The name of the attribute to get as an array
+     * @param{CHTMLWrapper} wrapper  The wrapper whose attribute is to be used
+     * @return{string[]}             The array of values in the given attribute, split at spaces
+     *                                 (after leading and trailing spaces are removed, and multiple
+     *                                  spaces have been collapsed to one).
+     */
+    protected getAttributeArray(name: string, wrapper: CHTMLWrapper = null) {
+        const value = ((wrapper || this).node.attributes.get(name) as string);
+        if (!value) return [];
+        return value.replace(/^\s+/, '').replace(/\s+$/, '').replace(/\s+/g, ' ').split(/ /);
+    }
+
+    /*
+     * Converts an array of dimensions (with arbitrary units) to an array of dimensions
+     *   in units of em's, dividing the dimension by n (defaults to 1).
+     *
+     * @param{string[]} list   The array of dimensions to be turned into em's
+     * @param{nunber} n        The number to divide each dimension by after converted
+     * @return{string[]}       The array of values converted to em's 
+     */
+    protected convertLengths(list: string[], n: number = 1) {
+        if (!list) return;
+        return list.map(x => this.em(this.length2em(x) / n));
+    }
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -133,7 +133,7 @@ export class CHTMLmtable extends CHTMLWrapper {
         const cLines = this.getColumnAttributes('columnlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const rLines = this.getColumnAttributes('rowlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const a = this.font.params.axis_height;
-        const h = H.concat(D,rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
+        const h = H.concat(D, rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
             rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
         this.bbox.h = h / 2 + a;
         this.bbox.d = h / 2 - a;
@@ -378,7 +378,7 @@ export class CHTMLmtable extends CHTMLWrapper {
      *
      * @param{string[]} list   The array of dimensions to be turned into em's
      * @param{nunber} n        The number to divide each dimension by after converted
-     * @return{string[]}       The array of values converted to em's 
+     * @return{string[]}       The array of values converted to em's
      */
     protected convertLengths(list: string[], n: number = 1) {
         if (!list) return;

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -109,19 +109,19 @@ export class CHTMLmtable extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
+    public computeBBox(bbox: BBox) {
         const H = new Array(this.numRows).fill(0);
         const D = new Array(this.numRows).fill(0);
         const W = new Array(this.numCols).fill(0);
         for (let j = 0; j < this.numRows; j++) {
             const row = this.childNodes[j] as CHTMLmtr;
             for (let i = 0; i < row.childNodes.length; i++) {
-                const bbox = row.childNodes[i].getBBox();
-                const h = Math.max(bbox.h, .75);
-                const d = Math.max(bbox.d, .25);
+                const cbox = row.childNodes[i].getBBox();
+                const h = Math.max(cbox.h, .75);
+                const d = Math.max(cbox.d, .25);
                 if (h > H[j]) H[j] = h;
                 if (d > D[j]) D[j] = d;
-                if (bbox.w > W[i]) W[i] = bbox.w;
+                if (cbox.w > W[i]) W[i] = cbox.w;
             }
         }
         const cMax = Math.max(0, this.numCols - 1);
@@ -135,11 +135,10 @@ export class CHTMLmtable extends CHTMLWrapper {
         const a = this.font.params.axis_height;
         const h = H.concat(D, rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
             rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
-        this.bbox.h = h / 2 + a;
-        this.bbox.d = h / 2 - a;
-        this.bbox.w = W.concat(cLines).reduce((a, b) => a + b) +
+        bbox.h = h / 2 + a;
+        bbox.d = h / 2 - a;
+        bbox.w = W.concat(cLines).reduce((a, b) => a + b) +
             cSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
-        return this.bbox;
     }
 
     /******************************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -1,0 +1,74 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmtd wrapper for the MmlMtd object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {BBox} from '../BBox.js';
+import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
+import {StyleList} from '../CssStyles.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmtd wrapper for the MmlMtd object
+ */
+
+export class CHTMLmtd extends CHTMLWrapper {
+    public static kind = MmlMtd.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mtd': {
+            display: 'table-cell',
+            'text-align': 'center',
+            'padding': '.25em .5em'
+        },
+        'mjx-mtd:first-child': {
+            'padding-left': 0
+        },
+        'mjx-mtd:last-child': {
+            'padding-right': 0
+        },
+        'mjx-mtable > mjx-itable > *:first-child > mjx-mtd': {
+            'padding-top': 0
+        },
+        'mjx-mtable > mjx-itable > *:last-child > mjx-mtd': {
+            'padding-bottom': 0
+        },
+        'mjx-tstrut': {
+            display: 'inline-block',
+            height: '1em',
+            'vertical-align': '-.25em'
+        }
+    };
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        super.toCHTML(parent);
+        //
+        // Include a strut to force minimum height and depth
+        //
+        this.chtml.appendChild(this.html('mjx-tstrut'));
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -1,0 +1,109 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmtr wrapper for the MmlMtr object
+ *                and CHTMLmlabeledtr for MmlMlabeledtr
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {BBox} from '../BBox.js';
+import {MmlMtr, MmlMlabeledtr} from '../../../core/MmlTree/MmlNodes/mtr.js';
+import {StyleList} from '../CssStyles.js';
+
+/*****************************************************************/
+/*
+ *  The CHTMLmtr wrapper for the MmlMtr object
+ */
+
+export class CHTMLmtr extends CHTMLWrapper {
+    public static kind = MmlMtr.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mtr': {
+            display: 'table-row',
+        }
+    };
+
+    /*
+     * @return{number}   The number of mtd's in the mtr
+     */
+    get numCells() {
+        return this.childNodes.length;
+    }
+
+    /*
+     * @return{BBox[]}  An array of the bounding boxes for the mtd's in the row
+     */
+    public getChildBBoxes() {
+        return this.childNodes.map(cell => cell.getBBox());
+    }
+
+}
+
+/*****************************************************************/
+/*
+ *  The CHTMLlabeledmtr wrapper for the MmlMlabeledtr object
+ */
+
+export class CHTMLmlabeledtr extends CHTMLWrapper {
+    public static kind = MmlMlabeledtr.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mlabeledtr': {
+            display: 'table-row'
+        }
+    };
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        super.toCHTML(parent);
+        //
+        //  FIXME: for now, remove label
+        //
+        const row = this.chtml;
+        if (row.firstChild) {
+            row.removeChild(row.firstChild);
+        }
+    }
+
+    /*
+     * @override
+     */
+    get numCells() {
+        //
+        //  Don't include the label mtd
+        //
+        return Math.max(0, this.childNodes.length - 1);
+    }
+
+    /*
+     * @override
+     */
+    public getChildBBoxes() {
+        //
+        //  Don't include the label mtd
+        //
+        return this.childNodes.slice(1).map(cell => cell.getBBox());
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -50,15 +50,13 @@ export class CHTMLsemantics extends CHTMLWrapper {
     /*
      * @override
      */
-    public computeBBox() {
-        const bbox = this.bbox;
+    public computeBBox(bbox: BBox) {
         if (this.childNodes.length) {
             const {w, h, d} = this.childNodes[0].getBBox();
             bbox.w = w;
             bbox.h = h;
             bbox.d = d;
         }
-        return bbox;
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CHTMLsemantics wrapper for the Mmlsemantics object
+ * @fileoverview  Implements the CHTMLsemantics wrapper for the MmlSemantics object
  *                and the associated wrappers for annotations
  *
  * @author dpvc@mathjax.org (Davide Cervone)


### PR DESCRIPTION
This fixes a number of small issues with attribute inheritance in MmlNodes, and with the bounding boxes in CHTML.

*  Although the `mathsize` attribute is only allowed on token elements, we want it to affect things like fractions, roots, tables, etc., so that when `\large` and the other sizing macros are used, everything scales appropriately.  Similarly, `<math mathsize="200%">...</math>` should scale everything up, not just the token elements.

* When inheriting values check for default attribute values only in the actual default list, not the chained global defaults (now that the global defaults are in the chain).

* The `<math>` element should set the `displaystyle` as an inherited value, since its default value is computed from several other values, when not explicitly given.

* Fix the handling of `displaystyle` in `<mstyle>`

* In CHTML, the bounding boxes are now computed in place by `computeBBox()`, rather than creating new BBox structures each time.  But that means that when `getBBox()` is called with `save = false`, then the box is saved anyway.  So `computeBBox()` was changed to accept the BBox to be used, and `getBBox()` passes it either the original box (when the value is to be saved), or a new zeroed box (if the box isn't being saved).  The CHTMLWrapper `computeBBox()` implementations are modified to include the BBox parameter.  The return value is no longer needed, since the BBox is passed to it.

* Finally, `super.computeBBox()` is replaced by `this.childNode[0].getBBox()`, since that way you get the cached bounding box of the inferred row (the only child), rather than creating a new BBox and appending one BBox to it (extra work for nothing).