### PR TITLE
Fixes HTMLDOMStrings find() for problems with nesting.  Resolves #78.

### DIFF
--- a/mathjax3-ts/handlers/html/HTMLDomStrings.ts
+++ b/mathjax3-ts/handlers/html/HTMLDomStrings.ts
@@ -190,7 +190,7 @@ export class HTMLDomStrings {
      *   Check the class to see if it matches the processClass regex
      *   If the node has a child and is not marked as created by MathJax (data-MJX)
      *       and either it is marked as restarting processing or is not a tag to be skipped, then
-     *     Save the current node and whether we are currently ignoring content
+     *     Save the next node (if there is one) and whether we are currently ignoring content
      *     Move to the first child node
      *     Update whether we are ignoring content
      *   Otherwise
@@ -208,7 +208,9 @@ export class HTMLDomStrings {
         let process = this.processClass.exec(cname);
         if (node.firstChild && !node.getAttribute('data-MJX') &&
             (process || !this.skipTags.exec(tname))) {
-            this.stack.push([node.nextSibling as Element, ignore]);
+            if (node.nextSibling) {
+                this.stack.push([node.nextSibling as Element, ignore]);
+            }
             node = node.firstChild as Element;
             ignore = (ignore || this.ignoreClass.exec(cname)) && !process;
         } else {

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -152,6 +152,7 @@ export class CHTML extends AbstractOutputJax {
      * @override
      */
     public styleSheet(html: MathDocument) {
+        this.nodes.document = html.document;
         //
         // Gather the CSS from the classes
         //


### PR DESCRIPTION
Only push sibling node onto the stack when it exists, and make sure `node.document` is set for stylesheets, even if no typesetting occurred (i.e., not math was found).  Resolves issue #78.