### PR TITLE
Fix problem with \xrightarrow not stretching.

### DIFF
--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -337,6 +337,18 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         bbox.clean();
     }
 
+    /*
+     * Mark BBox to be computed again (e.g., when an mo has stretched)
+     */
+    public invalidateBBox() {
+        if (this.bboxComputed) {
+            this.bboxComputed = false;
+            if (this.parent) {
+                this.parent.invalidateBBox();
+            }
+        }
+    }
+
     /*******************************************************************/
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -248,6 +248,9 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
      * @override
      */
     public canStretch(direction: DIRECTION) {
+        if (this.stretch.dir !== DIRECTION.None) {
+            return this.stretch.dir === direction;
+        }
         const attributes = this.node.attributes;
         if (!attributes.get('stretchy')) return false;
         const c = this.getText();

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -300,6 +300,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
             //
             if (delim.stretch) {
                 this.size = -1;
+                this.invalidateBBox();
                 this.getStretchBBox(WH, D, delim);
             } else {
                 this.variant = this.font.getSizeVariant(c, i - 1);

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -74,6 +74,9 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         'mjx-stretchy-h > mjx-ext > mjx-c': {
             transform: 'scalex(500)'
         },
+        'mjx-stretchy-h > mjx-ext > mjx-c::before': {
+            padding: '.001em 0'                  // for blink
+        },
         'mjx-stretchy-h > mjx-beg > mjx-c': {
             'margin-right': '-.1em'
         },

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -296,8 +296,8 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
             for (const child of this.childNodes) {
                 const noStretch = (child.stretch.dir === DIRECTION.None);
                 if (all || noStretch) {
-                    const {w} = child.getBBox(noStretch);
-                    if (w > W) W = w;
+                    const {w, rscale} = child.getBBox(noStretch);
+                    if (w * rscale > W) W = w * rscale;
                 }
             }
             //


### PR DESCRIPTION
This fixes the problem with `\xrightarrow` not stretching reported by Volker.  This was due to the `<mo>` being asked to stretchy both horizontally (by the `<munderover>`) and vertically (by the enclosing `<mrow>`, since it is an embellished operator in that row).

The resolution is to only allow stretching in one direction (since we don't support bi-directional stretching), that being the first direction for which stretching was requested and possible.

This also properly scales the maximum width computations in `munderover` so the size of the arrow is correct.