### PR TITLE
Add support for mglyph

### DIFF
--- a/mathjax3-ts/core/MmlTree/MML.ts
+++ b/mathjax3-ts/core/MmlTree/MML.ts
@@ -55,6 +55,8 @@ import {MmlMtd}         from './MmlNodes/mtd.js';
 import {MmlMaligngroup} from './MmlNodes/maligngroup.js';
 import {MmlMalignmark}  from './MmlNodes/malignmark.js';
 
+import {MmlMglyph}      from './MmlNodes/mglyph.js';
+
 import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from './MmlNodes/semantics.js';
 
 import {TeXAtom} from './MmlNodes/TeXAtom.js';
@@ -108,6 +110,8 @@ export let MML: {[kind: string]: MmlNodeClass} = {
     [MmlMtd.prototype.kind]: MmlMtd,
     [MmlMaligngroup.prototype.kind]: MmlMaligngroup,
     [MmlMalignmark.prototype.kind]: MmlMalignmark,
+
+    [MmlMglyph.prototype.kind]: MmlMglyph,
 
     [MmlSemantics.prototype.kind]: MmlSemantics,
     [MmlAnnotation.prototype.kind]: MmlAnnotation,

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mglyph.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mglyph.ts
@@ -29,7 +29,7 @@ import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
  *  Implements the MmlMglyph node class (subclass of AbstractMmlTokenNode)
  */
 
-export class MmlMi extends AbstractMmlTokenNode {
+export class MmlMglyph extends AbstractMmlTokenNode {
     public static defaults: PropertyList = {
         ...AbstractMmlTokenNode.defaults,
         alt: '',

--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -38,6 +38,7 @@ import {CHTMLmover, CHTMLmunder, CHTMLmunderover} from './Wrappers/munderover.js
 import {CHTMLmtable} from './Wrappers/mtable.js';
 import {CHTMLmtr, CHTMLmlabeledtr} from './Wrappers/mtr.js';
 import {CHTMLmtd} from './Wrappers/mtd.js';
+import {CHTMLmglyph} from './Wrappers/mglyph.js';
 import {CHTMLsemantics, CHTMLannotation, CHTMLannotationXML, CHTMLxml} from './Wrappers/semantics.js';
 import {CHTMLTeXAtom} from './Wrappers/TeXAtom.js';
 import {CHTMLTextNode} from './Wrappers/TextNode.js';
@@ -65,6 +66,7 @@ export const CHTMLWrappers: {[kind: string]: typeof CHTMLWrapper}  = {
     [CHTMLmtr.kind]: CHTMLmtr,
     [CHTMLmlabeledtr.kind]: CHTMLmlabeledtr,
     [CHTMLmtd.kind]: CHTMLmtd,
+    [CHTMLmglyph.kind]: CHTMLmglyph,
     [CHTMLsemantics.kind]: CHTMLsemantics,
     [CHTMLannotation.kind]: CHTMLannotation,
     [CHTMLannotationXML.kind]: CHTMLannotationXML,

--- a/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
@@ -93,7 +93,6 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
         const img = this.html('img', {src: src, style: styles, alt: alt, title: alt});
         this.adaptor.append(chtml, img);
-        this.drawBBox();
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
@@ -65,7 +65,7 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /*
-     * Obtain the widt, height, and voffset.
+     * Obtain the width, height, and voffset.
      * Note:  Currently, the width and height must be specified explicitly, or they default to 1em
      *   Since loading the image may be asynchronous, it would require a restart.
      *   A future extension could implement this either by subclassing this object, or

--- a/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
@@ -1,0 +1,108 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmglyph wrapper for the MmlMglyph object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper, StringMap} from '../Wrapper.js';
+import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {BBox} from '../BBox.js';
+import {MmlMglyph} from '../../../core/MmlTree/MmlNodes/mglyph.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {Property} from '../../../core/Tree/Node.js';
+import {StyleList, StyleData} from '../CssStyles.js';
+
+/*****************************************************************/
+/*
+ * The CHTMLmglyph wrapper for the MmlMglyph object
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
+    public static kind = MmlMglyph.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-mglyph > img': {
+            display: 'inline-block',
+            border: 0,
+            padding: 0
+        }
+    };
+
+    /*
+     * The image's width, height, and voffset values converted to em's
+     */
+    public width: number;
+    public height: number;
+    public voffset: number;
+
+    /*
+     * @override
+     * @constructor
+     */
+    constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
+        super(factory, node, parent);
+        this.getParameters();
+    }
+
+    /*
+     * Obtain the widt, height, and voffset.
+     * Note:  Currently, the width and height must be specified explicitly, or they default to 1em
+     *   Since loading the image may be asynchronous, it would require a restart.
+     *   A future extension could implement this either by subclassing this object, or
+     *   perhaps as a post-filter on the MathML input jax that adds the needed dimensions
+     */
+    protected getParameters() {
+        const {width, height, voffset} = this.node.attributes.getList('width', 'height', 'voffset');
+        this.width = (width === 'auto' ? 1 : this.length2em(width));
+        this.height = (height === 'auto' ? 1 : this.length2em(height));
+        this.voffset = this.length2em(voffset || '0');
+    }
+
+    /*
+     * @override
+     */
+    public toCHTML(parent: N) {
+        const chtml = this.standardCHTMLnode(parent);
+        const {src, alt} = this.node.attributes.getList('src', 'alt');
+        const styles: StyleData = {
+            width: this.em(this.width),
+            height: this.em(this.height)
+        };
+        if (this.voffset) {
+            styles.verticalAlign = this.em(-this.voffset);
+        }
+        const img = this.html('img', {src: src, style: styles, alt: alt, title: alt});
+        this.adaptor.append(chtml, img);
+        this.drawBBox();
+    }
+
+    /*
+     * @override
+     */
+    public computeBBox(bbox: BBox) {
+        bbox.w = this.width;
+        bbox.h = this.height - this.voffset;
+        bbox.d = this.voffset;
+    }
+
+}


### PR DESCRIPTION
This PR adds preliminary support for mglyph elements.

Currently, you need to give explicit `width` and `height` attributes (they default to `1em` otherwise), because loading images may be asynchronous, and for node-based use, you might want to read from files rather than from the network to find the images, so that would require additional configuration and name mapping.  I'm going to leave those for future extensions.