### PR TITLE
Update asynchronous loading

### DIFF
--- a/load.html
+++ b/load.html
@@ -6,9 +6,8 @@
 <script src="lib/system.js"></script>
 <script>
 (function () {
-  var argv = ['browser','load.html'].concat(
-    decodeURI(location.search.substr(1) || 'main.js').split(/&/)
-  );
+  var args = (location.search.substr(1) || 'main.js').split(/&/);
+  var argv = ['browser','load.html'].concat(args.map(x => decodeURIComponent(x)));
   window.process = {argv: argv};
   System.import(argv[2])
     .then(function () {document.body.appendChild(document.createTextNode("Done"))})

--- a/mathjax3-ts/util/AsyncLoad-disabled.ts
+++ b/mathjax3-ts/util/AsyncLoad-disabled.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2017 The MathJax Consortium
+ *  Copyright (c) 2018 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,28 +16,15 @@
  */
 
 /**
- * @fileoverview  Implements asynchronous loading of files
+ * @fileoverview  A disabled version of asyncLoad that always fails
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-declare var System: {import: Function};
-declare function require(name: string): Object;
-
 /*
- * Load a file asynchronously, either using System.js, or node's require().
- *
  * @param{string} name  The name of the file to load
- * @return{Promise}     The promise that is satisfied when the file is loaded
+ * @return{Promise}     The promise that always fails (indicating file not loaded)
  */
 export function asyncLoad(name: string) {
-    if (name.charAt(0) === '.') {
-        name = __dirname + name.replace(/\.\.?/,'/..');
-    }
-    if (typeof(System) !== 'undefined') {
-        return System.import(name);
-    }
-    return new Promise((ok, fail) => {
-        ok(require(name));
-    });
+    return new Promise((ok, fail) => fail());
 }

--- a/mathjax3-ts/util/AsyncLoad.ts
+++ b/mathjax3-ts/util/AsyncLoad.ts
@@ -32,7 +32,7 @@ declare function require(name: string): Object;
  */
 export function asyncLoad(name: string) {
     if (name.charAt(0) === '.') {
-        name = __dirname + name.replace(/\.\.?/,'/..');
+        name = __dirname + name.replace(/^\.\.?/,'/..');
     }
     if (typeof(System) !== 'undefined') {
         return System.import(name);

--- a/mathjax3-ts/util/Entities.ts
+++ b/mathjax3-ts/util/Entities.ts
@@ -543,7 +543,7 @@ export class Entities {
             let loaded = this.loaded;
             if (!loaded[file]) {
                 loaded[file] = true;
-                retryAfter(asyncLoad('mathjax3/util/entities/' + file + '.js'));
+                retryAfter(asyncLoad('./util/entities/' + file + '.js'));
             }
         }
         return match;


### PR DESCRIPTION
This updates the `asyncLoad()` function to work no matter where the `mathjax3` directory is located (so in `v3`, or in `node_modules/mathjax3`, for example).  The path fort he file whose name is passed to `asyncLoad()` is now relative to the `mathjax3` directory (rather than the application directory, as it used to be).

This also provides a "disabled" version of `asyncLoa()` that does not try to load the file but simply reports a failure immediately.  This is for use with webpack, which produced warnings for the current version.  The disabled one is selected in the webpack configuration using

```
        new webpack.NormalModuleReplacementPlugin(
          /\/AsyncLoad\.js/,
          function (resource) {
            resource.request = resource.request.replace(/AsyncLoad/,"AsyncLoad-disabled");
          }
        )
```

in the `plugins` array to switch the file being loaded (when `AsynchLoad.js` is requested) to be the disabled one.