### PR TITLE
Reset text-align to left in CSS for MathML elements.  #128 and #120

### DIFF
--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -165,7 +165,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         for (const kind of this.factory.getKinds()) {
             const CLASS = this.factory.getNodeClass(kind);
             if (CLASS.autoStyle && kind !== 'unknown') {
-                this.cssStyles.addStyles({['mjx-' + CLASS.kind]: {display: 'inline-block'}});
+                this.cssStyles.addStyles({['mjx-' + CLASS.kind]: {display: 'inline-block', 'text-align': 'left'}});
             }
             this.cssStyles.addStyles(CLASS.styles);
         }

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -130,9 +130,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         'mjx-chtml [size="hg"]': {'font-size': '207%'},
         'mjx-chtml [size="HG"]': {'font-size': '249%'},
 
-        'mjx-chtml [width="full"]': {
-            width: '100%'
-        },
+        'mjx-chtml [width="full"]': {width: '100%'},
 
         'mjx-box': {display: 'inline-block'},
         'mjx-block': {display: 'block'},
@@ -143,14 +141,11 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         //
         //  These don't have Wrapper subclasses, so add their styles here
         //
-        'mjx-mn': {display: 'inline-block'},
-        'mjx-mtext': {display: 'inline-block'},
         'mjx-merror': {
             display: 'inline-block',
             color: 'red',
             'background-color': 'yellow'
         },
-
         'mjx-mphantom': {visibility: 'hidden'}
 
     };


### PR DESCRIPTION
Reset `text-align` to `left` in CSS for MathML elements in CHTML output.

Resolves issues #128 and #120.