### PR TITLE
Add support for indentalign and indentshift

### DIFF
--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -67,6 +67,14 @@ const TEXSPACE = [
     [ 1, -1,  2,  3,  1,  0,  1,  1]  // INNER
 ];
 
+/*
+ * Attributes used to determine indentation and shifting
+ */
+export const indentAttributes = [
+    'indentalign', 'indentalignfirst',
+    'indentshift', 'indentshiftfirst'
+];
+
 
 /*****************************************************************/
 /*

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -26,7 +26,7 @@ import {Property, PropertyList, Node, AbstractNode, AbstractEmptyNode, NodeClass
 import {MmlFactory} from './MmlFactory.js';
 
 /*
- *  Used in setInheritedAttrbutes() to pass originating node kind as well as property value
+ *  Used in setInheritedAttributes() to pass originating node kind as well as property value
  */
 export type AttributeList = {[attribute: string]: [string, Property]};
 

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -72,6 +72,25 @@ export class MmlMtable extends AbstractMmlNode {
     }
 
     /*
+     * @override
+     */
+    setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
+        //
+        // Force inheritance of shift and align values (since they are needed to output tables with labels)
+        //   but make sure they are not given explicitly on the <mtable> tag.
+        //
+        for (const name of ['indentalign', 'indentalignfirst', 'indentshift', 'indentshiftfirst']) {
+            if (attributes[name]) {
+                this.attributes.setInherited(name, attributes[name][1]);
+            }
+            if (this.attributes.getExplicit(name) !== undefined) {
+                delete (this.attributes.getAllAttributes())[name];
+            }
+        }
+        super.setInheritedAttributes(attributes, display, level, prime);
+    };
+
+    /*
      * Make sure all children are mtr or mlabeledtr nodes
      * Inherit the table attributes, and set the display attribute based on the table's displaystyle attribute
      *

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList, Node} from '../../Tree/Node.js';
-import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
+import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS, indentAttributes} from '../MmlNode.js';
 import {split} from '../../../util/string.js';
 
 /*****************************************************************/
@@ -79,7 +79,7 @@ export class MmlMtable extends AbstractMmlNode {
         // Force inheritance of shift and align values (since they are needed to output tables with labels)
         //   but make sure they are not given explicitly on the <mtable> tag.
         //
-        for (const name of ['indentalign', 'indentalignfirst', 'indentshift', 'indentshiftfirst']) {
+        for (const name of indentAttributes) {
             if (attributes[name]) {
                 this.attributes.setInherited(name, attributes[name][1]);
             }

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -53,6 +53,11 @@ export type BBoxData = {
 
 export class BBox {
     /*
+     * Constant for pwidth of full width box
+     */
+    public static fullWidth = '100%';
+
+    /*
      *  These are the data stored for a bounding box
      */
     public w: number;

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -23,7 +23,7 @@
 
 import {AbstractWrapper} from '../../core/Tree/Wrapper.js';
 import {Node, PropertyList} from '../../core/Tree/Node.js';
-import {MmlNode, TextNode, AbstractMmlNode, AttributeList} from '../../core/MmlTree/MmlNode.js';
+import {MmlNode, TextNode, AbstractMmlNode, AttributeList, indentAttributes} from '../../core/MmlTree/MmlNode.js';
 import {Property} from '../../core/Tree/Node.js';
 import {OptionList} from '../../util/Options.js';
 import {unicodeChars} from '../../util/string.js';
@@ -279,7 +279,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         this.childNodes = node.childNodes.map((child: Node) => {
             const wrapped = this.wrap(child as MmlNode);
             if (wrapped.bbox.pwidth) {
-                this.bbox.pwidth = '100%';
+                this.bbox.pwidth = BBox.fullWidth;
             }
             return wrapped;
         });
@@ -622,7 +622,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      */
     protected handlePWidth() {
         if (this.bbox.pwidth) {
-            if (this.bbox.pwidth === '100%') {
+            if (this.bbox.pwidth === BBox.fullWidth) {
                 this.adaptor.setAttribute(this.chtml, 'width', 'full');
             } else {
                 this.adaptor.setStyle(this.chtml, 'width', this.bbox.pwidth);
@@ -683,8 +683,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      */
     protected getAlignShift() {
         let {indentalign, indentshift, indentalignfirst, indentshiftfirst} =
-            this.node.attributes.getList('indentalign', 'indentshift',
-                                    'indentalignfirst', 'indentshiftfirst') as StringMap;
+            this.node.attributes.getList(...indentAttributes) as StringMap;
         if (indentalignfirst !== 'indentalign') {
             indentalign = indentalignfirst;
         }
@@ -702,7 +701,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /*
-     * @param{N} chtml       The HTML node whose indenting is to be adjusted
+     * @param{N} chtml       The HTML node whose indentation is to be adjusted
      * @param{string} align  The alignment for the node
      * @param{number} shift  The indent (positive or negative) for the node
      */

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -277,7 +277,11 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         this.getScale();
         this.getSpace();
         this.childNodes = node.childNodes.map((child: Node) => {
-            return this.wrap(child as MmlNode);
+            const wrapped = this.wrap(child as MmlNode);
+            if (wrapped.bbox.pwidth) {
+                this.bbox.pwidth = '100%';
+            }
+            return wrapped;
         });
     }
 
@@ -494,6 +498,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         this.handleColor();
         this.handleSpace();
         this.handleAttributes();
+        this.handlePWidth();
         return chtml;
     }
 
@@ -602,12 +607,26 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         const defaults = attributes.getAllDefaults();
         const skip = CHTMLWrapper.skipAttributes;
         for (const name of attributes.getExplicitNames()) {
-            if (skip[name] === false || (!(name in defaults) && !skip[name] && !this.adaptor.hasAttribute(this.chtml, name))) {
+            if (skip[name] === false || (!(name in defaults) && !skip[name] &&
+                                         !this.adaptor.hasAttribute(this.chtml, name))) {
                 this.adaptor.setAttribute(this.chtml, name, attributes.getExplicit(name) as string);
             }
         }
         if (attributes.get('class')) {
             this.adaptor.addClass(this.chtml, attributes.get('class') as string);
+        }
+    }
+
+    /*
+     * Handle the attributes needed for percentage widths
+     */
+    protected handlePWidth() {
+        if (this.bbox.pwidth) {
+            if (this.bbox.pwidth === '100%') {
+                this.adaptor.setAttribute(this.chtml, 'width', 'full');
+            } else {
+                this.adaptor.setStyle(this.chtml, 'width', this.bbox.pwidth);
+            }
         }
     }
 
@@ -657,6 +676,43 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
             }
         }
         return this.stretch.dir !== DIRECTION.None;
+    }
+
+    /*
+     * @return{[string, number]}  The alignment and indentation shift for the expression
+     */
+    protected getAlignShift() {
+        let {indentalign, indentshift, indentalignfirst, indentshiftfirst} =
+            this.node.attributes.getList('indentalign', 'indentshift',
+                                    'indentalignfirst', 'indentshiftfirst') as StringMap;
+        if (indentalignfirst !== 'indentalign') {
+            indentalign = indentalignfirst;
+        }
+        if (indentalign === 'auto') {
+            indentalign = 'center';
+        }
+        if (indentshiftfirst !== 'indentshift') {
+            indentshift = indentshiftfirst;
+        }
+        if (indentshift === 'auto') {
+            indentshift = '0';
+        }
+        const shift = this.length2em(indentshift, this.metrics.containerWidth);
+        return [indentalign, shift] as [string, number];
+    }
+
+    /*
+     * @param{N} chtml       The HTML node whose indenting is to be adjusted
+     * @param{string} align  The alignment for the node
+     * @param{number} shift  The indent (positive or negative) for the node
+     */
+    protected setIndent(chtml: N, align: string, shift: number) {
+        if (align === 'center' || align === 'left') {
+            this.adaptor.setStyle(chtml, 'margin-left', this.em(shift));
+        }
+        if (align === 'center' || align === 'right') {
+            this.adaptor.setStyle(chtml, 'margin-right', this.em(-shift));
+        }
     }
 
     /*******************************************************************/

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -61,6 +61,12 @@ export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
         },
         'mjx-chtml.MJX-DISPLAY mjx-math': {
             padding: 0
+        },
+        'mjx-chtml[justify="left"]': {
+            'text-align': 'left'
+        },
+        'mjx-chtml[justify="right"]': {
+            'text-align': 'right'
         }
     };
 
@@ -69,9 +75,20 @@ export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     public toCHTML(parent: N) {
         super.toCHTML(parent);
-        if (this.node.attributes.get('display') === 'block') {
-            this.adaptor.setAttribute(this.chtml, 'display', 'true');
-            this.adaptor.addClass(parent, 'MJX-DISPLAY');
+        const chtml = this.chtml;
+        const adaptor = this.adaptor;
+        const attributes = this.node.attributes;
+        const display = (attributes.get('display') === 'block');
+        if (display) {
+            adaptor.setAttribute(chtml, 'display', 'true');
+            adaptor.addClass(parent, 'MJX-DISPLAY');
+        }
+        const [align, shift] = this.getAlignShift();
+        if (align !== 'center') {
+            adaptor.setAttribute(parent, 'justify', align);
+        }
+        if (display && shift && !adaptor.hasAttribute(chtml, 'width')) {
+            this.setIndent(chtml, align, shift);
         }
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -46,6 +46,12 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
         super(factory, node, parent);
         this.stretchChildren();
+        for (const child of this.childNodes) {
+            if (child.bbox.pwidth) {
+                this.bbox.pwidth = '100%';
+                break;
+            }
+        }
     }
 
     /*
@@ -59,9 +65,6 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
             if (child.bbox.w < 0) {
                 hasNegative = true;
             }
-            if (child.bbox.pwidth) {
-                this.makeFullWidth();
-            }
         }
         // FIXME:  handle line breaks
         if (hasNegative) {
@@ -73,15 +76,6 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
                 }
             }
         }
-    }
-
-    /*
-     * Handle the case where a child has a percentage width by
-     * marking the parent as 100% width.
-     */
-    protected makeFullWidth() {
-        this.bbox.pwidth = '100%';
-        this.adaptor.setAttribute(this.chtml, 'width', 'full');
     }
 
     /*

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -48,7 +48,7 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.stretchChildren();
         for (const child of this.childNodes) {
             if (child.bbox.pwidth) {
-                this.bbox.pwidth = '100%';
+                this.bbox.pwidth = BBox.fullWidth;
                 break;
             }
         }

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -181,7 +181,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected getPercentageWidth() {
         for (const row of this.childNodes) {
             if (row.node.isKind('mlabeledtr')) {
-                this.bbox.pwidth = '100%';
+                this.bbox.pwidth = BBox.fullWidth;
                 return;
             }
         }

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -74,6 +74,22 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
             position: 'absolute',
             top: 0
         },
+        'mjx-mtable[justify="left"][side="left"]': {
+            'text-align': 'left',
+            'padding-right': '0 ! important'
+        },
+        'mjx-mtable[justify="left"][side="right"]': {
+            'text-align': 'left',
+            'padding-left': '0 ! important'
+        },
+        'mjx-mtable[justify="right"][side="left"]': {
+            'text-align': 'right',
+            'padding-right': '0 ! important'
+        },
+        'mjx-mtable[justify="right"][side="right"]': {
+            'text-align': 'right',
+            'padding-left': '0 ! important'
+        },
         'mjx-mtable[align]': {
             'vertical-align': 'baseline'
         },
@@ -134,12 +150,13 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
         super(factory, node, parent);
-        this.labels = this.html('mjx-labels', {align: node.attributes.get('side')});
+        this.labels = this.html('mjx-labels');
         //
-        // Determine the number of columns and rows
+        // Determine the number of columns and rows, and whether the table is stretchy
         //
         this.numCols = max(this.tableRows.map(row => row.numCells));
         this.numRows = this.childNodes.length;
+        this.getPercentageWidth();
         //
         // Get the frame, row, and column parameters
         //
@@ -156,6 +173,22 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         //
         this.stretchRows();
         this.stretchColumns();
+    }
+
+    /*
+     * If the table has a precentage width or has labels, set the pwidth of the bounding box
+     */
+    protected getPercentageWidth() {
+        for (const row of this.childNodes) {
+            if (row.node.isKind('mlabeledtr')) {
+                this.bbox.pwidth = '100%';
+                return;
+            }
+        }
+        const width = this.node.attributes.get('width') as string;
+        if (isPercent(width)) {
+            this.bbox.pwidth = width;
+        }
     }
 
     /*
@@ -266,12 +299,13 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.handleWidth();
         this.handleLabels();
         this.handleAlign();
+        this.handleJustify();
         this.shiftColor();
     }
 
     /*
      * Move background color (if any) to inner itable node so that labeled tables are
-     * only colored on thei main part of the table.
+     * only colored on the main part of the table.
      */
     protected shiftColor() {
         const color = this.adaptor.getStyle(this.chtml, 'backgroundColor');
@@ -624,10 +658,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected handleWidth() {
         let w = this.node.attributes.get('width') as string;
         const hasLabels = (this.adaptor.childNodes(this.labels).length > 0);
-        if (isPercent(w) || hasLabels) {
-            this.bbox.pwidth = (hasLabels ? '100%' : w);
-            this.adaptor.setStyle(this.chtml, 'width', '100%');
-        } else {
+        if (!(isPercent(w) || hasLabels)) {
             if (w === 'auto') return;
             w = this.em(this.length2em(w) + (this.frame ? .14 : 0));
         }
@@ -651,6 +682,16 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
+    /*
+     * Mark the alignment of the table
+     */
+    protected handleJustify() {
+        const [align, shift] = this.getAlignShift();
+        if (align !== 'center') {
+            this.adaptor.setAttribute(this.chtml, 'justify', align);
+        }
+    }
+
     /******************************************************************/
 
     /*
@@ -658,26 +699,39 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
     protected handleLabels() {
         const labels = this.labels;
+        const attributes = this.node.attributes;
         const adaptor = this.adaptor;
         if (adaptor.childNodes(labels).length === 0) return;
         //
         //  Set the side for the labels
         //
-        const side = this.node.attributes.get('side') as string;
-        adaptor.setAttribute(labels, 'side', side);
+        const side = attributes.get('side') as string;
+        adaptor.setAttribute(this.chtml, 'side', side);
+        adaptor.setAttribute(labels, 'align', side);
         adaptor.setStyle(labels, side, '0');
         //
         //  Make sure labels don't overlap table
         //
         const {L} = this.getTableData();
-        const sep = this.length2em(this.node.attributes.get('minlabelspacing'));
-        let pad = L + sep;   // FIXME, handle indentalign values
+        const sep = this.length2em(attributes.get('minlabelspacing'));
+        let pad = L + sep;
         const [lpad, rpad] = (this.styles == null ? ['', ''] :
                               [this.styles.get('padding-left'), this.styles.get('padding-right')]);
         if (lpad || rpad) {
             pad = Math.max(pad, this.length2em(lpad || '0'), this.length2em(rpad || '0'));
         }
         adaptor.setStyle(this.chtml, 'padding', '0 ' + this.em(pad));
+        //
+        //  Handle indentation
+        //
+        let [align, shift] = this.getAlignShift();
+        if (align === side) {
+            shift = (side === 'left' ? Math.max(pad, shift) - pad : Math.min(-pad, shift) + pad);
+        }
+        if (shift) {
+            const table = adaptor.firstChild(this.chtml) as N;
+            this.setIndent(table, align, shift);
+        }
         //
         // Add the labels to the table
         //

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -106,7 +106,9 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     public toCHTML(parent: N) {
         super.toCHTML(parent);
         const align = this.node.attributes.get('rowalign') as string;
-        this.adaptor.setAttribute(this.chtml, 'rowalign', align);
+        if (align !== 'baseline') {
+            this.adaptor.setAttribute(this.chtml, 'rowalign', align);
+        }
     }
 
     /*


### PR DESCRIPTION
This PR adds support for `indentalign` and `indentshift`, which control the alignment and indenting of displayed equations.  This is handled in the `math` wrapper, and also in the `mtable` wrapper since tables with labels are in full-width elements, and the alignment of the actual table must be inside the full-width container.  Stylesheet CSS handles the alignment, but the shifting requires explicit styles.  Because tables rely on the `indentalign` and `indentshift` values, they need to be added to the mtable inheritance.

This PR also includes fixes for the bubbling up of full-width element, like tables with labels.  So if a table is inside another element (e.g., `mstyle`, or `semantics`), that won't disrupt the label positioning.  This was being done by hand in `mrow`elements, but that has now been moved to the wrapper super-class.