### PR TITLE
Implement more mtable attributes

### DIFF
--- a/lib/Mml-lab.js
+++ b/lib/Mml-lab.js
@@ -26,7 +26,7 @@ const Lab = window.Lab = {
   Typeset() {
     let MML = this.mml.value;
     let math = new LabMathItem(MML,mml);
-    math.setMetrics(16,8,1000000,100000,1);
+    math.setMetrics(16,8,16*20,100000,1);
     math.display = this.display;
     this.jax = math;
 

--- a/lib/TeX-lab.js
+++ b/lib/TeX-lab.js
@@ -26,7 +26,7 @@ const Lab = window.Lab = {
   Typeset() {
     let TeX = this.tex.value;
     let math = new LabMathItem(TeX,tex);
-    math.setMetrics(16,8,1000000,100000,1);
+    math.setMetrics(16,8,16*20,100000,1);
     math.display = this.display;
     this.jax = math;
 

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -47,7 +47,7 @@ export type Location<N, T> = {
 
 /*****************************************************************/
 /*
- *  The Metrics object includes tht data needed to typeset
+ *  The Metrics object includes the data needed to typeset
  *  a Mathitem.
  */
 

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -23,6 +23,7 @@
 
 import {PropertyList, Node} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
+import {split} from '../../../util/string.js';
 
 /*****************************************************************/
 /*
@@ -88,8 +89,7 @@ export class MmlMtable extends AbstractMmlNode {
             columnalign: this.attributes.get('columnalign'),
             rowalign: 'center'
         });
-        const ralign = (this.attributes.get('rowalign') as string)
-                     .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
+        const ralign = split(this.attributes.get('rowalign') as string);
         for (const child of this.childNodes) {
             attributes.rowalign[1] = ralign.shift() || attributes.rowalign[1];
             child.setInheritedAttributes(attributes, display, level, prime);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -84,8 +84,10 @@ export class MmlMtable extends AbstractMmlNode {
             }
         }
         display = !!(this.attributes.getExplicit('displaystyle') || this.attributes.getDefault('displaystyle'));
-        attributes.columnalign = [this.kind, this.attributes.get('columnalign')];
-        attributes.rowalign = [this.kind, 'center'];
+        attributes = this.addInheritedAttributes(attributes, {
+            columnalign: this.attributes.get('columnalign'),
+            rowalign: 'center'
+        });
         const ralign = (this.attributes.get('rowalign') as string)
                      .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
         for (const child of this.childNodes) {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -84,7 +84,14 @@ export class MmlMtable extends AbstractMmlNode {
             }
         }
         display = !!(this.attributes.getExplicit('displaystyle') || this.attributes.getDefault('displaystyle'));
-        super.setChildInheritedAttributes(attributes, display, level, prime);
+        attributes.columnalign = [this.kind, this.attributes.get('columnalign')];
+        attributes.rowalign = [this.kind, 'center'];
+        const ralign = (this.attributes.get('rowalign') as string)
+                     .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
+        for (const child of this.childNodes) {
+            attributes.rowalign[1] = ralign.shift() || attributes.rowalign[1];
+            child.setInheritedAttributes(attributes, display, level, prime);
+        }
     }
 
     /*

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
@@ -24,6 +24,7 @@
 import {PropertyList, Node} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, AttributeList} from '../MmlNode.js';
 import {INHERIT} from '../Attributes.js';
+import {split} from '../../../util/string.js';
 
 /*****************************************************************/
 /*
@@ -64,8 +65,7 @@ export class MmlMtr extends AbstractMmlNode {
                     .appendChild(child);
             }
         }
-        const calign = (this.attributes.get('columnalign') as string)
-                       .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
+        const calign = split(this.attributes.get('columnalign') as string);
         if (this.arity === 1) {
             calign.unshift(this.parent.attributes.get('side') as string);
         }

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
@@ -64,10 +64,15 @@ export class MmlMtr extends AbstractMmlNode {
                     .appendChild(child);
             }
         }
-        attributes.rowalign = [this.kind, this.attributes.get('rowalign')];
-        attributes.columnalign = [this.kind, 'center'];
         const calign = (this.attributes.get('columnalign') as string)
                        .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
+        if (this.arity === 1) {
+            calign.unshift(this.parent.attributes.get('side') as string);
+        }
+        attributes = this.addInheritedAttributes(attributes, {
+            rowalign: this.attributes.get('rowalign'),
+            columnalign: 'center'
+        });
         for (const child of this.childNodes) {
             attributes.columnalign[1] = calign.shift() || attributes.columnalign[1];
             child.setInheritedAttributes(attributes, display, level, prime);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
@@ -64,7 +64,14 @@ export class MmlMtr extends AbstractMmlNode {
                     .appendChild(child);
             }
         }
-        super.setChildInheritedAttributes(attributes, display, level, prime);
+        attributes.rowalign = [this.kind, this.attributes.get('rowalign')];
+        attributes.columnalign = [this.kind, 'center'];
+        const calign = (this.attributes.get('columnalign') as string)
+                       .replace(/^\s+/, '').replace(/\s+$/, '').split(/ +/);
+        for (const child of this.childNodes) {
+            attributes.columnalign[1] = calign.shift() || attributes.columnalign[1];
+            child.setInheritedAttributes(attributes, display, level, prime);
+        }
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -265,7 +265,6 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.handleFrame();
         this.handleWidth();
         this.handleAlign();
-        this.drawBBox();
     }
 
     /******************************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -66,21 +66,6 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         },
         'mjx-mtable[width] > mjx-itable': {
             width: '100%'
-        },
-        'mjx-mtr[rowalign="top"] > mjx-mtd, mjx-mlabeledtr[rowalign="top"] > mjx-mtd': {
-            'vertical-align': 'top'
-        },
-        'mjx-mtr[rowalign="center"] > mjx-mtd, mjx-mlabeledtr[rowalign="center"] > mjx-mtd': {
-            'vertical-align': 'middle'
-        },
-        'mjx-mtr[rowalign="bottom"] > mjx-mtd, mjx-mlabeledtr[rowalign="bottom"] > mjx-mtd': {
-            'vertical-align': 'bottom'
-        },
-        'mjx-mtr[rowalign="baseline"] > mjx-mtd, mjx-mlabeledtr[rowalign="baseline"] > mjx-mtd': {
-            'vertical-align': 'baseline'
-        },
-        'mjx-mtr[rowalign="axis"] > mjx-mtd, mjx-mlabeledtr[rowalign="axis"] > mjx-mtd': {
-            'vertical-align': '.25em'
         }
     };
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -250,7 +250,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         } else {
             height = H.concat(D, this.rLines, this.rSpace).reduce((a, b) => a + b, 0);
         }
-        height += (this.frame ? .14 : 0) + 2 * this.fSpace[1];
+        height += (this.frame ? .14 + 2 * this.fSpace[1] : 0);
         //
         //  Get the widths of all columns (explicit width or computed width)
         //
@@ -261,8 +261,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         //  Get the expected width of the table
         //
         width = CW.concat(this.cLines, this.cSpace).reduce((a, b) => a + b, 0)
-              + (this.frame ? .14 : 0)
-              + 2 * this.fSpace[0];
+              + (this.frame ? .14 + 2 * this.fSpace[0] : 0);
         //
         //  If the table width is not 'auto', determine the specified width
         //    and pick the larger of the specified and computed widths.

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -42,7 +42,7 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
         'mjx-mtd': {
             display: 'table-cell',
             'text-align': 'center',
-            'padding': '.25em .5em'
+            'padding': '.215em .4em'
         },
         'mjx-mtd:first-child': {
             'padding-left': 0
@@ -60,6 +60,12 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
             display: 'inline-block',
             height: '1em',
             'vertical-align': '-.25em'
+        },
+        'mjx-labels[align="left"] > mjx-mtr > mjx-mtd': {
+            'text-align': 'left'
+        },
+        'mjx-labels[align="right"] > mjx-mtr > mjx-mtd': {
+            'text-align': 'right'
         },
         'mjx-mtr mjx-mtd[rowalign="top"], mjx-mlabeledtr mjx-mtd[rowalign="top"]': {
             'vertical-align': 'top'
@@ -89,7 +95,9 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
         if (ralign !== palign) {
             this.adaptor.setAttribute(this.chtml, 'rowalign', ralign);
         }
-        if (calign !== 'center') {
+        if (calign !== 'center' &&
+            (this.parent.kind !== 'mlabeledtr' || this !== this.parent.childNodes[0] ||
+             calign !== this.parent.parent.node.attributes.get('side'))) {
             this.adaptor.setStyle(this.chtml, 'textAlign', calign);
         }
         //

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -68,6 +68,14 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     public toCHTML(parent: N) {
         super.toCHTML(parent);
+        const ralign = this.node.attributes.get('rowalign') as string;
+        const calign = this.node.attributes.get('columnalign') as string;
+        if (ralign !== 'baseline' && ralign !== 'axis') {
+            this.adaptor.setStyle(this.chtml, 'verticalAlign', (ralign === 'center' ? 'middle' : ralign));
+        }
+        if (calign !== 'center') {
+            this.adaptor.setStyle(this.chtml, 'textAlign', calign);
+        }
         //
         // Include a strut to force minimum height and depth
         //

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -60,6 +60,21 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
             display: 'inline-block',
             height: '1em',
             'vertical-align': '-.25em'
+        },
+        'mjx-mtr mjx-mtd[rowalign="top"], mjx-mlabeledtr mjx-mtd[rowalign="top"]': {
+            'vertical-align': 'top'
+        },
+        'mjx-mtr mjx-mtd[rowalign="center"], mjx-mlabeledtr mjx-mtd[rowalign="center"]': {
+            'vertical-align': 'middle'
+        },
+        'mjx-mtr mjx-mtd[rowalign="bottom"], mjx-mlabeledtr mjx-mtd[rowalign="bottom"]': {
+            'vertical-align': 'bottom'
+        },
+        'mjx-mtr mjx-mtd[rowalign="baseline"], mjx-mlabeledtr mjx-mtd[rowalign="baseline"]': {
+            'vertical-align': 'baseline'
+        },
+        'mjx-mtr mjx-mtd[rowalign="axis"], mjx-mlabeledtr mjx-mtd[rowalign="axis"]': {
+            'vertical-align': '.25em'
         }
     };
 
@@ -70,8 +85,9 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
         super.toCHTML(parent);
         const ralign = this.node.attributes.get('rowalign') as string;
         const calign = this.node.attributes.get('columnalign') as string;
-        if (ralign !== 'baseline' && ralign !== 'axis') {
-            this.adaptor.setStyle(this.chtml, 'verticalAlign', (ralign === 'center' ? 'middle' : ralign));
+        const palign = this.parent.node.attributes.get('rowalign') as string;
+        if (ralign !== palign) {
+            this.adaptor.setAttribute(this.chtml, 'rowalign', ralign);
         }
         if (calign !== 'center') {
             this.adaptor.setStyle(this.chtml, 'textAlign', calign);

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -25,6 +25,7 @@
 import {CHTMLWrapper} from '../Wrapper.js';
 import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {CHTMLmtable} from './mtable.js';
+import {CHTMLmtd} from './mtd.js';
 import {BBox} from '../BBox.js';
 import {MmlMtr, MmlMlabeledtr} from '../../../core/MmlTree/MmlNodes/mtr.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
@@ -71,10 +72,25 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /*
-     * @return{number}   The index of the first table cell (overridden in mlabeledtr)
+     * @return{boolean}   True if this is a labeled row
      */
-    get firstCell() {
+    get labeled() {
         return 0;
+    }
+
+    /*
+     * @return{CHTMLmtd[]}  The child nodes that are part of the table (no label node)
+     */
+    get tableCells() {
+        return this.childNodes as CHTMLmtd<N, T, D>[];
+    }
+
+    /*
+     * @param{nunber} i   The index of the child to get (skipping labels)
+     * @return{Wrapper}   The ith child node wrapper
+     */
+    public getChild(i: number) {
+        return this.childNodes[i] as CHTMLmtd<N, T, D>;
     }
 
     /*
@@ -103,7 +119,7 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     public stretchChildren(HD: number[] = null) {
         let stretchy: CHTMLWrapper<N, T, D>[] = [];
-        let children = (this.firstCell ? this.childNodes.slice(this.firstCell) : this.childNodes);
+        let children = (this.labeled ? this.childNodes.slice(1) : this.childNodes);
         //
         //  Locate and count the stretchy children
         //
@@ -213,8 +229,22 @@ export class CHTMLmlabeledtr<N, T, D> extends CHTMLmtr<N, T, D> {
     /*
      * @override
      */
-    get firstCell() {
-        return 1;
+    get labeled() {
+        return true;
+    }
+
+    /*
+     * @override
+     */
+    get tableCells() {
+        return this.childNodes.slice(1) as CHTMLmtd<N, T, D>[];
+    }
+
+    /*
+     * @override
+     */
+    public getChild(i: number) {
+        return this.childNodes[i + 1] as CHTMLmtd<N, T, D>;
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -24,6 +24,7 @@
 
 import {CHTMLWrapper} from '../Wrapper.js';
 import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {CHTMLmtable} from './mtable.js';
 import {BBox} from '../BBox.js';
 import {MmlMtr, MmlMlabeledtr} from '../../../core/MmlTree/MmlNodes/mtr.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
@@ -45,19 +46,19 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
         'mjx-mtr': {
             display: 'table-row',
         },
-        'mjx-mtr[rowalign="top"] > mjx-mtd, mjx-mlabeledtr[rowalign="top"] > mjx-mtd': {
+        'mjx-mtr[rowalign="top"] > mjx-mtd': {
             'vertical-align': 'top'
         },
-        'mjx-mtr[rowalign="center"] > mjx-mtd, mjx-mlabeledtr[rowalign="center"] > mjx-mtd': {
+        'mjx-mtr[rowalign="center"] > mjx-mtd': {
             'vertical-align': 'middle'
         },
-        'mjx-mtr[rowalign="bottom"] > mjx-mtd, mjx-mlabeledtr[rowalign="bottom"] > mjx-mtd': {
+        'mjx-mtr[rowalign="bottom"] > mjx-mtd': {
             'vertical-align': 'bottom'
         },
-        'mjx-mtr[rowalign="baseline"] > mjx-mtd, mjx-mlabeledtr[rowalign="baseline"] > mjx-mtd': {
+        'mjx-mtr[rowalign="baseline"] > mjx-mtd': {
             'vertical-align': 'baseline'
         },
-        'mjx-mtr[rowalign="axis"] > mjx-mtd, mjx-mlabeledtr[rowalign="axis"] > mjx-mtd': {
+        'mjx-mtr[rowalign="axis"] > mjx-mtd': {
             'vertical-align': '.25em'
         }
     };
@@ -157,12 +158,27 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmlabeledtr<N, T, D> extends CHTMLWrapper<N, T, D> {
+export class CHTMLmlabeledtr<N, T, D> extends CHTMLmtr<N, T, D> {
     public static kind = MmlMlabeledtr.prototype.kind;
 
     public static styles: StyleList = {
         'mjx-mlabeledtr': {
             display: 'table-row'
+        },
+        'mjx-mlabeledtr[rowalign="top"] > mjx-mtd': {
+            'vertical-align': 'top'
+        },
+        'mjx-mlabeledtr[rowalign="center"] > mjx-mtd': {
+            'vertical-align': 'middle'
+        },
+        'mjx-mlabeledtr[rowalign="bottom"] > mjx-mtd': {
+            'vertical-align': 'bottom'
+        },
+        'mjx-mlabeledtr[rowalign="baseline"] > mjx-mtd': {
+            'vertical-align': 'baseline'
+        },
+        'mjx-mlabeledtr[rowalign="axis"] > mjx-mtd': {
+            'vertical-align': '.25em'
         }
     };
 
@@ -171,12 +187,16 @@ export class CHTMLmlabeledtr<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     public toCHTML(parent: N) {
         super.toCHTML(parent);
-        //
-        //  FIXME: for now, remove label
-        //
-        const child = this.adaptor.firstChild(this.chtml);
+        const child = this.adaptor.firstChild(this.chtml) as N;
         if (child) {
+            //
+            // Remove label and put it into the labels box inside a row
+            //
             this.adaptor.remove(child);
+            const align = this.node.attributes.get('rowalign') as string;
+            const attr = (align !== 'baseline' && align !== 'axis' ? {rowalign: align} : {});
+            const row = this.html('mjx-mtr', attr, [child]);
+            this.adaptor.append((this.parent as CHTMLmtable<N, T, D>).labels, row);
         }
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -85,15 +85,6 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /*
      * @override
-     * @constructor
-     */
-    constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
-        super(factory, node, parent);
-        this.stretchChildren();
-    }
-
-    /*
-     * @override
      */
     public toCHTML(parent: N) {
         super.toCHTML(parent);
@@ -104,8 +95,12 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     /*
      * Handle vertical stretching of cells to match height of
      *  other cells in the row.
+     *
+     * @param{number[]} HD   The total height and depth for the row [H, D]
+     *
+     * If this isn't specified, the maximum height and depth is computed.
      */
-    protected stretchChildren() {
+    public stretchChildren(HD: number[] = null) {
         let stretchy: CHTMLWrapper<N, T, D>[] = [];
         let children = (this.firstCell ? this.childNodes.slice(this.firstCell) : this.childNodes);
         //
@@ -120,31 +115,34 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
         let count = stretchy.length;
         let nodeCount = this.childNodes.length;
         if (count && nodeCount > 1) {
-            let H = 0, D = 0;
-            //
-            //  If all the children are stretchy, find the largest one,
-            //  otherwise, find the height and depth of the non-stretchy
-            //  children.
-            //
-            let all = (count > 1 && count === nodeCount);
-            for (const mtd of children) {
-                const child = mtd.childNodes[0];
-                const noStretch = (child.stretch.dir === DIRECTION.None);
-                if (all || noStretch) {
-                    const {h, d} = child.getBBox(noStretch);
-                    if (h > H) {
-                        H = h;
-                    }
-                    if (d > D) {
-                        D = d;
+            if (HD === null) {
+                let H = 0, D = 0;
+                //
+                //  If all the children are stretchy, find the largest one,
+                //  otherwise, find the height and depth of the non-stretchy
+                //  children.
+                //
+                let all = (count > 1 && count === nodeCount);
+                for (const mtd of children) {
+                    const child = mtd.childNodes[0];
+                    const noStretch = (child.stretch.dir === DIRECTION.None);
+                    if (all || noStretch) {
+                        const {h, d} = child.getBBox(noStretch);
+                        if (h > H) {
+                            H = h;
+                        }
+                        if (d > D) {
+                            D = d;
+                        }
                     }
                 }
+                HD = [H, D];
             }
             //
             //  Stretch the stretchable children
             //
             for (const child of stretchy) {
-                child.coreMO().getStretchedVariant([H, D]);
+                child.coreMO().getStretchedVariant(HD);
             }
         }
     }

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -44,6 +44,21 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static styles: StyleList = {
         'mjx-mtr': {
             display: 'table-row',
+        },
+        'mjx-mtr[rowalign="top"] > mjx-mtd, mjx-mlabeledtr[rowalign="top"] > mjx-mtd': {
+            'vertical-align': 'top'
+        },
+        'mjx-mtr[rowalign="center"] > mjx-mtd, mjx-mlabeledtr[rowalign="center"] > mjx-mtd': {
+            'vertical-align': 'middle'
+        },
+        'mjx-mtr[rowalign="bottom"] > mjx-mtd, mjx-mlabeledtr[rowalign="bottom"] > mjx-mtd': {
+            'vertical-align': 'bottom'
+        },
+        'mjx-mtr[rowalign="baseline"] > mjx-mtd, mjx-mlabeledtr[rowalign="baseline"] > mjx-mtd': {
+            'vertical-align': 'baseline'
+        },
+        'mjx-mtr[rowalign="axis"] > mjx-mtd, mjx-mlabeledtr[rowalign="axis"] > mjx-mtd': {
+            'vertical-align': '.25em'
         }
     };
 
@@ -83,9 +98,7 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     public toCHTML(parent: N) {
         super.toCHTML(parent);
         const align = this.node.attributes.get('rowalign') as string;
-        if (align !== 'baseline' && align !== 'axis') {
-            this.adaptor.setStyle(this.chtml, 'verticalAlign', (align === 'center' ? 'middle' : align));
-        }
+        this.adaptor.setAttribute(this.chtml, 'rowalign', align);
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -78,6 +78,17 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /*
+     * @override
+     */
+    public toCHTML(parent: N) {
+        super.toCHTML(parent);
+        const align = this.node.attributes.get('rowalign') as string;
+        if (align !== 'baseline' && align !== 'axis') {
+            this.adaptor.setStyle(this.chtml, 'verticalAlign', (align === 'center' ? 'middle' : align));
+        }
+    }
+
+    /*
      * Handle vertical stretching of cells to match height of
      *  other cells in the row.
      */

--- a/mathjax3-ts/util/numeric.ts
+++ b/mathjax3-ts/util/numeric.ts
@@ -1,0 +1,40 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements some numeric utility functions
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+/*
+ * @param{number[]} A  The array to sum
+ * @return{number}     The summ of the elements in A
+ */
+export function sum(A: number[]) {
+    return A.reduce((a, b) => a + b, 0);
+}
+
+/*
+ * @param{number[]} A  The array whose maximum entry is sought
+ * @return{number}     The largest entry in the array
+ */
+export function max(A: number[]) {
+    return A.reduce((a, b) => Math.max(a, b), 0);
+}
+
+

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -59,3 +59,24 @@ export function unicodeChars(text: string) {
     }
     return unicode;
 }
+
+/*
+ * Test if a value is a percentage
+ *
+ * @param{string} x   The string to test
+ * @return{boolean}   True if the string ends with a percent sign
+ */
+export function isPercent(x: string) {
+    return x.match(/%\s*$/);
+}
+
+/*
+ * Split a space-separated string of values
+ *
+ * @param{string} x   The string to be split
+ * @return{string[]}  The list of white-space-separated "words" in the string
+ */
+export function split(x: string) {
+    return x.trim().split(/\s+/);
+}
+


### PR DESCRIPTION
This PR implements a number of previously unimplemented attributes for `mtable` elements, including `equalrows`, `equalcolumns`, `columnwidth` and `align`, with improvements to `rowalign` and `columnalign`.  This required some reorganization (which I think is an improvement anyway), so there are some pieces being moved around and indentation changes that might make it look like more changes than are actually significant ones.

The `mtable.js` file has the most changes, but it is not being displayed by default, so you will have to open that by hand.

There are some changes to the `core/MmlTree/MmlNodes` for `mtable` and `mtr` to get some of the inheritance working for `rowalign` and `columnalign`.  I also changed the labs to set the container width to something more reasonable (20em, since the font size is pumped up).  This affects the width computation for percentage-width rows (but since 20em isn't exact, neither is that width).  

Alignment has been pushed into the `mtr` and `mtd` objects, by and large.  The `mtable` also now caches more values (like the row and column spacing, row and column lines, requested column widths, and, when needed, the row height and depth, and the computed column widths).  There are also now separate routines for computing some of these (the `H`, `D`, `W` arrays of maximum height, depth, and width of the rows and columns, for example, were computed in `computeBBox()`, but are not in a separate `getTableData()` function, which caches the results so they are only computed once.  That makes some of the changes a little harder to see, I'm afraid.

The mtable element is one of the most complicated of the ones implemented in MathJax.  The `columnwidth` handling is particularly complicated since the table width can be automatic, fixed, or a percentage, and the column widths can be fixed, auto, percentages, or "fit", and the interactions of those provide a lot of individual cases.  Then there is `equalcolumns` to worry about.  Similarly, `equalrows` complicates the computations of the table height and `align` positions when the alignment is for an individual row (e.g., `align="baseline 3"` for the baseline of the third row).

If you have questions, let me know.