### PR TITLE
Scale math to match surrounding text

### DIFF
--- a/mathjax3-ts/adaptors/HTMLAdaptor.ts
+++ b/mathjax3-ts/adaptors/HTMLAdaptor.ts
@@ -60,6 +60,8 @@ export interface MinHTMLElement<N, T> {
     parentNode: N | Node;
     nextSibling: N | T | Node;
     previousSibling: N | T | Node;
+    offsetWidth: number;
+    offsetHeight: number;
 
     attributes: AttributeData[] | NamedNodeMap;
     classList: DOMTokenList;
@@ -118,9 +120,10 @@ export interface MinDOMParser<D> {
  */
 
 /*
+ * @template N  The HTMLElement node class
  * @template D  The Document class
  */
-export interface MinWindow<D> {
+export interface MinWindow<N, D> {
     document: D;
     DOMParser: {
         new(): MinDOMParser<D>
@@ -130,6 +133,7 @@ export interface MinWindow<D> {
     HTMLElement: any;
     DocumentFragment: any;
     Document: any;
+    getComputedStyle(node: N): any;
 }
 
 /*****************************************************************/
@@ -143,7 +147,7 @@ export interface MinWindow<D> {
  * @template D  The Document class
  */
 export interface MinHTMLAdaptor<N, T, D> extends DOMAdaptor<N, T, D> {
-    window: MinWindow<D>
+    window: MinWindow<N, D>
 }
 
 /*****************************************************************/
@@ -168,7 +172,7 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
     /*
      * The window object for this adaptor
      */
-    window: MinWindow<D>;
+    window: MinWindow<N, D>;
 
     /*
      * The DOMParser used to parse a string into a DOM tree
@@ -179,7 +183,7 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
      * @override
      * @constructor
      */
-    constructor(window: MinWindow<D>) {
+    constructor(window: MinWindow<N, D>) {
         super(window.document);
         this.window = window;
         this.parser = new (window.DOMParser as any)();
@@ -462,4 +466,18 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         return node.style.cssText;
     }
 
+    /*
+     * @override
+     */
+    public fontSize(node: N) {
+        const style = this.window.getComputedStyle(node);
+        return parseFloat(style.fontSize);
+    }
+
+    /*
+     * @override
+     */
+    public nodeSize(node: N) {
+        return [node.offsetWidth, node.offsetHeight] as [number, number];
+    }
 }

--- a/mathjax3-ts/adaptors/liteAdaptor.ts
+++ b/mathjax3-ts/adaptors/liteAdaptor.ts
@@ -29,12 +29,25 @@ import {LiteList} from './lite/List.js';
 import {LiteWindow} from './lite/Window.js';
 import {LiteParser} from './lite/Parser.js';
 import {Styles} from '../util/Styles.js';
+import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
 
 /************************************************************/
 /*
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
 export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocument> {
+    /*
+     * The default options
+     */
+    public static OPTIONS: OptionList = {
+        fontSize: 16,      // we can't compute the font size, so always use this
+    };
+
+    /*
+     * The options for the instance
+     */
+    public options: OptionList;
+
     /*
      * The document in which the HTML nodes will be created
      */
@@ -43,16 +56,19 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     /*
      * The window for the document
      */
-    public window: LiteWindow = new LiteWindow();
+    public window: LiteWindow;
 
     /*
      * The parser for serialized HTML
      */
     public parser: LiteParser;
 
-    constructor() {
+    constructor(options: OptionList = null) {
         super();
+        let CLASS = this.constructor as typeof LiteAdaptor;
+        this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
         this.parser = new LiteParser();
+        this.window = new LiteWindow();
     }
 
     /*
@@ -499,12 +515,27 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     public allStyles(node: LiteElement) {
         return this.getAttribute(node, 'style');
     }
+
+    /*
+     * @override
+     */
+    public fontSize(node: LiteElement) {
+        return this.options.fontSize;
+    }
+
+    /*
+     * @override
+     */
+    public nodeSize(node: LiteElement) {
+        return [0, 0] as [number, number];
+    }
+
 }
 
 /************************************************************/
 /*
  * The function to call to obtain a LiteAdaptor
  */
-export function liteAdaptor() {
-    return new LiteAdaptor();
+export function liteAdaptor(options: OptionList = null) {
+    return new LiteAdaptor(options);
 }

--- a/mathjax3-ts/core/DOMAdaptor.ts
+++ b/mathjax3-ts/core/DOMAdaptor.ts
@@ -293,6 +293,18 @@ export interface DOMAdaptor<N, T, D> {
      * @return{string}       The cssText for the styles
      */
     allStyles(node: N): string;
+
+    /*
+     * @param{N} node        The HTML node whose font size is to be determined
+     * @return{number}       The font size (in pixels) of the node
+     */
+    fontSize(node: N): number;
+
+    /*
+     * @param{N} node        The HTML node whose dimensions are to be determined
+     * @return{number}       The width and height (in pixels) of the element
+     */
+    nodeSize(node: N): [number, number];
 }
 
 /*****************************************************************/
@@ -554,5 +566,15 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
      * @override
      */
     public abstract allStyles(node: N): string;
+
+    /*
+     * @override
+     */
+    public abstract fontSize(node: N): number;
+
+    /*
+     * @override
+     */
+    public abstract nodeSize(node: N): [number, number];
 
 }

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -48,7 +48,7 @@ export type Location<N, T> = {
 /*****************************************************************/
 /*
  *  The Metrics object includes the data needed to typeset
- *  a Mathitem.
+ *  a MathItem.
  */
 
 export type Metrics = {

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -24,7 +24,7 @@
 import {AbstractOutputJax} from '../core/OutputJax.js';
 import {OptionList, separateOptions} from '../util/Options.js';
 import {MathDocument} from '../core/MathDocument.js';
-import {MathItem} from '../core/MathItem.js';
+import {MathItem, Metrics} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {CHTMLWrapper} from './chtml/Wrapper.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
@@ -34,6 +34,15 @@ import {CssStyles} from './chtml/CssStyles.js';
 import {percent} from '../util/lengths.js';
 import {BBox} from './chtml/BBox.js';
 
+
+/*****************************************************************/
+
+/*
+ * Maps linking a node to the test node it contains,
+ *  and a map linking a node to the metrics within that node.
+ */
+export type MetricMap<N> = Map<N, Metrics>;
+type MetricDomMap<N> = Map<N, N>;
 
 /*****************************************************************/
 /*
@@ -52,6 +61,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         ...AbstractOutputJax.OPTIONS,
         scale: 1,                      // Global scaling factor for all expressions
         skipAttributes: {},            // RFDa and other attributes NOT to copy to CHTML output
+        exFactor: .5,                  // default size of ex in em units
         CHTMLWrapperFactory: null,     // The CHTMLWrapper factory to use
         font: null,                    // The FontData object to use
         cssStyles: null                // The CssStyles object to use
@@ -78,6 +88,8 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
      * from the core nodes)
      */
     public nodeMap: Map<MmlNode, CHTMLWrapper<N, T, D>>;
+
+    public testNodes: N;
 
     /*
      * Get the WrapperFactory and connect it to this output jax
@@ -147,9 +159,91 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
      * @override
      */
     public getMetrics(html: MathDocument<N, T, D>) {
+        const adaptor = this.adaptor;
+        adaptor.document = html.document;
+        const map = this.getMetricMap(html);
         for (const math of html.math) {
-            math.setMetrics(16, 8, 1000000, 1000000, 1);
+            const parent = adaptor.parent(math.start.node);
+            const {em, ex, containerWidth, lineWidth, scale} = map.get(parent);
+            math.setMetrics(em, ex, containerWidth, lineWidth, scale);
         }
+    }
+
+    /*
+     * Get a MetricMap for the math list
+     *
+     * @return{MetricMap}   The node-to-metrics map for all the containers that have math
+     */
+    protected getMetricMap(html: MathDocument<N, T, D>) {
+        const adaptor = this.adaptor;
+        const domMap = new Map() as MetricDomMap<N>;
+        //
+        // Add the test elements all at once (so only one reflow)
+        //
+        for (const math of html.math) {
+            const parent = adaptor.parent(math.start.node);
+            if (!domMap.has(parent)) {
+                domMap.set(parent, this.getTestElement(parent));
+            }
+        }
+        //
+        // Measure the metrics for all the mapped elements
+        //
+        const map = new Map() as MetricMap<N>;
+        for (const node of domMap.keys()) {
+            map.set(node, this.measureMetrics(domMap.get(node)));
+        }
+        //
+        // Remove the test elements
+        //
+        for (const node of domMap.values()) {
+            adaptor.remove(node);
+        }
+        return map;
+    }
+
+    /*
+     * @param{N} node    The container to add the test elements to
+     * @return{N}        The test elements that were added
+     */
+    protected getTestElement(node: N) {
+        const adaptor = this.adaptor;
+        if (!this.testNodes) {
+            this.testNodes = this.html('mjx-test', {style: {
+                display:           'inline-block',
+                'font-style':      'normal',
+                'font-weight':     'normal',
+                'font-size':       '100%',
+                'font-size-adjust':'none',
+                'text-indent':     0,
+                'text-transform':  'none',
+                'letter-spacing':  'normal',
+                'word-spacing':    'normal',
+                overflow:          'hidden',
+                height:            '1px'
+            }}, [
+                this.html('mjx-ex-box', {style: {
+                    position: 'absolute',
+                    overflow: 'hidden',
+                    width: '1px', height: '60ex'
+                }})
+            ]);
+        }
+        return adaptor.append(node, adaptor.clone(this.testNodes)) as N;
+    }
+
+    /*
+     * @param{N} node    The test node to measure
+     * @return{Metrics}  The metric data for the given node
+     */
+    protected measureMetrics(node: N) {
+        const adaptor = this.adaptor;
+        const em = adaptor.fontSize(node);
+        const ex = (adaptor.nodeSize(adaptor.firstChild(node) as N)[1] / 60) || (em * this.options.exFactor);
+        const containerWidth = 80 * em; // for now (should be measured in the DOM)
+        const scale = ex / this.font.params.x_height / em;
+        const lineWidth = 1000000;      // no linebreaking (otherwise would be a percentage of cwidth)
+        return {em, ex, containerWidth, lineWidth, scale} as Metrics;
     }
 
     /*


### PR DESCRIPTION
This PR implements the `getMetrics()` method that determines the metrics of the surrounding font, and computes the proper scaling for that.  It computes the `em` and `ex` sizes for the surroundings, though it does not yet compute the container width (which is needed for line breaking).

For the liteAdaptor, the font size is a fixed size set by a configuration parameter.  If the ex size can't be computed (e.g., in the lite and jsdom adaptors), a fixed percentage of the em size is used (it can be set in an option for the CHTML output jax).  