### PR TITLE
V2 fixes

### DIFF
--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -23,14 +23,13 @@
     toMmlNode: function (factory) {
       var kind = this.type;
       if (kind === 'texatom') kind = 'TeXAtom';
-      if (this.inferred) kind = 'inferredMrow';
       var node = this.nodeMake(factory, kind);
       if ("texClass" in this) node.texClass = this.texClass;
       return node;
     },
     nodeMake: function (factory,kind) {
       var node = factory.MML[kind]();
-      var data = (this.data[0] && this.data[0].inferred ? this.data[0].data : this.data);
+      var data = (this.data[0] && this.data[0].inferred && this.inferRow ? this.data[0].data : this.data);
       for (var i = 0, m = data.length; i < m; i++) {
         var child = data[i];
         if (child) node.appendChild(child.toMmlNode(factory));

--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -2,6 +2,7 @@
   var MML = MathJax.ElementJax.mml;
   
   var PROPERTY = [
+    'texWithDelims',
     'movesupsub',
     'subsupOK',
     'primes',
@@ -14,6 +15,9 @@
     'variantForm',
     'autoOP'
   ];
+  var RENAME = {
+      texWithDelims: 'withDelims'
+  };
 
   MML.mbase.Augment({
     toMmlNode: function (factory) {
@@ -62,7 +66,7 @@
         var name = PROPERTY[i];
         if (this[name] != null &&
             (this.defaults[name] == null || this.defaults[name] === MML.AUTO)) {
-          node.setProperty(name, this[name]);
+          node.setProperty(RENAME[name] || name, this[name]);
         }
       }
     }

--- a/mathjax2/legacy/jax/element/MmlNode.js
+++ b/mathjax2/legacy/jax/element/MmlNode.js
@@ -13,7 +13,8 @@
     'isError',
     'multiline',
     'variantForm',
-    'autoOP'
+    'autoOP',
+    'fnOP'  
   ];
   var RENAME = {
       texWithDelims: 'withDelims'


### PR DESCRIPTION
[I accidentally closed this PR, and don't seem to be able to reopen it, so I'm submitting it again. I don't think Volker had any comment on it yet.  Sorry about the problem.  Also messed up the table PR where there were comments, but I will fix the problems raised and resubmit that PR as well.]

This fixes a number of small issues with attribute inheritance in MmlNodes, and with the bounding boxes in CHTML.

*  Although the `mathsize` attribute is only allowed on token elements, we want it to affect things like fractions, roots, tables, etc., so that when `\large` and the other sizing macros are used, everything scales appropriately.  Similarly, `<math mathsize="200%">...</math>` should scale everything up, not just the token elements.

* When inheriting values check for default attribute values only in the actual default list, not the chained global defaults (now that the global defaults are in the chain).

* The `<math>` element should set the `displaystyle` as an inherited value, since its default value is computed from several other values, when not explicitly given.

* Fix the handling of `displaystyle` in `<mstyle>`

* In CHTML, the bounding boxes are now computed in place by `computeBBox()`, rather than creating new BBox structures each time.  But that means that when `getBBox()` is called with `save = false`, then the box is saved anyway.  So `computeBBox()` was changed to accept the BBox to be used, and `getBBox()` passes it either the original box (when the value is to be saved), or a new zeroed box (if the box isn't being saved).  The CHTMLWrapper `computeBBox()` implementations are modified to include the BBox parameter.  The return value is no longer needed, since the BBox is passed to it.

* Finally, `super.computeBBox()` is replaced by `this.childNode[0].getBBox()`, since that way you get the cached bounding box of the inferred row (the only child), rather than creating a new BBox and appending one BBox to it (extra work for nothing).