### PR TITLE
Italic correction

### DIFF
--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -65,6 +65,7 @@ export class BBox {
     public L: number;      // extra space on the left
     public R: number;      // extra space on the right
     public pwidth: string; // percentage width (for tables)
+    public ic: number;
 
     /*
      * @return{BBox}  A BBox initialized to zeros
@@ -91,7 +92,7 @@ export class BBox {
         this.w = def.w || 0;
         this.h = ('h' in def ? def.h : -BIGDIMEN);
         this.d = ('d' in def ? def.d : -BIGDIMEN);
-        this.x = this.y = this.L = this.R = 0;
+        this.x = this.y = this.L = this.R = this.ic = 0;
         this.scale = this.rscale = 1;
         this.pwidth = '';
     }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -118,7 +118,6 @@ export class CHTMLWrapper extends AbstractWrapper<MmlNode, CHTMLWrapper> {
         //
         //  These don't have Wrapper subclasses, so add their styles here
         //
-        'mjx-mi': {display: 'inline-block'},
         'mjx-mn': {display: 'inline-block'},
         'mjx-mtext': {display: 'inline-block'},
         'mjx-merror': {

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -23,6 +23,7 @@
 
 import {CHTMLWrapper} from './Wrapper.js';
 import {CHTMLmath} from './Wrappers/math.js';
+import {CHTMLmi} from './Wrappers/mi.js';
 import {CHTMLmo} from './Wrappers/mo.js';
 import {CHTMLms} from './Wrappers/ms.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
@@ -44,6 +45,7 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmath.kind]: CHTMLmath,
     [CHTMLmrow.kind]: CHTMLmrow,
     [CHTMLinferredMrow.kind]: CHTMLinferredMrow,
+    [CHTMLmi.kind]: CHTMLmi,
     [CHTMLmo.kind]: CHTMLmo,
     [CHTMLms.kind]: CHTMLms,
     [CHTMLmspace.kind]: CHTMLmspace,

--- a/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
@@ -56,6 +56,9 @@ export class CHTMLTeXAtom extends CHTMLWrapper {
      */
     public computeBBox(bbox: BBox) {
         super.computeBBox(bbox);
+        if (this.childNodes[0] && this.childNodes[0].bbox.ic) {
+            bbox.ic = this.childNodes[0].bbox.ic;
+        }
         //
         // Center VCENTER atoms vertically
         //

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -82,7 +82,7 @@ export class CHTMLTextNode extends CHTMLWrapper {
     /*
      * @param{string} variant   The variant in which to look for the character
      * @param{number} n         The number of the character to look up
-     * @param{CharData}         The full CharData object, with CharOptions guaranteed to be defined
+     * @return{CharData}        The full CharData object, with CharOptions guaranteed to be defined
      */
     protected getChar(variant: string, n: number) {
         const char = this.font.getChar(variant, n) || [0, 0, 0, null];

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -24,6 +24,7 @@
 import {CHTMLWrapper} from '../Wrapper.js';
 import {BBox} from '../BBox.js';
 import {TextNode} from '../../../core/MmlTree/MmlNode.js';
+import {CharOptions} from '../FontData.js';
 
 /*****************************************************************/
 /*
@@ -63,17 +64,29 @@ export class CHTMLTextNode extends CHTMLWrapper {
             // FIXME:  measure this using DOM, if possible
         } else {
             const chars = this.unicodeChars((this.node as TextNode).getText());
-            let [h, d, w] = this.font.getChar(variant, chars[0]) || [0, 0, 0];
+            let [h, d, w, data] = this.getChar(variant, chars[0]);
             bbox.h = h;
             bbox.d = d;
             bbox.w = w;
+            bbox.ic = data.ic || 0;
             for (let i = 1, m = chars.length; i < m; i++) {
-                [h, d, w] = this.font.getChar(variant, chars[i]) || [0, 0, 0];
+                [h, d, w, data] = this.getChar(variant, chars[i]);
                 bbox.w += w;
                 if (h > bbox.h) bbox.h = h;
                 if (d > bbox.d) bbox.d = d;
+                bbox.ic = data.ic || 0;
             }
         }
+    }
+
+    /*
+     * @param{string} variant   The variant in which to look for the character
+     * @param{number} n         The number of the character to look up
+     * @param{CharData}         The full CharData object, with CharOptions guaranteed to be defined
+     */
+    protected getChar(variant: string, n: number) {
+        const char = this.font.getChar(variant, n) || [0, 0, 0, null];
+        return [char[0], char[1], char[2], char[3] || {}] as [number, number, number, CharOptions];
     }
 
     /******************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/mi.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mi.ts
@@ -21,21 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CHTMLWrapper, StringMap} from '../Wrapper.js';
+import {CHTMLWrapper} from '../Wrapper.js';
 import {MmlMi} from '../../../core/MmlTree/MmlNodes/mi.js';
-import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
-import {DelimiterData} from '../FontData.js';
-import {StyleList} from '../CssStyles.js';
-import {DIRECTION} from '../FontData.js';
-
-/*
- * Convert direction to letter
- */
-const DirectionVH: {[n: number]: string} = {
-    [DIRECTION.Vertical]: 'v',
-    [DIRECTION.Horizontal]: 'h'
-};
 
 /*****************************************************************/
 /*

--- a/mathjax3-ts/output/chtml/Wrappers/mi.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mi.ts
@@ -1,0 +1,74 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmi wrapper for the MmlMi object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper, StringMap} from '../Wrapper.js';
+import {MmlMi} from '../../../core/MmlTree/MmlNodes/mi.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {BBox} from '../BBox.js';
+import {DelimiterData} from '../FontData.js';
+import {StyleList} from '../CssStyles.js';
+import {DIRECTION} from '../FontData.js';
+
+/*
+ * Convert direction to letter
+ */
+const DirectionVH: {[n: number]: string} = {
+    [DIRECTION.Vertical]: 'v',
+    [DIRECTION.Horizontal]: 'h'
+};
+
+/*****************************************************************/
+/*
+ *  The CHTMLmi wrapper for the MmlMi object
+ */
+export class CHTMLmi extends CHTMLWrapper {
+    public static kind = MmlMi.prototype.kind;
+
+    /*
+     * True if no italic correction should be used
+     */
+    public noIC: boolean = false;
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: HTMLElement) {
+        super.toCHTML(parent);
+        if (this.noIC) {
+            this.chtml.setAttribute('noIC', 'true');
+        }
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox(bbox: BBox) {
+        super.computeBBox(bbox);
+        const child = this.childNodes[this.childNodes.length-1];
+        if (child && child.bbox.ic) {
+            bbox.ic = child.bbox.ic;
+            bbox.w += bbox.ic;
+        }
+    }
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -22,6 +22,7 @@
  */
 
 import {CHTMLWrapper, StringMap} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
@@ -105,10 +106,16 @@ export class CHTMLmo extends CHTMLWrapper {
     };
 
     /*
+     * True if no italic correction should be used
+     */
+    public noIC: boolean = false;
+
+    /*
      * The font size that a stretched operator uses.
      * If -1, then stretch arbitrarily, and bbox gives the actual height, depth, width
      */
     public size: number = null;
+
 
     /*
      * @override
@@ -121,6 +128,9 @@ export class CHTMLmo extends CHTMLWrapper {
             this.getStretchedVariant([]);
         }
         let chtml = this.standardCHTMLnode(parent);
+        if (this.noIC) {
+            chtml.setAttribute('noIC', 'true');
+        }
         if (this.stretch && this.size < 0) {
             this.stretchHTML(chtml, symmetric);
         } else {
@@ -196,6 +206,11 @@ export class CHTMLmo extends CHTMLWrapper {
         }
         if (this.stretch && this.size < 0) return;
         super.computeBBox(bbox);
+        const child = this.childNodes[this.childNodes.length-1];
+        if (child && child.bbox.ic) {
+            bbox.ic = child.bbox.ic;
+            if (!this.noIC) bbox.w += bbox.ic;
+        }
         if (symmetric) {
             const d = ((bbox.h + bbox.d) / 2 + this.font.params.axis_height) - bbox.h;
             bbox.h += d;

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -53,6 +53,10 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         },
         'mjx-sqrt > mjx-box': {
             'border-top': '.07em solid'
+        },
+        'mjx-sqrt.mjx-tall > mjx-box': {
+            'padding-left': '.3em',
+            'margin-left': '-.3em'
         }
     };
 
@@ -126,7 +130,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * @override
      */
     public toCHTML(parent: HTMLElement) {
-        const surd = this.childNodes[this.surd];
+        const surd = this.childNodes[this.surd] as CHTMLmo;
         const base = this.childNodes[this.base];
         //
         //  Get the parameters for the spacing of the parts
@@ -153,6 +157,14 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         this.addRoot(ROOT, root, sbox);
         surd.toCHTML(SURD);
         base.toCHTML(BASE);
+        if (surd.size < 0) {
+            //
+            // size < 0 means surd is multi-character.  The angle glyph at the
+            // top is hard to align with the horizontal line, so overlap them
+            // using CSS.
+            //
+            SQRT.classList.add('mjx-tall');
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -50,7 +50,7 @@ export class CHTMLmsub extends CHTMLscriptbase {
      * @override
      */
     protected getOffset(bbox: BBox, sbox: BBox) {
-        return -this.getV(bbox, sbox);
+        return [0, -this.getV(bbox, sbox)];
     }
 
 }
@@ -62,6 +62,8 @@ export class CHTMLmsub extends CHTMLscriptbase {
 
 export class CHTMLmsup extends CHTMLscriptbase {
     public static kind = MmlMsup.prototype.kind;
+
+    public static useIC: boolean = true;
 
     /*
      * @override
@@ -76,7 +78,8 @@ export class CHTMLmsup extends CHTMLscriptbase {
      * @override
      */
     public getOffset(bbox: BBox, sbox: BBox) {
-        return this.getU(bbox, sbox);
+        const x = (this.baseCore.bbox.ic ? .2 * this.baseCore.bbox.ic + .05 : 0);
+        return [x, this.getU(bbox, sbox)];
     }
 
 }
@@ -98,6 +101,8 @@ export class CHTMLmsubsup extends CHTMLscriptbase {
             display: 'block'
         }
     };
+
+    public static noIC: boolean = true;
 
     /*
      *  Cached values for the script offsets and separation (so if they are
@@ -131,6 +136,10 @@ export class CHTMLmsubsup extends CHTMLscriptbase {
         this.sup.toCHTML(stack);
         stack.appendChild(this.html('mjx-spacer', {style: {'margin-top': this.em(q)}}));
         this.sub.toCHTML(stack);
+        const corebox = this.baseCore.bbox;
+        if (corebox.ic) {
+            this.sup.chtml.style.marginLeft = this.em((1.2 * corebox.ic + .05) / this.sup.bbox.rscale);
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -171,8 +171,9 @@ export class CHTMLmsubsup extends CHTMLscriptbase {
         if (this.UVQ) return this.UVQ;
         const tex = this.font.params;
         const t = 3 * tex.rule_thickness;
-        let [u, v] = (this.isCharBase() ? [0, 0] : [this.getU(basebox, supbox),
-                       Math.max(basebox.d + tex.sub_drop * subbox.rscale, tex.sub2)]);
+        const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub2);
+        const drop = (this.isCharBase() ? 0 : basebox.d + tex.sub_drop * subbox.rscale);
+        let [u, v] = [this.getU(basebox, supbox), Math.max(drop, subscriptshift)];
         let q = (u - supbox.d * supbox.rscale) - (subbox.h * subbox.rscale - v);
         if (q < t) {
             v += t - q;

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -173,7 +173,19 @@ export class CHTMLmsubsup extends CHTMLscriptbase {
         const t = 3 * tex.rule_thickness;
         const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub2);
         const drop = (this.isCharBase() ? 0 : basebox.d + tex.sub_drop * subbox.rscale);
+        //
+        // u and v are the veritcal shifts of the scripts, initially set to minimum values and then adjusted
+        //
         let [u, v] = [this.getU(basebox, supbox), Math.max(drop, subscriptshift)];
+        //
+        // q is the space currently between the super- and subscripts.
+        // If it is less than 3 rule thicknesses,
+        //   increase the subscript offset to make the space 3 rule thicknesses
+        //   If the bottom of the superscript is below 4/5 of the x-height
+        //     raise both the super- and subscripts by the difference
+        //     (make the bottom of the superscript be at 4/5 the x-height, and the
+        //      subscript 3 rule thickness below that).
+        //
         let q = (u - supbox.d * supbox.rscale) - (subbox.h * subbox.rscale - v);
         if (q < t) {
             v += t - q;
@@ -183,6 +195,10 @@ export class CHTMLmsubsup extends CHTMLscriptbase {
                 v -= p;
             }
         }
+        //
+        // Make sure the shifts are at least the minimum amounts and
+        // return the shifts and the space between the scripts
+        //
         u = Math.max(this.length2em(this.node.attributes.get('superscriptshift'), u), u);
         v = Math.max(this.length2em(this.node.attributes.get('subscriptshift'), v), v);
         q = (u - supbox.d * supbox.rscale) - (subbox.h * subbox.rscale - v);

--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -29,6 +29,11 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
 import {StyleList} from '../CssStyles.js';
 
+/*
+ * Mutliply italic correction by this much (improve horizontal shift for italic characters)
+ */
+const DELTA = 1.1;
+
 /*****************************************************************/
 /*
  *  The CHTMLmunder wrapper for the MmlMunder object
@@ -36,6 +41,8 @@ import {StyleList} from '../CssStyles.js';
 
 export class CHTMLmunder extends CHTMLmsub {
     public static kind = MmlMunder.prototype.kind;
+
+    public static useIC: boolean = true;
 
     public static styles: StyleList = {
         'mjx-munder:not([limits="false"])': {
@@ -73,8 +80,9 @@ export class CHTMLmunder extends CHTMLmsub {
         const basebox = this.base.getBBox();
         const underbox = this.script.getBBox();
         const [k, v] = this.getUnderKV(basebox, underbox);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
         under.style.paddingTop = this.em(k);
-        this.setDeltaW([base, under], this.getDeltaW([basebox, underbox]));
+        this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -delta]));
     }
 
     /*
@@ -89,7 +97,8 @@ export class CHTMLmunder extends CHTMLmsub {
         const basebox = this.base.getBBox();
         const underbox = this.script.getBBox();
         const [k, v] = this.getUnderKV(basebox, underbox);
-        const [bw, uw] = this.getDeltaW([basebox, underbox]);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
+        const [bw, uw] = this.getDeltaW([basebox, underbox], [0, -delta]);
         bbox.combine(basebox, bw, 0);
         bbox.combine(underbox, uw, v);
         bbox.d += this.font.params.big_op_spacing5;
@@ -105,6 +114,8 @@ export class CHTMLmunder extends CHTMLmsub {
 
 export class CHTMLmover extends CHTMLmsup {
     public static kind = MmlMover.prototype.kind;
+
+    public static useIC: boolean = true;
 
     public static styles: StyleList = {
         'mjx-mover:not([limits="false"])': {
@@ -140,8 +151,9 @@ export class CHTMLmover extends CHTMLmsup {
         const overbox = this.script.getBBox();
         const basebox = this.base.getBBox();
         const [k, u] = this.getOverKU(basebox, overbox);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
         over.style.paddingBottom = this.em(k);
-        this.setDeltaW([base, over], this.getDeltaW([basebox, overbox]));
+        this.setDeltaW([base, over], this.getDeltaW([basebox, overbox], [0, delta]));
         if (overbox.d < 0) {
             over.style.marginBottom = this.em(overbox.d * overbox.rscale);
         }
@@ -159,7 +171,8 @@ export class CHTMLmover extends CHTMLmsup {
         const basebox = this.base.getBBox();
         const overbox = this.script.getBBox();
         const [k, u] = this.getOverKU(basebox, overbox);
-        const [bw, ow] = this.getDeltaW([basebox, overbox]);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
+        const [bw, ow] = this.getDeltaW([basebox, overbox], [0, delta]);
         bbox.combine(basebox, bw, 0);
         bbox.combine(overbox, ow, u);
         bbox.h += this.font.params.big_op_spacing5;
@@ -175,6 +188,8 @@ export class CHTMLmover extends CHTMLmsup {
 
 export class CHTMLmunderover extends CHTMLmsubsup {
     public static kind = MmlMunderover.prototype.kind;
+
+    public static useIC: boolean = true;
 
     public static styles: StyleList = {
         'mjx-munderover:not([limits="false"])': {
@@ -239,9 +254,10 @@ export class CHTMLmunderover extends CHTMLmsubsup {
         const underbox = this.under.getBBox();
         const [ok, u] = this.getOverKU(basebox, overbox);
         const [uk, v] = this.getUnderKV(basebox, underbox);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
         over.style.paddingBottom = this.em(ok);
         under.style.paddingTop = this.em(uk);
-        this.setDeltaW([base, under, over], this.getDeltaW([basebox, underbox, overbox]));
+        this.setDeltaW([base, under, over], this.getDeltaW([basebox, underbox, overbox], [0, -delta, delta]));
         if (overbox.d < 0) {
             over.style.marginBottom = this.em(overbox.d * overbox.rscale);
         }
@@ -261,7 +277,8 @@ export class CHTMLmunderover extends CHTMLmsubsup {
         const underbox = this.under.getBBox();
         const [ok, u] = this.getOverKU(basebox, overbox);
         const [uk, v] = this.getUnderKV(basebox, underbox);
-        const [bw, uw, ow] = this.getDeltaW([basebox, underbox, overbox]);
+        const delta = DELTA * this.baseCore.bbox.ic / 2;
+        const [bw, uw, ow] = this.getDeltaW([basebox, underbox, overbox], [0, -delta, delta]);
         bbox.combine(basebox, bw, 0);
         bbox.combine(overbox, ow, u);
         bbox.combine(underbox, uw, v);

--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -80,9 +80,9 @@ export class CHTMLmunder extends CHTMLmsub {
         const basebox = this.base.getBBox();
         const underbox = this.script.getBBox();
         const [k, v] = this.getUnderKV(basebox, underbox);
-        const delta = DELTA * this.baseCore.bbox.ic / 2;
+        const del = DELTA * this.baseCore.bbox.ic / 2;
         under.style.paddingTop = this.em(k);
-        this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -delta]));
+        this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -del]));
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -25,10 +25,12 @@
  */
 
 import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {CHTMLmo} from './mo.js';
 import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../BBox.js';
-import {StyleList} from '../CssStyles.js';
+import {StyleData, StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
 /*
@@ -38,6 +40,16 @@ import {StyleList} from '../CssStyles.js';
 
 export class CHTMLscriptbase extends CHTMLWrapper {
     public static kind = 'scriptbase';
+
+    /*
+     * Set to true for munderover/munder/mover/msup (Appendix G 13)
+     */
+    public static useIC: boolean = false;
+
+    /*
+     * The core mi or mo of the base (or the base itself if there isn't one)
+     */
+    protected baseCore: CHTMLWrapper;
 
     /*
      * @return{CHTMLWrapper}  The base element's wrapper
@@ -54,6 +66,30 @@ export class CHTMLscriptbase extends CHTMLWrapper {
     }
 
     /*
+     * @override
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        //
+        //  Find the base core
+        //
+        let core = this.baseCore = this.childNodes[0];
+        if (!core) return;
+        while (core.childNodes.length === 1 && (core.node.isKind('mrow') || core.node.isKind('TeXAtom'))) {
+            core = core.childNodes[0];
+            if (!core) return;
+        }
+        if (!('noIC' in core)) return;
+        this.baseCore = core;
+        //
+        //  Check if the base is a mi or mo that needs italic correction removed
+        //
+        if (!(this.constructor as typeof CHTMLscriptbase).useIC) {
+            (core as CHTMLmo).noIC = true;
+        }
+    }
+
+    /*
      * This gives the common output for msub and msup.  It is overriden
      * for all the others (msubsup, munder, mover, munderover).
      *
@@ -61,8 +97,11 @@ export class CHTMLscriptbase extends CHTMLWrapper {
      */
     public toCHTML(parent: HTMLElement) {
         this.chtml = this.standardCHTMLnode(parent);
-        const v = this.getOffset(this.base.getBBox(), this.script.getBBox());
-        const style = {'vertical-align': this.em(v)};
+        const [x, v] = this.getOffset(this.base.getBBox(), this.script.getBBox());
+        const style: StyleData = {'vertical-align': this.em(v)};
+        if (x) {
+            style['margin-left'] = this.em(x);
+        }
         this.base.toCHTML(this.chtml);
         this.script.toCHTML(this.chtml.appendChild(this.html('mjx-script', {style})));
     }
@@ -76,8 +115,9 @@ export class CHTMLscriptbase extends CHTMLWrapper {
     public computeBBox(bbox: BBox) {
         const basebox = this.base.getBBox();
         const scriptbox = this.script.getBBox();
+        const [x, y] = this.getOffset(basebox, scriptbox);
         bbox.append(basebox);
-        bbox.combine(scriptbox, bbox.w, this.getOffset(basebox, scriptbox));
+        bbox.combine(scriptbox, bbox.w + x, y);
         bbox.w += this.font.params.scriptspace;
         bbox.clean();
     }
@@ -105,10 +145,10 @@ export class CHTMLscriptbase extends CHTMLWrapper {
      *
      * @param{BBox} bbox   The bounding box of the base element
      * @param{BBox} sbox   The bounding box of the script element
-     * @return{number}     The vertical offset for the script
+     * @return{number[]}   The horizontal and vertical offsets for the script
      */
     protected getOffset(bbox: BBox, sbox: BBox) {
-        return 0;
+        return [0, 0];
     }
 
     /*
@@ -194,10 +234,21 @@ export class CHTMLscriptbase extends CHTMLWrapper {
      * @param{BBox[]} boxes  The bounding boxes whose offsets are to be computed
      * @param{number[]}      The x offsets of the boxes to center them in a vertical stack
      */
-    protected getDeltaW(boxes: BBox[]) {
+    protected getDeltaW(boxes: BBox[], delta: number[] = [0, 0, 0]) {
         const widths = boxes.map(box => box.w * box.rscale);
         const w = Math.max(...widths);
-        return widths.map(width => (w - width) / 2);
+        const dw = [];
+        let m = 0;
+        for (const i of widths.keys()) {
+            dw[i] = (w - widths[i]) / 2 + delta[i];
+            if (dw[i] < m) m = -dw[i];
+        }
+        if (m) {
+            for (const i of dw.keys()) {
+                dw[i] += m;
+            }
+        }
+        return dw;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -242,7 +242,9 @@ export class CHTMLscriptbase extends CHTMLWrapper {
         let m = 0;
         for (const i of widths.keys()) {
             dw[i] = (w - widths[i]) / 2 + delta[i];
-            if (dw[i] < m) m = -dw[i];
+            if (dw[i] < m) {
+                m = -dw[i];
+            }
         }
         if (m) {
             for (const i of dw.keys()) {

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -232,7 +232,8 @@ export class CHTMLscriptbase extends CHTMLWrapper {
 
     /*
      * @param{BBox[]} boxes  The bounding boxes whose offsets are to be computed
-     * @param{number[]}      The x offsets of the boxes to center them in a vertical stack
+     * @param{number[]}      The initial x offsets of the boxes
+     * @return{number[]}     The actual offsets needed to center the boxes in the stack
      */
     protected getDeltaW(boxes: BBox[], delta: number[] = [0, 0, 0]) {
         const widths = boxes.map(box => box.w * box.rscale);

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -444,8 +444,9 @@ export class TeXFont extends FontData {
         const char = vclass + ' mjx-c[c="' + this.char(n) + '"]';
         styles['.MJX-TEX' + char + '::before'] = css;
         if (options.ic) {
-            styles['.MJX-TEX mjx-mi:not([noIC="true"])' + char.substr(1) + ':last-child::before'] =
-            styles['.MJX-TEX mjx-mo:not([noIC="true"])' + char.substr(1) + ':last-child::before'] = {
+            const [MJX, noIC] = ['.MJX-TEX mjx-', ':not([noIC="true"])' + char.substr(1) + ':last-child::before'];
+            styles[MJX + 'mi' + noIC] =
+            styles[MJX + 'mo' + noIC] = {
                 width: this.em(w + options.ic)
             };
         }

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -441,7 +441,14 @@ export class TeXFont extends FontData {
             }
         }
         if (options.f !== undefined) css['font-family'] = 'MJXZERO, MJXTEX' + (options.f ? '-' + options.f : '');
-        styles['.MJX-TEX' + vclass + ' mjx-c[c="' + this.char(n) + '"]::before'] = css;
+        const char = vclass + ' mjx-c[c="' + this.char(n) + '"]';
+        styles['.MJX-TEX' + char + '::before'] = css;
+        if (options.ic) {
+            styles['.MJX-TEX mjx-mi:not([noIC="true"])' + char.substr(1) + ':last-child::before'] =
+            styles['.MJX-TEX mjx-mo:not([noIC="true"])' + char.substr(1) + ':last-child::before'] = {
+                width: this.em(w + options.ic)
+            };
+        }
     }
 
     /*


### PR DESCRIPTION
This PR adds support for italic correction, based on TeX's rules.  We use the difference between a characters right-bearing and its width as a surrogate for italic-correction (since we don't have the actual TeX metrics for this).

The italic correction is added to the last character in `mi` and `mo` nodes (and should probably be added in `mn` as well, but numbers are usually in roman and so don't have italic correction).  So an `mi` wrapper is added and the `mo` wrapper modified to do that.  The italic correction is added via the CSS.

Italic correction is *not* to be used in some superscript and under-over situations.  So there is CSS set up to remove the italic correction when needed in those cases.

Also, the italic correction is used to properly place super- and subscripts and under-over constructs, as per TeX placement rules.  We adjust the italic correction value in theses cases to more closely match the actual TeX placements (since we don't have the actual TeX values used).