### PR TITLE
Update to work with node 10's esm module rather than system.js

### DIFF
--- a/load.mjs
+++ b/load.mjs
@@ -1,0 +1,2 @@
+require = require("esm")(module/*, options*/)
+module.exports = require('./' + (process.argv[2] || 'main.js'));

--- a/mathjax2/legacy/extensions/TeX/AMSmath.js
+++ b/mathjax2/legacy/extensions/TeX/AMSmath.js
@@ -24,9 +24,9 @@
  *  limitations under the License.
  */
 
-let sm = require('mathjax3/input/tex/SymbolMap.js');
-let tc = require('mathjax3/input/tex/TexConstants.js');
-let BaseMethods = require('mathjax3/input/tex/BaseMethods.js').default;
+let sm = require('../../../../mathjax3/input/tex/SymbolMap.js');
+let tc = require('../../../../mathjax3/input/tex/TexConstants.js');
+let BaseMethods = require('../../../../mathjax3/input/tex/BaseMethods.js').default;
 
 
 MathJax.Extension["TeX/AMSmath"] = {

--- a/mathjax2/legacy/extensions/TeX/AMSsymbols.js
+++ b/mathjax2/legacy/extensions/TeX/AMSsymbols.js
@@ -24,9 +24,9 @@
  *  limitations under the License.
  */
 
-let sm = require('mathjax3/input/tex/SymbolMap.js');
-let tc = require('mathjax3/input/tex/TexConstants.js');
-let BaseMethods = require('mathjax3/input/tex/BaseMethods.js').default;
+let sm = require('../../../../mathjax3/input/tex/SymbolMap.js');
+let tc = require('../../../../mathjax3/input/tex/TexConstants.js');
+let BaseMethods = require('../../../../mathjax3/input/tex/BaseMethods.js').default;
 
 
 MathJax.Extension["TeX/AMSsymbols"] = {

--- a/mathjax2/legacy/jax/input/TeX/jax.js
+++ b/mathjax2/legacy/jax/input/TeX/jax.js
@@ -27,8 +27,8 @@
  */
 
 
-let MapHandler = require('mathjax3/input/tex/MapHandler.js').default;
-let TeXParser = require('mathjax3/input/tex/TexParser.js').default;
+let MapHandler = require('../../../../../mathjax3/input/tex/MapHandler.js').default;
+let TeXParser = require('../../../../../mathjax3/input/tex/TexParser.js').default;
 
 (function (TEX,HUB,AJAX) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,11 @@
         "is-symbol": "1.0.1"
       }
     },
+    "esm": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.34.tgz",
+      "integrity": "sha512-napl1sk7uu4ULhGVWVGIleN2G1TpURvfq5+ALLSc1V4jXcbftCtV8RIOkHw46UnLtzw3xIZgMES39f6N75JhtA=="
+    },
     "findup-sync": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,7 @@
     "AsciiMath"
   ],
   "license": "Apache-2.0",
-  "dependencies": {}
+  "dependencies": {
+    "esm": "^3.0.34"
+  }
 }


### PR DESCRIPTION
This PR adds a `load.mjs` file that will trigger node's esm module (in version 10+) so that ES6 files can be loaded directly into node without the need of `system.js`.  That is, you can use `import` and `export` directly without down compiling.  I tested it with the `ES6` target for Typescript, and it works nicely, though I haven't changed that in this PR.  The only real changes needed was to make sure the imports use relative file names rather than root-level filenames.