### PR TITLE
Fix bbox for msqrt.

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -175,7 +175,7 @@ export class CHTMLmsqrt extends CHTMLWrapper {
         const [p, q] = this.getPQ(sbox);
         const [x] = this.getRootDimens(sbox);
         const t = this.font.params.rule_thickness;
-        const H = bbox.h + q + t;
+        const H = basebox.h + q + t;
         bbox.h = H + t;
         this.combineRootBBox(BBOX, sbox);
         BBOX.combine(sbox, x, H - sbox.h);


### PR DESCRIPTION
This fixes a problem with the bounding box for msqrt.  It didn't take the base bounding box height into account correctly.  (This happened when renaming bounding boxes for Volker's request — I missed one in the renaming.)