### PR TITLE
Don't transform attribute names in adaptor.  #128

### DIFF
--- a/mathjax3-ts/adaptors/HTMLAdaptor.ts
+++ b/mathjax3-ts/adaptors/HTMLAdaptor.ts
@@ -385,7 +385,6 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
      * @override
      */
     public setAttribute(node: N, name: string, value: string) {
-        name = name.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
         return node.setAttribute(name, value);
     }
 

--- a/mathjax3-ts/adaptors/liteAdaptor.ts
+++ b/mathjax3-ts/adaptors/liteAdaptor.ts
@@ -397,7 +397,6 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
      * @override
      */
     public setAttribute(node: LiteElement, name: string, value: string) {
-        name = name.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
         node.attributes[name] = value;
         if (name === 'style') {
             node.styles = null;

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -355,7 +355,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
         bbox.clean();
     }
-  
+
     /*
      * Mark BBox to be computed again (e.g., when an mo has stretched)
      */


### PR DESCRIPTION
Don't transform mixed-case attribute names (that was supposed to be for styles, but it is not needed there).

This cased `noIC` attribute to become `no-i-c`, and so it didn't match the CSS selectors for it, which cased the spacing problem in #128.
