### PR TITLE
Table support

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -133,7 +133,7 @@ export class CHTMLmtable extends CHTMLWrapper {
         const cLines = this.getColumnAttributes('columnlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const rLines = this.getColumnAttributes('rowlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const a = this.font.params.axis_height;
-        const h = H.concat(D,rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
+        const h = H.concat(D, rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
             rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
         this.bbox.h = h / 2 + a;
         this.bbox.d = h / 2 - a;
@@ -378,7 +378,7 @@ export class CHTMLmtable extends CHTMLWrapper {
      *
      * @param{string[]} list   The array of dimensions to be turned into em's
      * @param{nunber} n        The number to divide each dimension by after converted
-     * @return{string[]}       The array of values converted to em's 
+     * @return{string[]}       The array of values converted to em's
      */
     protected convertLengths(list: string[], n: number = 1) {
         if (!list) return;

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -88,7 +88,7 @@ export class CHTMLmtable extends CHTMLWrapper {
         const attributes = this.node.attributes;
         const frame = attributes.get('frame') !== 'none';
         const lines = frame || attributes.get('columnlines') !== 'none' || attributes.get('rowlines') !== 'none';
-        const fspacing = (lines ? this.convertLengths(this.getAttributeArray('framespacing')) : ['0', '0']);
+        const fspacing = (lines ? this.convertLengths(this.getAttributeArray('framespacing')) : []);
         //
         //  Pad the rows of the table, if needed
         //  Then set the column and row attributes for alignment, spacing, and lines
@@ -96,10 +96,10 @@ export class CHTMLmtable extends CHTMLWrapper {
         //
         this.padRows();
         this.handleColumnAlign();
-        this.handleColumnSpacing(lines, fspacing[0]);
+        this.handleColumnSpacing(lines, fspacing[0] || '0');
         this.handleColumnLines();
         this.handleRowAlign();
-        this.handleRowSpacing(lines, fspacing[1]);
+        this.handleRowSpacing(lines, fspacing[1] || '0');
         this.handleRowLines();
         this.handleFrame(frame);
     }
@@ -129,16 +129,16 @@ export class CHTMLmtable extends CHTMLWrapper {
         const cSpace = this.convertLengths(this.getColumnAttributes('columnspacing')).slice(0, cMax);
         const rSpace = this.convertLengths(this.getRowAttributes('rowspacing')).slice(0, rMax);
         const frame = this.node.attributes.get('frame') !== 'none';
-        const fSpace = (frame ? this.convertLengths(this.getAttributeArray('framespacing')) : ['0', '0']);
+        const fSpace = (frame ? this.convertLengths(this.getAttributeArray('framespacing')) : []);
         const cLines = this.getColumnAttributes('columnlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const rLines = this.getColumnAttributes('rowlines').slice(0, cMax).map(x => (x === 'none' ? 0 : .07));
         const a = this.font.params.axis_height;
         const h = H.concat(D, rLines).reduce((a, b) => a + b) + (frame ? .14 : 0) +
-            rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
+            rSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1] || '0');
         this.bbox.h = h / 2 + a;
         this.bbox.d = h / 2 - a;
         this.bbox.w = W.concat(cLines).reduce((a, b) => a + b) +
-            cSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1]);
+            cSpace.map(x => parseFloat(x)).reduce((a, b) => a + b) + 2 * parseFloat(fSpace[1] || '0');
         return this.bbox;
     }
 
@@ -156,7 +156,7 @@ export class CHTMLmtable extends CHTMLWrapper {
     }
 
     /*
-     * Set the cell aligmentsbased on the table, row, or cell columnalign attributes
+     * Set the cell aligments based on the table, row, or cell columnalign attributes
      */
     protected handleColumnAlign() {
         const colAlign = this.getColumnAttributes('columnalign') || [];
@@ -319,7 +319,7 @@ export class CHTMLmtable extends CHTMLWrapper {
     }
 
     /*
-     * Add a frame to the mjx-itable, if needed
+     * Add a frame to the mtable, if needed
      */
     protected handleFrame(frame: boolean) {
         if (frame) {


### PR DESCRIPTION
[I deleted the branch the original PR was being merged to, and the old PR it was closed automatically.  So I'm making a new one.  It already addresses Volker's comments from the old one.  Again, sorry for the error.]

This PR adds support for `mtable`/`mtr`/`mtd`.  Not all `mtable` attributes are supported (so far, only `columnspacing`, `rowspacing`, `columnalign`, `rowalign`, `columnlines`, `rowlines`, `frame`, and `framespacing`).  This is enough for most of the TeX requirements.  Labeled rows are handled, but the label is dropped for now.  Still to be done are things like setting column widths, forcing equal columns and rows, label support, and setting the table width (in particular, percentage width tables).  Note that partial frames (possible within LaTeX's array environment) rely on `menclose`, which is not yet implemented.

But for now, this is pretty good.

This also includes fixes for some typos in comments, and a fix for incorrect inheritance of `mtr` and `mtd` attributes from `mtable` elements.