### PR TITLE
Add a mathchoice MmlNode type

### DIFF
--- a/mathjax3-ts/core/MmlTree/MML.ts
+++ b/mathjax3-ts/core/MmlTree/MML.ts
@@ -58,6 +58,7 @@ import {MmlMalignmark}  from './MmlNodes/malignmark.js';
 import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from './MmlNodes/semantics.js';
 
 import {TeXAtom} from './MmlNodes/TeXAtom.js';
+import {mathchoice} from './MmlNodes/mathchoice.js';
 
 /************************************************************************/
 /*
@@ -113,6 +114,7 @@ export let MML: {[kind: string]: MmlNodeClass} = {
     [MmlAnnotationXML.prototype.kind]: MmlAnnotationXML,
 
     [TeXAtom.prototype.kind]: TeXAtom,
+    [mathchoice.prototype.kind]: mathchoice,
 
     [TextNode.prototype.kind]: TextNode,
     [XMLNode.prototype.kind]: XMLNode

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mathchoice.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mathchoice.ts
@@ -1,0 +1,74 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the mathchoice node
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {PropertyList} from '../../Tree/Node.js';
+import {AbstractMmlBaseNode, MmlNode, TEXCLASS, AttributeList} from '../MmlNode.js';
+
+/*****************************************************************/
+/*
+ *  Implements the mathchoice node class (subclass of AbstractMmlBaseNode)
+ *
+ *  This is used by TeX's \mathchoice macro, but removes itself
+ *  during the setInheritedAttributes process
+ */
+
+export class mathchoice extends AbstractMmlBaseNode {
+    public static defaults: PropertyList = {
+        ...AbstractMmlBaseNode.defaults
+    };
+
+    /*
+     *  @return {string}  The mathcoice kind
+     */
+    public get kind() {
+        return 'mathchoice';
+    }
+
+    /*
+     *  @return {number}  4 children (display, text, script, and scriptscript styles)
+     */
+    public get arity() {
+        return 4;
+    }
+
+    /*
+     *  @return {boolean}  This element is not considered a MathML container
+     */
+    public get notParent() {
+        return true;
+    }
+
+    /*
+     * Replace the mathchoice node with the selected on based on the displaystyle and scriptlevel settings
+     * (so the mathchoice never ends up in a finished MmlNode tree)
+     *
+     * @override
+     */
+    setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
+        const selection = (display ? 0 : Math.max(0, Math.min(level, 2)) + 1);
+        const child = this.childNodes[selection] || this.factory.create('mrow');
+        this.parent.replaceChild(child, this);
+        child.setInheritedAttributes(attributes, display, level, prime);
+    }
+
+}


### PR DESCRIPTION
This is an implementation for the `mathchoice` object needed by TeX's `\mathchoice` macro.  This object is only temporary, in that it removes itself from the tree during the finalization of the MmlNode tree leaving only the proper subtree for the TeX class in effect for the node.  This is accomplished during the `setInheritedAttributes()` call on the parent, when the `displaystyle` and `scriptlevel` are being set, as these are what determine the TeX style in effect (displaystyle, text style, scriptstyle, or scriptscriptstyle).