### PR TITLE
Add support for stretchy cells in tables

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -68,7 +68,7 @@ export class CHTMLmo extends CHTMLWrapper {
             width: '100%'
         },
         'mjx-stretchy-h > mjx-ext > mjx-c': {
-            transform: 'scalex(1000)'
+            transform: 'scalex(500)'
         },
         'mjx-stretchy-h > mjx-beg > mjx-c': {
             'margin-right': '-.1em'
@@ -101,7 +101,7 @@ export class CHTMLmo extends CHTMLWrapper {
             overflow: 'hidden'
         },
         'mjx-stretchy-v > mjx-ext > mjx-c': {
-            transform: 'scaleY(1000) translateY(.5em)'
+            transform: 'scaleY(500) translateY(.1em)'
         },
         'mjx-mark': {
             display: 'inline-block',

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -347,8 +347,8 @@ export class CHTMLmo extends CHTMLWrapper {
      * @return{number[]}        The height and depth for the vertically stretched delimiter
      */
     protected getBaseline(WHD: number[], HD: number, C: DelimiterData) {
-        const hasWHD = (WHD.length === 2);
-        const symmetric = (hasWHD && this.node.attributes.get('symmetric'));
+        const hasWHD = (WHD.length === 2 && WHD[0] + WHD[1] === HD);
+        const symmetric = this.node.attributes.get('symmetric');
         const [H, D] = (hasWHD ? WHD : [HD, 0]);
         let [h, d] = [H + D, 0];
         if (symmetric) {
@@ -356,7 +356,7 @@ export class CHTMLmo extends CHTMLWrapper {
             //  Center on the math axis
             //
             const a = this.font.params.axis_height;
-            h = 2 * Math.max(H - a, D + a);
+            if (hasWHD) h = 2 * Math.max(H - a, D + a);
             d = h / 2 - a;
         } else if (hasWHD) {
             //

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -356,7 +356,9 @@ export class CHTMLmo extends CHTMLWrapper {
             //  Center on the math axis
             //
             const a = this.font.params.axis_height;
-            if (hasWHD) h = 2 * Math.max(H - a, D + a);
+            if (hasWHD) {
+                h = 2 * Math.max(H - a, D + a);
+            }
             d = h / 2 - a;
         } else if (hasWHD) {
             //

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -92,7 +92,8 @@ export class CHTMLmtable extends CHTMLWrapper {
             const cell = row.childNodes[i + row.firstCell];
             if (cell) {
                 const child = cell.childNodes[0];
-                if (child.stretch.dir === DIRECTION.None && child.canStretch(DIRECTION.Horizontal)) {
+                if (child.stretch.dir === DIRECTION.None &&
+                    child.canStretch(DIRECTION.Horizontal)) {
                     stretchy.push(child);
                 }
             }
@@ -113,7 +114,9 @@ export class CHTMLmtable extends CHTMLWrapper {
                     const noStretch = (child.stretch.dir === DIRECTION.None);
                     if (all || noStretch) {
                         const {w} = child.getBBox(noStretch);
-                        if (w > W) W = w;
+                        if (w > W) {
+                            W = w;
+                        }
                     }
                 }
             }

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -105,8 +105,12 @@ export class CHTMLmtr extends CHTMLWrapper {
                 const noStretch = (child.stretch.dir === DIRECTION.None);
                 if (all || noStretch) {
                     const {h, d} = child.getBBox(noStretch);
-                    if (h > H) H = h;
-                    if (d > D) D = d;
+                    if (h > H) {
+                        H = h;
+                    }
+                    if (d > D) {
+                        D = d;
+                    }
                 }
             }
             //

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -26,7 +26,9 @@ import {CHTMLWrapper} from '../Wrapper.js';
 import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {BBox} from '../BBox.js';
 import {MmlMtr, MmlMlabeledtr} from '../../../core/MmlTree/MmlNodes/mtr.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../CssStyles.js';
+import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
 /*
@@ -50,10 +52,70 @@ export class CHTMLmtr extends CHTMLWrapper {
     }
 
     /*
+     * @return{number}   The index of the first table cell (overridden in mlabeledtr)
+     */
+    get firstCell() {
+        return 0;
+    }
+
+    /*
      * @return{BBox[]}  An array of the bounding boxes for the mtd's in the row
      */
     public getChildBBoxes() {
         return this.childNodes.map(cell => cell.getBBox());
+    }
+
+    /*
+     * @override
+     * @constructor
+     */
+    constructor(factory: CHTMLWrapperFactory, node: MmlNode, parent: CHTMLWrapper = null) {
+        super(factory, node, parent);
+        this.stretchChildren();
+    }
+
+    /*
+     * Handle vertical stretching of cells to match height of
+     *  other cells in the row.
+     */
+    protected stretchChildren() {
+        let stretchy: CHTMLWrapper[] = [];
+        let children = (this.firstCell ? this.childNodes.slice(this.firstCell) : this.childNodes);
+        //
+        //  Locate and count the stretchy children
+        //
+        for (const mtd of children) {
+            const child = mtd.childNodes[0];
+            if (child.canStretch(DIRECTION.Vertical)) {
+                stretchy.push(child);
+            }
+        }
+        let count = stretchy.length;
+        let nodeCount = this.childNodes.length;
+        if (count && nodeCount > 1) {
+            let H = 0, D = 0;
+            //
+            //  If all the children are stretchy, find the largest one,
+            //  otherwise, find the height and depth of the non-stretchy
+            //  children.
+            //
+            let all = (count > 1 && count === nodeCount);
+            for (const mtd of children) {
+                const child = mtd.childNodes[0];
+                const noStretch = (child.stretch.dir === DIRECTION.None);
+                if (all || noStretch) {
+                    const {h, d} = child.getBBox(noStretch);
+                    if (h > H) H = h;
+                    if (d > D) D = d;
+                }
+            }
+            //
+            //  Stretch the stretchable children
+            //
+            for (const child of stretchy) {
+                child.coreMO().getStretchedVariant([H, D]);
+            }
+        }
     }
 
 }
@@ -94,6 +156,13 @@ export class CHTMLmlabeledtr extends CHTMLWrapper {
         //  Don't include the label mtd
         //
         return Math.max(0, this.childNodes.length - 1);
+    }
+
+    /*
+     * @override
+     */
+    get firstCell() {
+        return 1;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -284,7 +284,7 @@ export class CHTMLscriptbase extends CHTMLWrapper {
             let W = 0;
             //
             //  If all the children are stretchy, find the largest one,
-            //  otherwise, find the width of the non-stretchy  children.
+            //  otherwise, find the width of the non-stretchy children.
             //
             let all = (count > 1 && count === nodeCount);
             for (const child of this.childNodes) {

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -400,9 +400,14 @@ export class TeXFont extends FontData {
      * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterVStyles(styles: StyleList, c: string, data: DelimiterData) {
-        const Hb = this.addDelimiterVPart(styles, c, 'beg', data.stretch[0]);
-        this.addDelimiterVPart(styles, c, 'ext', data.stretch[1]);
-        const He = this.addDelimiterVPart(styles, c, 'end', data.stretch[2]);
+        const [beg, ext, end, mid] = data.stretch;
+        const Hb = this.addDelimiterVPart(styles, c, 'beg', beg);
+        this.addDelimiterVPart(styles, c, 'ext', ext);
+        const He = this.addDelimiterVPart(styles, c, 'end', end);
+        if (mid) {
+            this.addDelimiterVPart(styles, c, 'mid', mid);
+            styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] > mjx-ext'] = {height: '50%'}
+        }
         const css: StyleData = {};
         if (Hb) {
             css['border-top-width'] = this.em0(Hb - .03);
@@ -410,6 +415,11 @@ export class TeXFont extends FontData {
         if (He) {
             css['border-bottom-width'] = this.em0(He - .03);
             css['margin-bottom'] = this.em(-He);
+            if (mid) {
+                styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] > mjx-ext:last-of-type'] = {
+                    'margin-top': this.em(-He)
+                };
+            }
         }
         if (Object.keys(css).length) {
             styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-ext'] = css;
@@ -440,11 +450,12 @@ export class TeXFont extends FontData {
      * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterHStyles(styles: StyleList, c: string, data: DelimiterData) {
-        this.addDelimiterHPart(styles, c, 'beg', data.stretch[0]);
-        this.addDelimiterHPart(styles, c, 'ext', data.stretch[1], !(data.stretch[0] || data.stretch[2]));
-        this.addDelimiterHPart(styles, c, 'end', data.stretch[2]);
-        if (data.stretch[3]) {
-            this.addDelimiterHPart(styles, c, 'mid', data.stretch[3]);
+        const [beg, ext, end, mid] = data.stretch;
+        this.addDelimiterHPart(styles, c, 'beg', beg);
+        this.addDelimiterHPart(styles, c, 'ext', ext, !(beg || end));
+        this.addDelimiterHPart(styles, c, 'end', end);
+        if (mid) {
+            this.addDelimiterHPart(styles, c, 'mid', mid);
             styles['.MJX-TEX mjx-stretchy-h[c="' + c + '"] > mjx-ext'] = {width: '50%'}
         }
     }

--- a/samples/mml-bbox.js
+++ b/samples/mml-bbox.js
@@ -25,7 +25,7 @@ MathJax.handleRetriesFor(function () {
     let chtml = html.options.OutputJax;
     chtml.document = html;
     chtml.math = math;
-    chtml.nodes.document(html.document);
+    chtml.nodes.document = html.document;
     chtml.nodeMap = new Map();
     let wrap = chtml.factory.wrap(math.root);
 


### PR DESCRIPTION
This PR adds support for horizontal and vertical stretchy characters in table cells.  Only rows or columns with actual stretchy characters will have their bounding boxes computed.