### PR TITLE
Implement remaining mfrac attributes

### DIFF
--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -23,7 +23,7 @@
 
 import {AbstractWrapper} from '../../core/Tree/Wrapper.js';
 import {Node, PropertyList} from '../../core/Tree/Node.js';
-import {MmlNode, TextNode, AbstractMmlNode} from '../../core/MmlTree/MmlNode.js';
+import {MmlNode, TextNode, AbstractMmlNode, AttributeList} from '../../core/MmlTree/MmlNode.js';
 import {Property} from '../../core/Tree/Node.js';
 import {OptionList} from '../../util/Options.js';
 import {unicodeChars} from '../../util/string.js';
@@ -770,6 +770,29 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      */
     public mmlNode(kind: string, properties: PropertyList = {}, children: MmlNode[] = []) {
         return (this.node as AbstractMmlNode).factory.create(kind, properties, children);
+    }
+
+    /*
+     * Create an mo wrapper with the given text,
+     *   link it in, and give it the right defaults.
+     *
+     * @param{string} text  The text for the wrapped element
+     * @return{CHTMLWrapper}  The wrapped MmlMo node
+     */
+    protected createMo(text: string): CHTMLmo<N, T, D> {
+        const mmlFactory = (this.node as AbstractMmlNode).factory;
+        const textNode = (mmlFactory.create('text') as TextNode).setText(text);
+        const mml = mmlFactory.create('mo', {stretchy: true}, [textNode]);
+        const attributes = this.node.attributes;
+        const display = attributes.get('display') as boolean;
+        const scriptlevel = attributes.get('scriptlevel') as number;
+        const defaults: AttributeList = {
+            mathsize: ['math', attributes.get('mathsize')]
+        };
+        mml.setInheritedAttributes(defaults, display, scriptlevel, false);
+        const node = this.wrap(mml) as CHTMLmo<N, T, D>;
+        node.parent = this;
+        return node;
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -75,10 +75,10 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         },
 
         'mjx-den[align="right"], mjx-num[align="right"]': {
-            align: 'right'
+            'text-align': 'right'
         },
         'mjx-den[align="left"], mjx-num[align="left"]': {
-            align: 'left'
+            'text-align': 'left'
         },
 
         'mjx-nstrut': {
@@ -120,17 +120,20 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     public toCHTML(parent: N) {
         const chtml = this.standardCHTMLnode(parent);
-        const attr = this.node.attributes.getList('displaystyle', 'scriptlevel');
-        const style = (attr.displaystyle && attr.scriptlevel === 0 ? {type: 'd'} : {});
-        const fstyle = (this.node.getProperty('withDelims') ? {...style, delims: 'true'} : style);
+        const {displaystyle, scriptlevel, numalign, denomalign, withDelims}
+            = this.node.attributes.getList('displaystyle', 'scriptlevel', 'numalign', 'denomalign', 'withDelims');
+        const attr = (displaystyle && scriptlevel === 0 ? {type: 'd'} : {});
+        const fattr = (withDelims ? {...attr, delims: 'true'} : attr);
+        const nattr = (numalign !== 'center' ? {align: numalign} : {});
+        const dattr = (denomalign !== 'center' ? {align: denomalign} : {});
         let num, den;
-        this.adaptor.append(chtml, this.html('mjx-frac', fstyle, [
-            num = this.html('mjx-num', {}, [this.html('mjx-nstrut', style)]),
+        this.adaptor.append(chtml, this.html('mjx-frac', fattr, [
+            num = this.html('mjx-num', nattr, [this.html('mjx-nstrut', attr)]),
             this.html('mjx-dbox', {}, [
                 this.html('mjx-dtable', {}, [
-                    this.html('mjx-line', style),
+                    this.html('mjx-line', attr),
                     this.html('mjx-row', {}, [
-                        den = this.html('mjx-den', {}, [this.html('mjx-dstrut', style)])
+                        den = this.html('mjx-den', dattr, [this.html('mjx-dstrut', attr)])
                     ])
                 ])
             ])

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -26,7 +26,7 @@ import {CHTMLWrapperFactory} from '../WrapperFactory.js';
 import {CHTMLmo} from './mo.js';
 import {BBox} from '../BBox.js';
 import {MmlMsqrt} from '../../../core/MmlTree/MmlNodes/msqrt.js';
-import {MmlNode, AbstractMmlNode, TextNode, AttributeList} from '../../../core/MmlTree/MmlNode.js';
+import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../CssStyles.js';
 import {DIRECTION} from '../FontData.js';
 
@@ -106,25 +106,10 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /*
-     * Create an mo wrapper with the given text,
-     *   link it in, and give it the right defaults.
-     *
-     * @param{string} text  The text for the wrapped element
-     * @return{CHTMLWrapper}  The wrapped MmlMo node
+     * @override
      */
     protected createMo(text: string) {
-        const mmlFactory = (this.node as AbstractMmlNode).factory;
-        const textNode = (mmlFactory.create('text') as TextNode).setText(text);
-        const mml = mmlFactory.create('mo', {stretchy: true}, [textNode]);
-        const attributes = this.node.attributes;
-        const display = attributes.get('display') as boolean;
-        const scriptlevel = attributes.get('scriptlevel') as number;
-        const defaults: AttributeList = {
-            mathsize: ['math', attributes.get('mathsize')]
-        };
-        mml.setInheritedAttributes(defaults, display, scriptlevel, false);
-        const node = this.wrap(mml) as CHTMLmo<N, T, D>;
-        node.parent = this;
+        const node = super.createMo(text);
         this.childNodes.push(node);
         return node;
     }


### PR DESCRIPTION
This PR finishes the CommonHTML output for `mfrac`.  It implements the `bevelled` attribute, implements `linethickness`, and in particular support for `linethickness="0"` which requires a different layout (in the TeXBook appendix G), and adds support for `numalign` and `denomalign` attributes.

As a side effect, the `createMo()` method has been moved from `msqrt.ts` to the base `Wrapper.ts` file, since it is needed for the bevelled fractions, and will be needed for `mfenced` in the future.