### PR TITLE
Fix alignment of over-scripts inside aligned environment.  #120

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -45,6 +45,9 @@ export class CHTMLmunder<N, T, D> extends CHTMLmsub<N, T, D> {
     public static useIC: boolean = true;
 
     public static styles: StyleList = {
+        'mjx-over': {
+            'text-align': 'left'
+        },
         'mjx-munder:not([limits="false"])': {
             display: 'inline-table',
         },


### PR DESCRIPTION
Add CSS to prevent `text-align` bleed-through in `munderover` elements.  Resolves issue #120.