### PR TITLE
Color.js package

### DIFF
--- a/lib/TeX-lab.js
+++ b/lib/TeX-lab.js
@@ -11,6 +11,7 @@ import 'mathjax3/input/tex/base/BaseConfiguration.js';
 import 'mathjax3/input/tex/ams/AmsConfiguration.js';
 import 'mathjax3/input/tex/noundefined/NoUndefinedConfiguration.js';
 import 'mathjax3/input/tex/boldsymbol/BoldsymbolConfiguration.js';
+import 'mathjax3/input/tex/color/ColorConfiguration.js';
 import 'mathjax3/input/tex/newcommand/NewcommandConfiguration.js';
 import 'mathjax3/input/tex/mhchem/MhchemConfiguration.js';
 import 'mathjax3/input/tex/noerrors/NoErrorsConfiguration.js';

--- a/mathjax3-ts/input/tex/color/ColorConfiguration.ts
+++ b/mathjax3-ts/input/tex/color/ColorConfiguration.ts
@@ -1,0 +1,56 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 Omar Al-Ithawi and The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Configuration file for the color package.
+ *
+ * @author i@omardo.com (Omar Al-Ithawi)
+ */
+
+
+import { CommandMap } from '../SymbolMap.js';
+import { Configuration } from '../Configuration.js';
+
+import { ColorMethods } from './ColorMethods.js';
+import { ColorModel } from './ColorUtil.js';
+
+
+new CommandMap('color', {
+    color: 'Color',
+    textcolor: 'TextColor',
+    definecolor: 'DefineColor',
+    colorbox: 'ColorBox',
+    fcolorbox: 'FColorBox'
+}, ColorMethods);
+
+/**
+ * Init method for Color package.
+ * @param {Configuration} config The current configuration.
+ */
+const init = function(config: Configuration) {
+    config.options['colorModel'] = new ColorModel();
+};
+
+export const ColorConfiguration = Configuration.create('color', {
+    handler: {
+        macro: ['color'],
+    }, options: {
+        colorPadding: '5px',
+        colorBorderWidth: '2px',
+    },
+    init: init
+});

--- a/mathjax3-ts/input/tex/color/ColorConstants.ts
+++ b/mathjax3-ts/input/tex/color/ColorConstants.ts
@@ -1,0 +1,93 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 Omar Al-Ithawi and The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Constants file for the color package.
+ *
+ * @author i@omardo.com (Omar Al-Ithawi)
+ */
+
+ export const COLORS: Map<string, string> = new Map<string, string>([
+    ['Apricot', '#FBB982'],
+    ['Aquamarine', '#00B5BE'],
+    ['Bittersweet', '#C04F17'],
+    ['Black', '#221E1F'],
+    ['Blue', '#2D2F92'],
+    ['BlueGreen', '#00B3B8'],
+    ['BlueViolet', '#473992'],
+    ['BrickRed', '#B6321C'],
+    ['Brown', '#792500'],
+    ['BurntOrange', '#F7921D'],
+    ['CadetBlue', '#74729A'],
+    ['CarnationPink', '#F282B4'],
+    ['Cerulean', '#00A2E3'],
+    ['CornflowerBlue', '#41B0E4'],
+    ['Cyan', '#00AEEF'],
+    ['Dandelion', '#FDBC42'],
+    ['DarkOrchid', '#A4538A'],
+    ['Emerald', '#00A99D'],
+    ['ForestGreen', '#009B55'],
+    ['Fuchsia', '#8C368C'],
+    ['Goldenrod', '#FFDF42'],
+    ['Gray', '#949698'],
+    ['Green', '#00A64F'],
+    ['GreenYellow', '#DFE674'],
+    ['JungleGreen', '#00A99A'],
+    ['Lavender', '#F49EC4'],
+    ['LimeGreen', '#8DC73E'],
+    ['Magenta', '#EC008C'],
+    ['Mahogany', '#A9341F'],
+    ['Maroon', '#AF3235'],
+    ['Melon', '#F89E7B'],
+    ['MidnightBlue', '#006795'],
+    ['Mulberry', '#A93C93'],
+    ['NavyBlue', '#006EB8'],
+    ['OliveGreen', '#3C8031'],
+    ['Orange', '#F58137'],
+    ['OrangeRed', '#ED135A'],
+    ['Orchid', '#AF72B0'],
+    ['Peach', '#F7965A'],
+    ['Periwinkle', '#7977B8'],
+    ['PineGreen', '#008B72'],
+    ['Plum', '#92268F'],
+    ['ProcessBlue', '#00B0F0'],
+    ['Purple', '#99479B'],
+    ['RawSienna', '#974006'],
+    ['Red', '#ED1B23'],
+    ['RedOrange', '#F26035'],
+    ['RedViolet', '#A1246B'],
+    ['Rhodamine', '#EF559F'],
+    ['RoyalBlue', '#0071BC'],
+    ['RoyalPurple', '#613F99'],
+    ['RubineRed', '#ED017D'],
+    ['Salmon', '#F69289'],
+    ['SeaGreen', '#3FBC9D'],
+    ['Sepia', '#671800'],
+    ['SkyBlue', '#46C5DD'],
+    ['SpringGreen', '#C6DC67'],
+    ['Tan', '#DA9D76'],
+    ['TealBlue', '#00AEB3'],
+    ['Thistle', '#D883B7'],
+    ['Turquoise', '#00B4CE'],
+    ['Violet', '#58429B'],
+    ['VioletRed', '#EF58A0'],
+    ['White', '#FFFFFF'],
+    ['WildStrawberry', '#EE2967'],
+    ['Yellow', '#FFF200'],
+    ['YellowGreen', '#98CC70'],
+    ['YellowOrange', '#FAA21A'],
+]);

--- a/mathjax3-ts/input/tex/color/ColorMethods.ts
+++ b/mathjax3-ts/input/tex/color/ColorMethods.ts
@@ -1,0 +1,155 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 Omar Al-Ithawi and The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Parse methods and helper functtions for the color package.
+ *
+ * @author i@omardo.com (Omar Al-Ithawi)
+ */
+
+
+import NodeUtil from '../NodeUtil.js';
+import { ParseMethod } from '../Types.js';
+import { PropertyList } from '../../../core/Tree/Node.js';
+import ParseUtil from '../ParseUtil.js';
+import TexParser from '../TexParser.js';
+
+import { ColorModel } from './ColorUtil.js';
+
+
+/**
+ * Build PropertyList from padding value.
+ *
+ * @param {string} colorPadding: Padding for \colorbox and \fcolorbox.
+ * @return {PropertyList} The padding properties.
+ */
+function padding(colorPadding: string): PropertyList {
+    const pad = `+${colorPadding}`;
+    const unit = colorPadding.replace(/^.*?([a-z]*)$/, '$1');
+    const pad2 = 2 * parseFloat(pad);
+    return {
+        width: `+${pad2}${unit}`,
+        height: pad,
+        depth: pad,
+        lspace: colorPadding,
+    };
+};
+
+
+export const ColorMethods: Record<string, ParseMethod> = {};
+
+
+/**
+ * Override \color macro definition.
+ *
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The name of the control sequence.
+ */
+ColorMethods.Color = function (parser: TexParser, name: string) {
+    const model = parser.GetBrackets(name, '');
+    const colorDef = parser.GetArgument(name);
+    const colorModel: ColorModel = parser.options['colorModel'];
+    const color = colorModel.getColor(model, colorDef);
+
+    const style = parser.itemFactory.create('style')
+                        .setProperties({styles: { mathcolor: color }});
+    parser.stack.env['color'] = color;
+
+    parser.Push(style);
+};
+
+
+/**
+ * Define the \textcolor macro.
+ *
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The name of the control sequence.
+ */
+ColorMethods.TextColor = function (parser: TexParser, name: string) {
+    const model = parser.GetBrackets(name, '');
+    const colorDef = parser.GetArgument(name);
+    const colorModel: ColorModel = parser.options['colorModel'];
+    const color = colorModel.getColor(model, colorDef);
+    const old = parser.stack.env['color'];
+
+    parser.stack.env['color'] = color;
+    const math = parser.ParseArg(name);
+
+    if (old) {
+        parser.stack.env['color'] = old;
+    } else {
+        delete parser.stack.env['color'];
+    }
+
+    const node = parser.create('node', 'mstyle', [math], { mathcolor: color });
+    parser.Push(node);
+};
+
+/**
+ * Define the \definecolor macro.
+ *
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The name of the control sequence.
+ */
+ColorMethods.DefineColor = function (parser: TexParser, name: string) {
+    const cname = parser.GetArgument(name);
+    const model = parser.GetArgument(name);
+    const def = parser.GetArgument(name);
+
+    const colorModel: ColorModel = parser.options['colorModel'];
+    colorModel.defineColor(model, cname, def);
+};
+
+/**
+ * Produce a text box with a colored background: `\colorbox`.
+ *
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The name of the control sequence.
+ */
+ColorMethods.ColorBox = function (parser: TexParser, name: string) {
+    const cname = parser.GetArgument(name);
+    const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
+    const colorModel: ColorModel = parser.options['colorModel'];
+
+    const node = parser.create('node', 'mpadded', math, {
+        mathbackground: colorModel.getColor('named', cname)
+    });
+
+    NodeUtil.setProperties(node, padding(parser.options['colorPadding']));
+    parser.Push(node);
+};
+
+/**
+ * Produce a framed text box with a colored background: `\fcolorbox`.
+ *
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The name of the control sequence.
+ */
+ColorMethods.FColorBox = function (parser: TexParser, name: string) {
+    const fname = parser.GetArgument(name);
+    const cname = parser.GetArgument(name);
+    const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
+    const colorModel: ColorModel = parser.options['colorModel'];
+
+    const node = parser.create('node', 'mpadded', math, {
+        mathbackground: colorModel.getColor('named', cname),
+        style: `border: ${parser.options['colorBorderWidth']} solid ${colorModel.getColor('named', fname)}`
+    });
+
+    NodeUtil.setProperties(node, padding(parser.options['colorPadding']));
+    parser.Push(node);
+};

--- a/mathjax3-ts/input/tex/color/ColorUtil.ts
+++ b/mathjax3-ts/input/tex/color/ColorUtil.ts
@@ -1,0 +1,218 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 Omar Al-Ithawi and The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview Utility functions and classes for the color package.
+ *
+ * @author i@omardo.com (Omar Al-Ithawi)
+ */
+
+
+import TexError from '../TexError.js';
+import { COLORS } from './ColorConstants.js';
+
+type ColorModelProcessor = (def: string) => string;
+const ColorModelProcessors: Map<string, ColorModelProcessor> = new Map<string, ColorModelProcessor>();
+
+
+export class ColorModel {
+
+    /**
+     * User defined colors.
+     *
+     * This variable is local to the parser, so two parsers in the same
+     * JavaScript thread can have two different sets of user-defined colors.
+     */
+    private userColors: Map<string, string> = new Map<string, string>();
+
+    /**
+     * Converts a color model from string representation to its CSS format `#44ff00`
+     *
+     * @param {string} model The coloring model type: `rgb` `RGB` or `gray`.
+     * @param {string} def The color definition: `0.5,0,1`, `128,0,255`, `0.5`.
+     * @return {string} The color definition in CSS format e.g. `#44ff00`.
+     */
+    private normalizeColor(model: string, def: string): string {
+        if (!model || model === 'named') {
+            // Allow to define colors directly by using the CSS format e.g. `#888`
+            return def;
+        }
+
+        if (ColorModelProcessors.has(model)) {
+            const modelProcessor = ColorModelProcessors.get(model);
+            return modelProcessor(def);
+        }
+
+        throw new TexError('UndefinedColorModel', 'Color model \'%1\' not defined', model);
+    }
+
+    /**
+     * Look up a color based on its model and definition.
+     *
+     * @param {string} model The coloring model type: `named`, `rgb` `RGB` or `gray`.
+     * @param {string} def The color definition: `red, `0.5,0,1`, `128,0,255`, `0.5`.
+     * @return {string} The color definition in CSS format e.g. `#44ff00`.
+     */
+    private getColor(model: string, def: string): string {
+        if (!model || model === 'named') {
+            return this.getColorByName(def);
+        }
+
+        return this.normalizeColor(model, def);
+    }
+
+    /**
+     * Get a named color.
+     *
+     * @param {string} name The color name e.g. `darkblue`.
+     * @return {string} The color definition in CSS format e.g. `#44ff00`.
+     *
+     * To retain backward compatilbity with MathJax v2 this method returns
+     * unknown as-is, this is useful for both passing through CSS format colors like `#ff0`,
+     * or even standard CSS color names that this plugin is unaware of.
+     *
+     * In TeX format, this would help to let `\textcolor{#f80}{\text{Orange}}` show an
+     * orange word.
+     */
+    private getColorByName(name: string): string {
+        if (this.userColors.has(name)) {
+            return this.userColors.get(name);
+        }
+
+        if (COLORS.has(name)) {
+            return COLORS.get(name);
+        }
+
+        // Pass the color name as-is to CSS
+        return name;
+    }
+
+    /**
+     * Create a new user-defined color.
+     *
+     * This color is local to the parser, so another MathJax parser won't be poluted.
+     *
+     * @param {string} model The coloring model type: e.g. `rgb`, `RGB` or `gray`.
+     * @param {string} name The color name: `darkblue`.
+     * @param {string} def The color definition in the color model format: `128,0,255`.
+     */
+    public defineColor(model: string, name: string, def: string) {
+        const normalized = this.normalizeColor(model, def);
+        this.userColors.set(name, normalized);
+    }
+}
+
+
+/**
+ * Get an rgb color.
+ *
+ * @param {OptionList} parserOptions The parser options object.
+ * @param {string} rgb The color definition in rgb: `0.5,0,1`.
+ * @return {string} The color definition in CSS format e.g. `#44ff00`.
+ */
+ColorModelProcessors.set('rgb', function (rgb: string): string {
+    const rgbParts: string[] = rgb.trim().split(/\s*,\s*/);
+    let RGB: string = '#';
+
+    if (rgbParts.length !== 3) {
+        throw new TexError('ModelArg1', 'Color values for the %1 model require 3 numbers', 'rgb');
+    }
+
+    for (const rgbPart of rgbParts) {
+        if (!rgbPart.match(/^(\d+(\.\d*)?|\.\d+)$/)) {
+            throw new TexError('InvalidDecimalNumber', 'Invalid decimal number');
+        }
+
+        const n = parseFloat(rgbPart);
+        if (n < 0 || n > 1) {
+            throw new TexError('ModelArg2',
+                'Color values for the %1 model must be between %2 and %3',
+                'rgb', '0', '1');
+        }
+
+        let pn = Math.floor(n * 255).toString(16);
+        if (pn.length < 2) {
+            pn = '0' + pn;
+        }
+
+        RGB += pn;
+    }
+
+    return RGB;
+});
+
+/**
+ * Get an RGB color.
+ *
+ * @param {OptionList} parserOptions The parser options object.
+ * @param {string} rgb The color definition in RGB: `128,0,255`.
+ * @return {string} The color definition in CSS format e.g. `#44ff00`.
+ */
+ColorModelProcessors.set('RGB', function (rgb: string): string {
+    const rgbParts: string[] = rgb.trim().split(/\s*,\s*/);
+    let RGB = '#';
+
+    if (rgbParts.length !== 3) {
+        throw new TexError('ModelArg1', 'Color values for the %1 model require 3 numbers', 'RGB');
+    }
+
+    for (const rgbPart of rgbParts) {
+        if (!rgbPart.match(/^\d+$/)) {
+            throw new TexError('InvalidNumber', 'Invalid number');
+        }
+
+        const n = parseInt(rgbPart);
+        if (n > 255) {
+            throw new TexError('ModelArg2',
+                'Color values for the %1 model must be between %2 and %3',
+                'RGB', '0', '255');
+        }
+
+        let pn = n.toString(16);
+        if (pn.length < 2) {
+            pn = '0' + pn;
+        }
+        RGB += pn;
+    }
+    return RGB;
+});
+
+/**
+ * Get a gray-scale value.
+ *
+ * @param {OptionList} parserOptions The parser options object.
+ * @param {string} gray The color definition in RGB: `0.5`.
+ * @return {string} The color definition in CSS format e.g. `#808080`.
+ */
+ColorModelProcessors.set('gray', function (gray: string): string {
+    if (!gray.match(/^\s*(\d+(\.\d*)?|\.\d+)\s*$/)) {
+        throw new TexError('InvalidDecimalNumber', 'Invalid decimal number');
+    }
+
+    const n: number = parseFloat(gray);
+    if (n < 0 || n > 1) {
+        throw new TexError('ModelArg2',
+            'Color values for the %1 model must be between %2 and %3',
+            'gray', '0', '1');
+    }
+    let pn = Math.floor(n * 255).toString(16);
+    if (pn.length < 2) {
+        pn = '0' + pn;
+    }
+
+    return `#${pn}${pn}${pn}`;
+});


### PR DESCRIPTION
The [color.js packages imported from v2](https://github.com/mathjax/MathJax/blob/master/unpacked/extensions/TeX/color.js)

### Changes
 - [x] Import the package and convert to TypeScript
 - [x] Make the padding and border configurable
 - [x] JSDocs with `@param` and `@return`
 - [x] TSLint
 - [x] Test all the functions

### Larger Review Comments
 - [x] Make sure `\color` works as a switch. See [David's comment](https://github.com/mathjax/mathjax-v3/pull/136#discussion_r224060747).
 - [x] `COLORS` should have a new instance per parser instead of being a global state effectively. See [David's comment](https://github.com/mathjax/mathjax-v3/pull/136#discussion_r224064198).
 - [x] `\textcolor` implementation isn't correct. See [David's comment](https://github.com/mathjax/mathjax-v3/pull/136#discussion_r225008026).
 - [x] Split into multiple files: Constants, Methods, others. [See base options](https://github.com/mathjax/mathjax-v3/blob/master/mathjax3-ts/input/tex/base/BaseConfiguration.ts#L139-L143), and [how it's being used](https://github.com/mathjax/mathjax-v3/blob/master/mathjax3-ts/input/tex/base/BaseMethods.ts#L1568-L1570).

### Not Done
 - [ ] Allow multiple color namespaces color package for CSS, SVG and others.

### Screenshot
![image](https://user-images.githubusercontent.com/645156/52363471-6cee9680-2a4b-11e9-86a4-ca405035c9dd.png)



### Testing TeX
```latex
\definecolor{salty}{named}{#888}

2bc \ { \color{blue} 1yz } \ 2\pi^2  \ldots

\textcolor[gray]{0.75}{ams} \ldots

\textcolor{#f80}{\text{Orange}} \ldots

\colorbox{green}{ams} \ldots 

\fcolorbox{green}{silver}{ Text } \ldots


\color[rgb]{0.5,0.5,1}
H_2O \ldots

\color{salty}
NaCl \ldots
```