### PR TITLE
Better tall square roots

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -158,6 +158,11 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         surd.toCHTML(SURD);
         base.toCHTML(BASE);
         if (surd.size < 0) {
+            //
+            // size < 0 means surd is multi-character.  The angle glyph at the
+            // top is hard to align with the horizontal line, so overlap them
+            // using CSS.
+            //
             SQRT.classList.add('mjx-tall');
         }
     }

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -53,6 +53,10 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         },
         'mjx-sqrt > mjx-box': {
             'border-top': '.07em solid'
+        },
+        'mjx-sqrt.mjx-tall > mjx-box': {
+            'padding-left': '.3em',
+            'margin-left': '-.3em'
         }
     };
 
@@ -126,7 +130,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
      * @override
      */
     public toCHTML(parent: HTMLElement) {
-        const surd = this.childNodes[this.surd];
+        const surd = this.childNodes[this.surd] as CHTMLmo;
         const base = this.childNodes[this.base];
         //
         //  Get the parameters for the spacing of the parts
@@ -153,6 +157,9 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         this.addRoot(ROOT, root, sbox);
         surd.toCHTML(SURD);
         base.toCHTML(BASE);
+        if (surd.size < 0) {
+            SQRT.classList.add('mjx-tall');
+        }
     }
 
     /*


### PR DESCRIPTION
Make sqrt line overlap with tall surd top corner glyph for better attachment.  Only affects very tall roots that requires multi-character surd.  The top corner has always been difficult to align properly with the overline, and this can improve the look (originally suggested in MathJax issue 1838).