### PR TITLE
Fix the comment open delimiter for jsdoc comments

### DIFF
--- a/mathjax3-ts/adaptors/HTMLAdaptor.ts
+++ b/mathjax3-ts/adaptors/HTMLAdaptor.ts
@@ -25,11 +25,9 @@ import {OptionList} from '../util/Options.js';
 import {AttributeData, AbstractDOMAdaptor, DOMAdaptor} from '../core/DOMAdaptor.js';
 
 /*****************************************************************/
-/*
+/**
  * The minimum fields needed for a Document
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -44,11 +42,9 @@ export interface MinDocument<N, T> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The minimum fields needed for an HTML Element
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -85,11 +81,9 @@ export interface MinHTMLElement<N, T> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The minimum fields needed for a Text element
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -103,11 +97,9 @@ export interface MinText<N, T> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The minimum fields needed for a DOMParser
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -116,11 +108,9 @@ export interface MinDOMParser<D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The minimum fields needed for a Window
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template D  The Document class
  */
@@ -138,11 +128,9 @@ export interface MinWindow<N, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The minimum needed for an HTML Adaptor
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -152,16 +140,14 @@ export interface MinHTMLAdaptor<N, T, D> extends DOMAdaptor<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Abstract HTMLAdaptor class for manipulating HTML elements
  *  (subclass of AbstractDOMAdaptor)
  *
  *  N = HTMLElement node class
  *  T = Text node class
  *  D = Document class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -170,17 +156,17 @@ export class HTMLAdaptor<N extends MinHTMLElement<N, T>,
                          T extends MinText<N, T>,
                          D extends MinDocument<N, T>>
 extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
-    /*
+    /**
      * The window object for this adaptor
      */
     window: MinWindow<N, D>;
 
-    /*
+    /**
      * The DOMParser used to parse a string into a DOM tree
      */
     parser: MinDOMParser<D>;
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -190,49 +176,49 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         this.parser = new (window.DOMParser as any)();
     }
 
-    /*
+    /**
      * @override
      */
     public parse(text: string, format: string = 'text/html') {
         return this.parser.parseFromString(text, format);
     }
 
-    /*
+    /**
      * @override
      */
     protected create(type: string) {
         return this.document.createElement(type);
     }
 
-    /*
+    /**
      * @override
      */
     public text(text: string) {
         return this.document.createTextNode(text);
     }
 
-    /*
+    /**
      * @override
      */
     public head(doc: D) {
         return doc.head;
     }
 
-    /*
+    /**
      * @override
      */
     public body(doc: D) {
         return doc.body;
     }
 
-    /*
+    /**
      * @override
      */
     public root(doc: D) {
         return doc.documentElement;
     }
 
-    /*
+    /**
      * @override
      */
     public tags(node: N, name: string, ns: string = null) {
@@ -240,7 +226,7 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         return Array.from(nodes as N[]) as N[];
     }
 
-    /*
+    /**
      * @override
      */
     public getElements(nodes: (string | N | N[])[], document: D) {
@@ -259,161 +245,161 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         return containers;
     }
 
-    /*
+    /**
      * @override
      */
     public parent(node: N | T) {
         return node.parentNode as N;
     }
 
-    /*
+    /**
      * @override
      */
     public append(node: N, child: N | T) {
         return node.appendChild(child) as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public insert(nchild: N | T, ochild: N | T) {
         return this.parent(ochild).insertBefore(nchild, ochild);
     }
 
-    /*
+    /**
      * @override
      */
     public remove(child: N | T) {
         return this.parent(child).removeChild(child) as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public replace(nnode: N | T, onode: N | T) {
         return this.parent(onode).replaceChild(nnode, onode) as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public clone(node: N) {
         return node.cloneNode(true) as N;
     }
 
-    /*
+    /**
      * @override
      */
     public split(node: T, n: number) {
         return node.splitText(n);
     }
 
-    /*
+    /**
      * @override
      */
     public next(node: N | T) {
         return node.nextSibling as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public previous(node: N | T) {
         return node.previousSibling as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public firstChild(node: N) {
         return node.firstChild as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public lastChild(node: N) {
         return node.lastChild as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public childNodes(node: N) {
         return Array.from(node.childNodes as (N | T)[]);
     }
 
-    /*
+    /**
      * @override
      */
     public childNode(node: N, i: number) {
         return node.childNodes[i] as N | T;
     }
 
-    /*
+    /**
      * @override
      */
     public kind(node: N | T) {
         return node.nodeName.toLowerCase();
     }
 
-    /*
+    /**
      * @override
      */
     public value(node: N | T) {
         return node.nodeValue || '';
     }
 
-    /*
+    /**
      * @override
      */
     public textContent(node: N) {
         return node.textContent;
     }
 
-    /*
+    /**
      * @override
      */
     public innerHTML(node: N) {
         return node.innerHTML;
     }
 
-    /*
+    /**
      * @override
      */
     public outerHTML(node: N) {
         return node.outerHTML;
     }
 
-    /*
+    /**
      * @override
      */
     public setAttribute(node: N, name: string, value: string) {
         return node.setAttribute(name, value);
     }
 
-    /*
+    /**
      * @override
      */
     public getAttribute(node: N, name: string) {
         return node.getAttribute(name);
     }
 
-    /*
+    /**
      * @override
      */
     public removeAttribute(node: N, name: string) {
         return node.removeAttribute(name);
     }
 
-    /*
+    /**
      * @override
      */
     public hasAttribute(node: N, name: string) {
         return node.hasAttribute(name);
     }
 
-    /*
+    /**
      * @override
      */
     public allAttributes(node: N) {
@@ -424,49 +410,49 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         );
     }
 
-    /*
+    /**
      * @override
      */
     public addClass(node: N, name: string) {
         node.classList.add(name);
     }
 
-    /*
+    /**
      * @override
      */
     public removeClass(node: N, name: string) {
         return node.classList.remove(name);
     }
 
-    /*
+    /**
      * @override
      */
     public hasClass(node: N, name: string) {
         return node.classList.contains(name);
     }
 
-    /*
+    /**
      * @override
      */
     public setStyle(node: N, name: string, value: string) {
         (node.style as OptionList)[name] = value;
     }
 
-    /*
+    /**
      * @override
      */
     public getStyle(node: N, name: string) {
         return (node.style as OptionList)[name];
     }
 
-    /*
+    /**
      * @override
      */
     public allStyles(node: N) {
         return node.style.cssText;
     }
 
-    /*
+    /**
      * @override
      */
     public fontSize(node: N) {
@@ -474,7 +460,7 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
         return parseFloat(style.fontSize);
     }
 
-    /*
+    /**
      * @override
      */
     public nodeSize(node: N) {

--- a/mathjax3-ts/adaptors/browserAdaptor.ts
+++ b/mathjax3-ts/adaptors/browserAdaptor.ts
@@ -40,7 +40,7 @@ declare global {
 /**
  * Function to create an HTML adpator for browsers
  *
- * @return{HTMLAdaptor}  The newly created adaptor
+ * @return {HTMLAdaptor}  The newly created adaptor
  */
 export function browserAdaptor() {
     return new HTMLAdaptor<HTMLElement, Text, Document>(window);

--- a/mathjax3-ts/adaptors/browserAdaptor.ts
+++ b/mathjax3-ts/adaptors/browserAdaptor.ts
@@ -37,8 +37,10 @@ declare global {
     }
 }
 
-/*
+/**
  * Function to create an HTML adpator for browsers
+ *
+ * @return{HTMLAdaptor}  The newly created adaptor
  */
 export function browserAdaptor() {
     return new HTMLAdaptor<HTMLElement, Text, Document>(window);

--- a/mathjax3-ts/adaptors/chooseAdaptor.ts
+++ b/mathjax3-ts/adaptors/chooseAdaptor.ts
@@ -34,7 +34,7 @@ try {
     choose = liteAdaptor;
 }
 
-/*
+/**
  * Function to selecting which adaptor to use (depending on whether we are in a browser of node.js)
  */
 export const chooseAdaptor = choose;

--- a/mathjax3-ts/adaptors/jsdomAdaptor.ts
+++ b/mathjax3-ts/adaptors/jsdomAdaptor.ts
@@ -23,8 +23,11 @@
 
 import {HTMLAdaptor} from './HTMLAdaptor.js';
 
-/*
+/**
  * Function for creating an HTML adaptor using jsdom
+ *
+ * @param{any} JSDOM      The jsdom object to use for this adaptor
+ * @return{HTMLAdaptor}   The newly created adaptor
  */
 export function jsdomAdaptor(JSDOM: any) {
     return new HTMLAdaptor<HTMLElement, Text, Document>(new JSDOM().window);

--- a/mathjax3-ts/adaptors/jsdomAdaptor.ts
+++ b/mathjax3-ts/adaptors/jsdomAdaptor.ts
@@ -26,8 +26,8 @@ import {HTMLAdaptor} from './HTMLAdaptor.js';
 /**
  * Function for creating an HTML adaptor using jsdom
  *
- * @param{any} JSDOM      The jsdom object to use for this adaptor
- * @return{HTMLAdaptor}   The newly created adaptor
+ * @param {any} JSDOM      The jsdom object to use for this adaptor
+ * @return {HTMLAdaptor}   The newly created adaptor
  */
 export function jsdomAdaptor(JSDOM: any) {
     return new HTMLAdaptor<HTMLElement, Text, Document>(new JSDOM().window);

--- a/mathjax3-ts/adaptors/lite/Document.ts
+++ b/mathjax3-ts/adaptors/lite/Document.ts
@@ -24,25 +24,25 @@
 import {LiteElement} from './Element.js';
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight Document replacement
  */
 export class LiteDocument {
-    /*
+    /**
      * The <html>, <head>, and <body> elements
      */
     public root: LiteElement;
     public head: LiteElement;
     public body: LiteElement;
 
-    /*
+    /**
      * The kind is always #document
      */
     public get kind() {
         return '#document';
     }
 
-    /*
+    /**
      * @constructor
      */
     constructor() {

--- a/mathjax3-ts/adaptors/lite/Element.ts
+++ b/mathjax3-ts/adaptors/lite/Element.ts
@@ -25,48 +25,48 @@ import {OptionList} from '../../util/Options.js';
 import {Styles} from '../../util/Styles.js';
 import {LiteText} from './Text.js';
 
-/*
+/**
  * Type for attribute lists
  */
 export type LiteAttributeList = OptionList;
 
-/*
+/**
  * Type for generic nodes in LiteAdaptor
  */
 export type LiteNode = LiteElement | LiteText;
 
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight HTML element replacement
  */
 export class LiteElement {
-    /*
+    /**
      * The type of element (tag name)
      */
     public kind: string;
 
-    /*
+    /**
      * The element's attribute list
      */
     public attributes: LiteAttributeList;
 
-    /*
+    /**
      * The element's children
      */
     public children: LiteNode[];
 
-    /*
+    /**
      * The element's parent
      */
     public parent: LiteElement;
 
-    /*
+    /**
      * The styles for the element
      */
     public styles: Styles;
 
-    /*
+    /**
      * @param{string} kind  The type of node to create
      * @param{LiteAttributeList} attributes  The list of attributes to set (if any)
      * @param{LiteNode[]} children  The children for the node (if any)

--- a/mathjax3-ts/adaptors/lite/Element.ts
+++ b/mathjax3-ts/adaptors/lite/Element.ts
@@ -67,9 +67,9 @@ export class LiteElement {
     public styles: Styles;
 
     /**
-     * @param{string} kind  The type of node to create
-     * @param{LiteAttributeList} attributes  The list of attributes to set (if any)
-     * @param{LiteNode[]} children  The children for the node (if any)
+     * @param {string} kind  The type of node to create
+     * @param {LiteAttributeList} attributes  The list of attributes to set (if any)
+     * @param {LiteNode[]} children  The children for the node (if any)
      * @constructor
      */
     constructor(kind: string, attributes: LiteAttributeList = {}, children: LiteNode[] = []) {

--- a/mathjax3-ts/adaptors/lite/List.ts
+++ b/mathjax3-ts/adaptors/lite/List.ts
@@ -36,7 +36,7 @@ export class LiteList<N> {
     public nodes: N[] = [];
 
     /**
-     * @param{N[]} children  The children for the fragment
+     * @param {N[]} children  The children for the fragment
      * @constructor
      */
     constructor(children: N[]) {
@@ -44,7 +44,7 @@ export class LiteList<N> {
     }
 
     /**
-     * @param{N} node  A node to append to the fragment
+     * @param {N} node  A node to append to the fragment
      */
     public append(node: N) {
         this.nodes.push(node);

--- a/mathjax3-ts/adaptors/lite/List.ts
+++ b/mathjax3-ts/adaptors/lite/List.ts
@@ -24,20 +24,18 @@
 import {LiteNode} from './Element.js';
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight DocumentFragment or NodeList replacement
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  */
 export class LiteList<N> {
-    /*
+    /**
      * The nodes held in the fragment
      */
     public nodes: N[] = [];
 
-    /*
+    /**
      * @param{N[]} children  The children for the fragment
      * @constructor
      */
@@ -45,14 +43,14 @@ export class LiteList<N> {
         this.nodes = [...children];
     }
 
-    /*
+    /**
      * @param{N} node  A node to append to the fragment
      */
     public append(node: N) {
         this.nodes.push(node);
     }
 
-    /*
+    /**
      * Make this class iterable (so it can be used with Array.from())
      */
     public [Symbol.iterator](): Iterator<LiteNode> {

--- a/mathjax3-ts/adaptors/lite/Parser.ts
+++ b/mathjax3-ts/adaptors/lite/Parser.ts
@@ -29,7 +29,7 @@ import {LiteElement} from './Element.js';
 import {LiteText, LiteComment} from './Text.js';
 import {LiteAdaptor} from '../liteAdaptor.js';
 
-/*
+/**
  * Patterns used in parsing serialized HTML
  */
 export namespace PATTERNS {
@@ -49,13 +49,13 @@ export namespace PATTERNS {
 }
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight DOMParser replacement
  * (Not perfect, but handles most well-formed HTML)
  */
 export class LiteParser implements MinDOMParser<LiteDocument> {
 
-    /*
+    /**
      * The list of self-closing tags
      */
     public static SELF_CLOSING: {[name: string]: boolean} = {
@@ -78,7 +78,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         wbr: true
     };
 
-    /*
+    /**
      * The list of tags chose content is not parsed (PCDATA)
      */
     public static PCDATA: {[name: string]: boolean} = {
@@ -90,7 +90,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         script: true
     };
 
-    /*
+    /**
      * The list of attributes that don't get entity translation
      */
     public static CDATA_ATTR: {[name: string]: boolean} = {
@@ -110,7 +110,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         scheme: true
     };
 
-    /*
+    /**
      * @override
      */
     public parseFromString(text: string, format: string = 'text/html', adaptor: LiteAdaptor = null) {
@@ -141,7 +141,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return root;
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node to add a text element to
      * @param{string} text          The text for the text node
@@ -152,7 +152,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return adaptor.append(node, adaptor.text(text)) as LiteText;
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node to add a comment to
      * @param{string} comment       The text for the comment node
@@ -162,7 +162,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return adaptor.append(node, new LiteComment(comment)) as LiteComment;
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node to close
      * @param{string} tag           The close tag being processed
@@ -176,7 +176,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return adaptor.parent(node);
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The parent node for the tag
      * @param{string} tag           The tag being processed
@@ -222,7 +222,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return node;
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node getting the attributes
      * @param{string[]} attributes  The array of space, name, value1, value2, value3
@@ -240,7 +240,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         }
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node whose PCDATA content is being collected
      * @param{string} kind          The tag name being handled
@@ -266,7 +266,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         adaptor.append(node, adaptor.text(pcdata.join('')));
     }
 
-    /*
+    /**
      * Check the contents of the parsed document and move html, head, and body
      * tags into the document structure.  That way, you can parse fragements or
      * full documents and still get a valid document.
@@ -315,7 +315,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         }
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node to serialize
      * @return{string}              The serialized element (like outerHTML)
@@ -333,7 +333,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return html;
     }
 
-    /*
+    /**
      * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
      * @param{LiteElement} node     The node whose innerHTML is needed
      * @return{string}              The serialized element (like innerHTML)
@@ -347,7 +347,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         }).join('');
     }
 
-    /*
+    /**
      * @param{string} text  The attribute value to be HTML escaped
      * @return{string}      The string with " replaced by entities
      */
@@ -355,7 +355,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         return text.replace(/"/, '&quot;');
     }
 
-    /*
+    /**
      * @param{string} text  The text to be HTML escaped
      * @return{string}      The string with &, <, and > replaced by entities
      */

--- a/mathjax3-ts/adaptors/lite/Parser.ts
+++ b/mathjax3-ts/adaptors/lite/Parser.ts
@@ -142,10 +142,10 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node to add a text element to
-     * @param{string} text          The text for the text node
-     * @return{LiteText}            The text element
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node to add a text element to
+     * @param {string} text          The text for the text node
+     * @return {LiteText}            The text element
      */
     protected addText(adaptor: LiteAdaptor, node: LiteElement, text: string) {
         text = Entities.translate(text);
@@ -153,20 +153,20 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node to add a comment to
-     * @param{string} comment       The text for the comment node
-     * @return{LiteText}            The comment element
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node to add a comment to
+     * @param {string} comment       The text for the comment node
+     * @return {LiteText}            The comment element
      */
     protected addComment(adaptor: LiteAdaptor, node: LiteElement, comment: string) {
         return adaptor.append(node, new LiteComment(comment)) as LiteComment;
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node to close
-     * @param{string} tag           The close tag being processed
-     * @return{LiteElement}         The first unclosed parent node
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node to close
+     * @param {string} tag           The close tag being processed
+     * @return {LiteElement}         The first unclosed parent node
      */
     protected closeTag(adaptor: LiteAdaptor, node: LiteElement, tag: string) {
         const kind = tag.slice(2,tag.length - 1).toLowerCase();
@@ -177,11 +177,11 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The parent node for the tag
-     * @param{string} tag           The tag being processed
-     * @param{string[]} parts       The rest of the text/tag array
-     * @return{LiteElement}         The node to which the next tag will be added
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The parent node for the tag
+     * @param {string} tag           The tag being processed
+     * @param {string[]} parts       The rest of the text/tag array
+     * @return {LiteElement}         The node to which the next tag will be added
      */
     protected openTag(adaptor: LiteAdaptor, node: LiteElement, tag: string, parts: string[]) {
         const PCDATA = (this.constructor as typeof LiteParser).PCDATA;
@@ -223,9 +223,9 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node getting the attributes
-     * @param{string[]} attributes  The array of space, name, value1, value2, value3
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node getting the attributes
+     * @param {string[]} attributes  The array of space, name, value1, value2, value3
      *                                as described above.
      */
     protected addAttributes(adaptor: LiteAdaptor, node: LiteElement, attributes: string[]) {
@@ -241,10 +241,10 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node whose PCDATA content is being collected
-     * @param{string} kind          The tag name being handled
-     * @param{string[]} parts       The array of text/tag data for the document
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node whose PCDATA content is being collected
+     * @param {string} kind          The tag name being handled
+     * @param {string[]} parts       The array of text/tag data for the document
      */
     protected handlePCDATA(adaptor: LiteAdaptor, node: LiteElement, kind: string, parts: string[]) {
         const pcdata = [] as string[];
@@ -271,8 +271,8 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
      * tags into the document structure.  That way, you can parse fragements or
      * full documents and still get a valid document.
      *
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteDocuemnt} root    The document being checked
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteDocuemnt} root    The document being checked
      */
     protected checkDocument(adaptor: LiteAdaptor, root: LiteDocument) {
         if (adaptor.childNodes(adaptor.body(root)).length !== 1) return;
@@ -316,9 +316,9 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node to serialize
-     * @return{string}              The serialized element (like outerHTML)
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node to serialize
+     * @return {string}              The serialized element (like outerHTML)
      */
     public serialize(adaptor: LiteAdaptor, node: LiteElement) {
         const SELF_CLOSING = (this.constructor as typeof LiteParser).SELF_CLOSING;
@@ -334,9 +334,9 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{LiteAdaptor} adaptor  The adaptor for managing nodes
-     * @param{LiteElement} node     The node whose innerHTML is needed
-     * @return{string}              The serialized element (like innerHTML)
+     * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
+     * @param {LiteElement} node     The node whose innerHTML is needed
+     * @return {string}              The serialized element (like innerHTML)
      */
     public serializeInner(adaptor: LiteAdaptor, node: LiteElement) {
         return adaptor.childNodes(node).map(x => {
@@ -348,16 +348,16 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     }
 
     /**
-     * @param{string} text  The attribute value to be HTML escaped
-     * @return{string}      The string with " replaced by entities
+     * @param {string} text  The attribute value to be HTML escaped
+     * @return {string}      The string with " replaced by entities
      */
     public protectAttribute(text: string) {
         return text.replace(/"/, '&quot;');
     }
 
     /**
-     * @param{string} text  The text to be HTML escaped
-     * @return{string}      The string with &, <, and > replaced by entities
+     * @param {string} text  The text to be HTML escaped
+     * @return {string}      The string with &, <, and > replaced by entities
      */
     public protectHTML(text: string) {
         return text.replace(/&/g, '&amp;')

--- a/mathjax3-ts/adaptors/lite/Text.ts
+++ b/mathjax3-ts/adaptors/lite/Text.ts
@@ -46,7 +46,7 @@ export class LiteText {
     }
 
     /**
-     * @param{string} text  The text for the node
+     * @param {string} text  The text for the node
      * @constructor
      */
     constructor(text: string = "") {

--- a/mathjax3-ts/adaptors/lite/Text.ts
+++ b/mathjax3-ts/adaptors/lite/Text.ts
@@ -24,28 +24,28 @@
 import {LiteElement} from './Element.js';
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight Text node replacement
  */
 export class LiteText {
-    /*
+    /**
      * The text stored in the node
      */
     public value: string;
 
-    /*
+    /**
      * The parent holding this text
      */
     public parent: LiteElement;
 
-    /*
+    /**
      * The kind of node is #text
      */
     public get kind() {
         return '#text';
     }
 
-    /*
+    /**
      * @param{string} text  The text for the node
      * @constructor
      */
@@ -55,7 +55,7 @@ export class LiteText {
 }
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight Comment node replacement
  */
 export class LiteComment extends LiteText {

--- a/mathjax3-ts/adaptors/lite/Window.ts
+++ b/mathjax3-ts/adaptors/lite/Window.ts
@@ -27,7 +27,7 @@ import {LiteList} from './List.js';
 import {LiteParser} from './Parser.js';
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight Window replacement
  */
 export class LiteWindow {

--- a/mathjax3-ts/adaptors/liteAdaptor.ts
+++ b/mathjax3-ts/adaptors/liteAdaptor.ts
@@ -32,38 +32,38 @@ import {Styles} from '../util/Styles.js';
 import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
 
 /************************************************************/
-/*
+/**
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
 export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocument> {
-    /*
+    /**
      * The default options
      */
     public static OPTIONS: OptionList = {
         fontSize: 16,      // we can't compute the font size, so always use this
     };
 
-    /*
+    /**
      * The options for the instance
      */
     public options: OptionList;
 
-    /*
+    /**
      * The document in which the HTML nodes will be created
      */
     public document: LiteDocument;
 
-    /*
+    /**
      * The window for the document
      */
     public window: LiteWindow;
 
-    /*
+    /**
      * The parser for serialized HTML
      */
     public parser: LiteParser;
 
-    /*
+    /**
      * @param{OptionList} options  The options for the lite adaptor (e.g., fontSize)
      * @constructor
      */
@@ -75,28 +75,28 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         this.window = new LiteWindow();
     }
 
-    /*
+    /**
      * @override
      */
     public parse(text: string, format?: string) {
         return this.parser.parseFromString(text, format, this);
     };
 
-    /*
+    /**
      * @override
      */
     protected create(type: string) {
         return new LiteElement(type);
     }
 
-    /*
+    /**
      * @override
      */
     public text(text: string) {
         return new LiteText(text);
     }
 
-    /*
+    /**
      * @param{string} text   The text of the comment
      * @return{LiteComment}  The comment node
      */
@@ -104,35 +104,35 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return new LiteComment(text);
     }
 
-    /*
+    /**
      * @return{LiteDocument}  A new document element
      */
     public createDocument() {
         return new LiteDocument();
     }
 
-    /*
+    /**
      * @override
      */
     public head(doc: LiteDocument) {
         return doc.head;
     }
 
-    /*
+    /**
      * @override
      */
     public body(doc: LiteDocument) {
         return doc.body;
     }
 
-    /*
+    /**
      * @override
      */
     public root(doc: LiteDocument) {
         return doc.root;
     }
 
-    /*
+    /**
      * @override
      */
     public tags(node: LiteElement, name: string, ns: string = null) {
@@ -158,7 +158,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return tags;
     }
 
-    /*
+    /**
      * @param{LiteELement} node   The node to be searched
      * @param{string} id          The id of the node to look for
      * @return{LiteElement}       The child node having the given id
@@ -181,7 +181,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return null as LiteElement;
     }
 
-    /*
+    /**
      * @param{LiteELement} node   The node to be searched
      * @param{string} name        The name of the class to find
      * @return{LiteElement[]}     The nodes with the given class
@@ -206,7 +206,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return tags;
     }
 
-    /*
+    /**
      * @override
      */
     public getElements(nodes: (string | LiteElement | LiteElement[])[], document: LiteDocument) {
@@ -235,14 +235,14 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return containers;
     }
 
-    /*
+    /**
      * @override
      */
     public parent(node: LiteNode) {
         return node.parent;
     }
 
-    /*
+    /**
      * @param{LiteNode} node  The node whose index is needed
      * @return{number}        THe index of the node it its parent's children array
      */
@@ -250,7 +250,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return (node.parent ? node.parent.children.findIndex(n => n === node) : -1);
     }
 
-    /*
+    /**
      * @override
      */
     public append(node: LiteElement, child: LiteNode) {
@@ -262,7 +262,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return child;
     }
 
-    /*
+    /**
      * @override
      */
     public insert(nchild: LiteNode, ochild: LiteNode) {
@@ -276,7 +276,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         }
     }
 
-    /*
+    /**
      * @override
      */
     public remove(child: LiteNode) {
@@ -288,7 +288,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return child;
     }
 
-    /*
+    /**
      * @override
      */
     public replace(nnode: LiteNode, onode: LiteNode) {
@@ -299,7 +299,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return onode;
     }
 
-    /*
+    /**
      * @override
      */
     public clone(node: LiteElement) {
@@ -319,7 +319,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return nnode;
     }
 
-    /*
+    /**
      * @override
      */
     public split(node: LiteText, n: number) {
@@ -330,7 +330,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return text;
     }
 
-    /*
+    /**
      * @override
      */
     public next(node: LiteNode) {
@@ -340,7 +340,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return (i >= 0 && i < parent.children.length ? parent.children[i] : null);
     }
 
-    /*
+    /**
      * @override
      */
     public previous(node: LiteNode) {
@@ -350,49 +350,49 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return (i >= 0 ? parent.children[i] : null);
     }
 
-    /*
+    /**
      * @override
      */
     public firstChild(node: LiteElement) {
         return node.children[0];
     }
 
-    /*
+    /**
      * @override
      */
     public lastChild(node: LiteElement) {
         return node.children[node.children.length - 1];
     }
 
-    /*
+    /**
      * @override
      */
     public childNodes(node: LiteElement) {
         return [...node.children];
     }
 
-    /*
+    /**
      * @override
      */
     public childNode(node: LiteElement, i: number) {
         return node.children[i];
     }
 
-    /*
+    /**
      * @override
      */
     public kind(node: LiteNode) {
         return node.kind;
     }
 
-    /*
+    /**
      * @override
      */
     public value(node: LiteNode | LiteText) {
         return (node.kind === '#text' ? (node as LiteText).value : '');
     }
 
-    /*
+    /**
      * @override
      */
     public textContent(node: LiteElement): string {
@@ -406,14 +406,14 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return this.parser.serializeInner(this, node);
     }
 
-    /*
+    /**
      * @override
      */
     public outerHTML(node: LiteElement) {
         return this.parser.serialize(this, node);
     }
 
-    /*
+    /**
      * @override
      */
     public setAttribute(node: LiteElement, name: string, value: string) {
@@ -423,28 +423,28 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         }
     }
 
-    /*
+    /**
      * @override
      */
     public getAttribute(node: LiteElement, name: string) {
         return node.attributes[name];
     }
 
-    /*
+    /**
      * @override
      */
     public removeAttribute(node: LiteElement, name: string) {
         delete node.attributes[name];
     }
 
-    /*
+    /**
      * @override
      */
     public hasAttribute(node: LiteElement, name: string) {
         return node.attributes.hasOwnProperty(name);
     }
 
-    /*
+    /**
      * @override
      */
     public allAttributes(node: LiteElement) {
@@ -456,7 +456,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return list;
     }
 
-    /*
+    /**
      * @override
      */
     public addClass(node: LiteElement, name: string) {
@@ -467,7 +467,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         }
     }
 
-    /*
+    /**
      * @override
      */
     public removeClass(node: LiteElement, name: string) {
@@ -479,7 +479,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         }
     }
 
-    /*
+    /**
      * @override
      */
     public hasClass(node: LiteElement, name: string) {
@@ -487,7 +487,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return !!classes.find(n => n === name);
     }
 
-    /*
+    /**
      * @override
      */
     public setStyle(node: LiteElement, name: string, value: string) {
@@ -498,7 +498,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         node.attributes['style'] = node.styles.cssText;
     }
 
-    /*
+    /**
      * @override
      */
     public getStyle(node: LiteElement, name: string) {
@@ -512,21 +512,21 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
         return node.styles.get(name);
     }
 
-    /*
+    /**
      * @override
      */
     public allStyles(node: LiteElement) {
         return this.getAttribute(node, 'style');
     }
 
-    /*
+    /**
      * @override
      */
     public fontSize(node: LiteElement) {
         return this.options.fontSize;
     }
 
-    /*
+    /**
      * @override
      */
     public nodeSize(node: LiteElement) {
@@ -536,8 +536,11 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
 }
 
 /************************************************************/
-/*
+/**
  * The function to call to obtain a LiteAdaptor
+ *
+ * @param{OptionList} options  The options for the adaptor
+ * @return{LiteAdaptor}        The newly created adaptor
  */
 export function liteAdaptor(options: OptionList = null) {
     return new LiteAdaptor(options);

--- a/mathjax3-ts/adaptors/liteAdaptor.ts
+++ b/mathjax3-ts/adaptors/liteAdaptor.ts
@@ -64,7 +64,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     public parser: LiteParser;
 
     /**
-     * @param{OptionList} options  The options for the lite adaptor (e.g., fontSize)
+     * @param {OptionList} options  The options for the lite adaptor (e.g., fontSize)
      * @constructor
      */
     constructor(options: OptionList = null) {
@@ -97,15 +97,15 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     }
 
     /**
-     * @param{string} text   The text of the comment
-     * @return{LiteComment}  The comment node
+     * @param {string} text   The text of the comment
+     * @return {LiteComment}  The comment node
      */
     public comment(text: string) {
         return new LiteComment(text);
     }
 
     /**
-     * @return{LiteDocument}  A new document element
+     * @return {LiteDocument}  A new document element
      */
     public createDocument() {
         return new LiteDocument();
@@ -159,9 +159,9 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     }
 
     /**
-     * @param{LiteELement} node   The node to be searched
-     * @param{string} id          The id of the node to look for
-     * @return{LiteElement}       The child node having the given id
+     * @param {LiteELement} node   The node to be searched
+     * @param {string} id          The id of the node to look for
+     * @return {LiteElement}       The child node having the given id
      */
     public elementById(node: LiteElement, id: string) {
         let stack = [] as LiteNode[];
@@ -182,9 +182,9 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     }
 
     /**
-     * @param{LiteELement} node   The node to be searched
-     * @param{string} name        The name of the class to find
-     * @return{LiteElement[]}     The nodes with the given class
+     * @param {LiteELement} node   The node to be searched
+     * @param {string} name        The name of the class to find
+     * @return {LiteElement[]}     The nodes with the given class
      */
     public elementsByClass(node: LiteElement, name: string) {
         let stack = [] as LiteNode[];
@@ -243,8 +243,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     }
 
     /**
-     * @param{LiteNode} node  The node whose index is needed
-     * @return{number}        THe index of the node it its parent's children array
+     * @param {LiteNode} node  The node whose index is needed
+     * @return {number}        THe index of the node it its parent's children array
      */
     public childIndex(node: LiteNode) {
         return (node.parent ? node.parent.children.findIndex(n => n === node) : -1);
@@ -539,8 +539,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
 /**
  * The function to call to obtain a LiteAdaptor
  *
- * @param{OptionList} options  The options for the adaptor
- * @return{LiteAdaptor}        The newly created adaptor
+ * @param {OptionList} options  The options for the adaptor
+ * @return {LiteAdaptor}        The newly created adaptor
  */
 export function liteAdaptor(options: OptionList = null) {
     return new LiteAdaptor(options);

--- a/mathjax3-ts/core/DOMAdaptor.ts
+++ b/mathjax3-ts/core/DOMAdaptor.ts
@@ -47,49 +47,49 @@ export interface DOMAdaptor<N, T, D> {
     document: D;
 
     /**
-     * @param{string} text    The serialized document to be parsed
-     * @param{string} format  The format (e.g., 'text/html' or 'text/xhtml')
-     * @return{D}             The parsed document
+     * @param {string} text    The serialized document to be parsed
+     * @param {string} format  The format (e.g., 'text/html' or 'text/xhtml')
+     * @return {D}             The parsed document
      */
     parse(text: string, format?: string): D;
 
     /**
-     * @param{string} type      The tag name of the HTML node to be created
-     * @param{OptionList} def   The properties to set for the created node
-     * @param{(N|T)[]} content  The child nodes for the created HTML node
-     * @return{N}               The generated HTML tree
+     * @param {string} type      The tag name of the HTML node to be created
+     * @param {OptionList} def   The properties to set for the created node
+     * @param {(N|T)[]} content  The child nodes for the created HTML node
+     * @return {N}               The generated HTML tree
      */
     node(type: string, def?: OptionList, children?: (N | T)[]): N;
 
     /**
-     * @param{string} text   The text from which to create an HTML text node
-     * @return{T}            The generated text node with the given text
+     * @param {string} text   The text from which to create an HTML text node
+     * @return {T}            The generated text node with the given text
      */
     text(text: string): T;
 
     /**
-     * @param{D} doc   The document whose head is to be obtained
-     * @return{N}      The document.head element
+     * @param {D} doc   The document whose head is to be obtained
+     * @return {N}      The document.head element
      */
     head(doc: D): N;
 
     /**
-     * @param{D} doc   The document whose body is to be obtained
-     * @return{N}      The document.body element
+     * @param {D} doc   The document whose body is to be obtained
+     * @return {N}      The document.body element
      */
     body(doc: D): N;
 
     /**
-     * @param{D} doc   The document whose documentElement is to be obtained
-     * @return{N}      The documentElement
+     * @param {D} doc   The document whose documentElement is to be obtained
+     * @return {N}      The documentElement
      */
     root(doc: D): N;
 
     /**
-     * @param{N} node        The node to search for tags
-     * @param{string} name   The name of the tag to search for
-     * @param{string} ns     The namespace to search in (or null for no namespace)
-     * @return{N[]}          The list of tags found
+     * @param {N} node        The node to search for tags
+     * @param {string} name   The name of the tag to search for
+     * @param {string} ns     The namespace to search in (or null for no namespace)
+     * @return {N[]}          The list of tags found
      */
     tags(node: N, name: string, ns?: string): N[];
 
@@ -97,210 +97,210 @@ export interface DOMAdaptor<N, T, D> {
      * Get a list of containers (to be searched for math).  These can be
      *  specified by CSS selector, or as actual DOM elements or arrays of such.
      *
-     * @param{(string | N | N[])[]} nodes  The array of items to make into a container list
-     * @param{D} document                  The document in which to search
-     * @return{N[]}                        The array of containers to search
+     * @param {(string | N | N[])[]} nodes  The array of items to make into a container list
+     * @param {D} document                  The document in which to search
+     * @return {N[]}                        The array of containers to search
      */
     getElements(nodes: (string | N | N[])[], document: D): N[];
 
     /**
-     * @param{N|T} node  The HTML node whose parent is to be obtained
-     * @return{N}        The parent node of the given one
+     * @param {N|T} node  The HTML node whose parent is to be obtained
+     * @return {N}        The parent node of the given one
      */
     parent(node: N | T): N;
 
     /**
-     * @param{N} node     The HTML node to be appended to
-     * @param{N|T} child  The node or text to be appended
-     * @return{N|T}       The appended node
+     * @param {N} node     The HTML node to be appended to
+     * @param {N|T} child  The node or text to be appended
+     * @return {N|T}       The appended node
      */
     append(node: N, child: N | T): N | T;
 
     /**
-     * @param{N|T} nchild  The node or text to be inserted
-     * @param{N|T} ochild  The node or text where the new child is to be added before it
+     * @param {N|T} nchild  The node or text to be inserted
+     * @param {N|T} ochild  The node or text where the new child is to be added before it
      */
     insert(nchild: N | T, ochild: N | T): void;
 
     /**
-     * @param{N|T} child  The node or text to be removed from its parent
-     * @return{N|T}       The removed node
+     * @param {N|T} child  The node or text to be removed from its parent
+     * @return {N|T}       The removed node
      */
     remove(child: N | T): N | T;
 
     /**
-     * @param{N|T} nnode  The node to replace with
-     * @param{N|T} onode  The child to be replaced
-     * @return{N|T}       The removed node
+     * @param {N|T} nnode  The node to replace with
+     * @param {N|T} onode  The child to be replaced
+     * @return {N|T}       The removed node
      */
     replace(nnode: N | T, onode: N | T): N | T;
 
     /**
-     * @param{N} node   The HTML node to be cloned
-     * @return{N}       The copied node
+     * @param {N} node   The HTML node to be cloned
+     * @return {N}       The copied node
      */
     clone(node: N): N;
 
     /**
-     * @param{T} node    The HTML text node to be split
-     * @param{number} n  The index of the character where the split will occur
+     * @param {T} node    The HTML text node to be split
+     * @param {number} n  The index of the character where the split will occur
      */
     split(node: T, n: number): T;
 
     /**
-     * @param{N|T} node   The HTML node whose sibling is to be obtained
-     * @return{N|T}       The node following the given one (or null)
+     * @param {N|T} node   The HTML node whose sibling is to be obtained
+     * @return {N|T}       The node following the given one (or null)
      */
     next(node: N | T): N | T;
 
     /**
-     * @param{N|T} node   The HTML node whose sibling is to be obtained
-     * @return{N|T}       The node preceding the given one (or null)
+     * @param {N|T} node   The HTML node whose sibling is to be obtained
+     * @return {N|T}       The node preceding the given one (or null)
      */
     previous(node: N | T): N | T;
 
     /**
-     * @param{N} node   The HTML node whose child is to be obtained
-     * @return{N|T}     The first child of the given node (or null)
+     * @param {N} node   The HTML node whose child is to be obtained
+     * @return {N|T}     The first child of the given node (or null)
      */
     firstChild(node: N): N | T;
 
     /**
-     * @param{N} node   The HTML node whose child is to be obtained
-     * @return{N}       The last child of the given node (or null)
+     * @param {N} node   The HTML node whose child is to be obtained
+     * @return {N}       The last child of the given node (or null)
      */
     lastChild(node: N): N | T;
 
     /**
-     * @param{N} node    The HTML node whose children are to be obtained
-     * @return{(N|T)[]}  Array of children for the given node (not a live list)
+     * @param {N} node    The HTML node whose children are to be obtained
+     * @return {(N|T)[]}  Array of children for the given node (not a live list)
      */
     childNodes(node: N): (N | T)[];
 
     /**
-     * @param{N} node    The HTML node whose child is to be obtained
-     * @param{number} i  The index of the child to return
-     * @return{N|T}      The i-th child node of the given node (or null)
+     * @param {N} node    The HTML node whose child is to be obtained
+     * @param {number} i  The index of the child to return
+     * @return {N|T}      The i-th child node of the given node (or null)
      */
     childNode(node: N, i: number): N | T;
 
     /**
-     * @param{N | T} node   The HTML node whose tag or node name is to be obtained
-     * @return{string}      The tag or node name of the given node
+     * @param {N | T} node   The HTML node whose tag or node name is to be obtained
+     * @return {string}      The tag or node name of the given node
      */
     kind(node: N | T): string;
 
     /**
-     * @param{N|T} node  The HTML node whose value is to be obtained
-     * @return{string}   The value of the given node
+     * @param {N|T} node  The HTML node whose value is to be obtained
+     * @return {string}   The value of the given node
      */
     value(node: N | T): string;
 
     /**
-     * @param{N} node    The HTML node whose text content is to be obtained
-     * @return{string}   The text content of the given node
+     * @param {N} node    The HTML node whose text content is to be obtained
+     * @return {string}   The text content of the given node
      */
     textContent(node: N): string;
 
     /**
-     * @param{N} node   The HTML node whose inner HTML string is to be obtained
-     * @return{string}  The serialized content of the node
+     * @param {N} node   The HTML node whose inner HTML string is to be obtained
+     * @return {string}  The serialized content of the node
      */
     innerHTML(node: N): string;
 
     /**
-     * @param{N} node   The HTML node whose outer HTML string is to be obtained
-     * @return{string}  The serialized node and its content
+     * @param {N} node   The HTML node whose outer HTML string is to be obtained
+     * @return {string}  The serialized node and its content
      */
     outerHTML(node: N): string;
 
     /**
-     * @param{N} node        The HTML node whose attribute is to be set
-     * @param{string} name   The name of the attribute to set
-     * @param{string} value  The new value of the attribute
+     * @param {N} node        The HTML node whose attribute is to be set
+     * @param {string} name   The name of the attribute to set
+     * @param {string} value  The new value of the attribute
      */
     setAttribute(node: N, name: string, value: string): void;
 
     /**
-     * @param{N} node        The HTML node whose attribute is to be obtained
-     * @param{string} name   The name of the attribute to get
-     * @return{string}       The value of the given attribute of the given node
+     * @param {N} node        The HTML node whose attribute is to be obtained
+     * @param {string} name   The name of the attribute to get
+     * @return {string}       The value of the given attribute of the given node
      */
     getAttribute(node: N, name: string): string;
 
     /**
-     * @param{N} node        The HTML node whose attribute is to be removed
-     * @param{string} name   The name of the attribute to remove
+     * @param {N} node        The HTML node whose attribute is to be removed
+     * @param {string} name   The name of the attribute to remove
      */
     removeAttribute(node: N, name: string): void;
 
     /**
-     * @param{N} node        The HTML node whose attribute is to be tested
-     * @param{string} name   The name of the attribute to test
-     * @return{boolean}      True of the node has the given attribute defined
+     * @param {N} node        The HTML node whose attribute is to be tested
+     * @param {string} name   The name of the attribute to test
+     * @return {boolean}      True of the node has the given attribute defined
      */
     hasAttribute(node: N, name: string): boolean;
 
     /**
-     * @param{N} node           The HTML node whose attributes are to be returned
-     * @return{AttributeData[]} The list of attributes
+     * @param {N} node           The HTML node whose attributes are to be returned
+     * @return {AttributeData[]} The list of attributes
      */
     allAttributes(node: N): AttributeData[];
 
     /**
-     * @param{N} node        The HTML node whose class is to be augmented
-     * @param{string} name   The class to be added
+     * @param {N} node        The HTML node whose class is to be augmented
+     * @param {string} name   The class to be added
      */
     addClass(node: N, name: string): void;
 
     /**
-     * @param{N} node        The HTML node whose class is to be changed
-     * @param{string} name   The class to be removed
+     * @param {N} node        The HTML node whose class is to be changed
+     * @param {string} name   The class to be removed
      */
     removeClass(node: N, name: string): void;
 
     /**
-     * @param{N} node        The HTML node whose class is to be tested
-     * @param{string} name   The class to test
-     * @return{boolean}      True if the node has the given class
+     * @param {N} node        The HTML node whose class is to be tested
+     * @param {string} name   The class to test
+     * @return {boolean}      True if the node has the given class
      */
     hasClass(node: N, name: string): void;
 
     /**
-     * @param{N} node        The HTML node whose class list is needed
-     * @return{string[]}     An array of the class names for this node
+     * @param {N} node        The HTML node whose class list is needed
+     * @return {string[]}     An array of the class names for this node
      */
     allClasses(node: N): string[];
 
     /**
-     * @param{N} node        The HTML node whose style is to be changed
-     * @param{string} name   The style to be set
-     * @param{string} name   The new value of the style
+     * @param {N} node        The HTML node whose style is to be changed
+     * @param {string} name   The style to be set
+     * @param {string} name   The new value of the style
      */
     setStyle(node: N, name: string, value: string): void;
 
     /**
-     * @param{N} node        The HTML node whose style is to be obtained
-     * @param{string} name   The style to be obtained
-     * @return{string}       The value of the style
+     * @param {N} node        The HTML node whose style is to be obtained
+     * @param {string} name   The style to be obtained
+     * @return {string}       The value of the style
      */
     getStyle(node: N, name: string): string;
 
     /**
-     * @param{N} node        The HTML node whose styles are to be returned
-     * @return{string}       The cssText for the styles
+     * @param {N} node        The HTML node whose styles are to be returned
+     * @return {string}       The cssText for the styles
      */
     allStyles(node: N): string;
 
     /**
-     * @param{N} node        The HTML node whose font size is to be determined
-     * @return{number}       The font size (in pixels) of the node
+     * @param {N} node        The HTML node whose font size is to be determined
+     * @return {number}       The font size (in pixels) of the node
      */
     fontSize(node: N): number;
 
     /**
-     * @param{N} node            The HTML node whose dimensions are to be determined
-     * @return{[number, number]} The width and height (in pixels) of the element
+     * @param {N} node            The HTML node whose dimensions are to be determined
+     * @return {[number, number]} The width and height (in pixels) of the element
      */
     nodeSize(node: N): [number, number];
 }
@@ -321,7 +321,7 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
     public document: D;
 
     /**
-     * @param{D} document  The document in which the nodes will be created
+     * @param {D} document  The document in which the nodes will be created
      * @constructor
      */
     constructor(document: D = null) {
@@ -346,8 +346,8 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
     }
 
     /**
-     * @param{string} type  The type of the node to create
-     * @return{N}           The created node
+     * @param {string} type  The type of the node to create
+     * @return {N}           The created node
      */
     protected abstract create(type: string): N;
 
@@ -357,8 +357,8 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
     public abstract text(text: string): T;
 
     /**
-     * @param{N} node           The HTML element whose attributes are to be set
-     * @param{OptionList} def   The attributes to set on that node
+     * @param {N} node           The HTML element whose attributes are to be set
+     * @param {OptionList} def   The attributes to set on that node
      */
     public setAttributes(node: N, def: OptionList) {
         if (def.style && typeof(def.style) !== 'string') {

--- a/mathjax3-ts/core/DOMAdaptor.ts
+++ b/mathjax3-ts/core/DOMAdaptor.ts
@@ -23,7 +23,7 @@
 
 import {OptionList} from '../util/Options.js';
 
-/*
+/**
  * The data for an attribute
  */
 export type AttributeData = {
@@ -33,29 +33,27 @@ export type AttributeData = {
 
 
 /*****************************************************************/
-/*
+/**
  *  The interface for the DOMAdaptor
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface DOMAdaptor<N, T, D> {
-    /*
+    /**
      * Document in which the nodes are to be created
      */
     document: D;
 
-    /*
+    /**
      * @param{string} text    The serialized document to be parsed
      * @param{string} format  The format (e.g., 'text/html' or 'text/xhtml')
      * @return{D}             The parsed document
      */
     parse(text: string, format?: string): D;
 
-    /*
+    /**
      * @param{string} type      The tag name of the HTML node to be created
      * @param{OptionList} def   The properties to set for the created node
      * @param{(N|T)[]} content  The child nodes for the created HTML node
@@ -63,31 +61,31 @@ export interface DOMAdaptor<N, T, D> {
      */
     node(type: string, def?: OptionList, children?: (N | T)[]): N;
 
-    /*
+    /**
      * @param{string} text   The text from which to create an HTML text node
      * @return{T}            The generated text node with the given text
      */
     text(text: string): T;
 
-    /*
+    /**
      * @param{D} doc   The document whose head is to be obtained
      * @return{N}      The document.head element
      */
     head(doc: D): N;
 
-    /*
+    /**
      * @param{D} doc   The document whose body is to be obtained
      * @return{N}      The document.body element
      */
     body(doc: D): N;
 
-    /*
+    /**
      * @param{D} doc   The document whose documentElement is to be obtained
      * @return{N}      The documentElement
      */
     root(doc: D): N;
 
-    /*
+    /**
      * @param{N} node        The node to search for tags
      * @param{string} name   The name of the tag to search for
      * @param{string} ns     The namespace to search in (or null for no namespace)
@@ -95,7 +93,7 @@ export interface DOMAdaptor<N, T, D> {
      */
     tags(node: N, name: string, ns?: string): N[];
 
-    /*
+    /**
      * Get a list of containers (to be searched for math).  These can be
      *  specified by CSS selector, or as actual DOM elements or arrays of such.
      *
@@ -105,202 +103,202 @@ export interface DOMAdaptor<N, T, D> {
      */
     getElements(nodes: (string | N | N[])[], document: D): N[];
 
-    /*
+    /**
      * @param{N|T} node  The HTML node whose parent is to be obtained
      * @return{N}        The parent node of the given one
      */
     parent(node: N | T): N;
 
-    /*
+    /**
      * @param{N} node     The HTML node to be appended to
      * @param{N|T} child  The node or text to be appended
      * @return{N|T}       The appended node
      */
     append(node: N, child: N | T): N | T;
 
-    /*
+    /**
      * @param{N|T} nchild  The node or text to be inserted
      * @param{N|T} ochild  The node or text where the new child is to be added before it
      */
     insert(nchild: N | T, ochild: N | T): void;
 
-    /*
+    /**
      * @param{N|T} child  The node or text to be removed from its parent
      * @return{N|T}       The removed node
      */
     remove(child: N | T): N | T;
 
-    /*
+    /**
      * @param{N|T} nnode  The node to replace with
      * @param{N|T} onode  The child to be replaced
      * @return{N|T}       The removed node
      */
     replace(nnode: N | T, onode: N | T): N | T;
 
-    /*
+    /**
      * @param{N} node   The HTML node to be cloned
      * @return{N}       The copied node
      */
     clone(node: N): N;
 
-    /*
+    /**
      * @param{T} node    The HTML text node to be split
      * @param{number} n  The index of the character where the split will occur
      */
     split(node: T, n: number): T;
 
-    /*
+    /**
      * @param{N|T} node   The HTML node whose sibling is to be obtained
      * @return{N|T}       The node following the given one (or null)
      */
     next(node: N | T): N | T;
 
-    /*
+    /**
      * @param{N|T} node   The HTML node whose sibling is to be obtained
      * @return{N|T}       The node preceding the given one (or null)
      */
     previous(node: N | T): N | T;
 
-    /*
+    /**
      * @param{N} node   The HTML node whose child is to be obtained
      * @return{N|T}     The first child of the given node (or null)
      */
     firstChild(node: N): N | T;
 
-    /*
+    /**
      * @param{N} node   The HTML node whose child is to be obtained
      * @return{N}       The last child of the given node (or null)
      */
     lastChild(node: N): N | T;
 
-    /*
+    /**
      * @param{N} node    The HTML node whose children are to be obtained
      * @return{(N|T)[]}  Array of children for the given node (not a live list)
      */
     childNodes(node: N): (N | T)[];
 
-    /*
+    /**
      * @param{N} node    The HTML node whose child is to be obtained
      * @param{number} i  The index of the child to return
      * @return{N|T}      The i-th child node of the given node (or null)
      */
     childNode(node: N, i: number): N | T;
 
-    /*
+    /**
      * @param{N | T} node   The HTML node whose tag or node name is to be obtained
      * @return{string}      The tag or node name of the given node
      */
     kind(node: N | T): string;
 
-    /*
+    /**
      * @param{N|T} node  The HTML node whose value is to be obtained
      * @return{string}   The value of the given node
      */
     value(node: N | T): string;
 
-    /*
+    /**
      * @param{N} node    The HTML node whose text content is to be obtained
      * @return{string}   The text content of the given node
      */
     textContent(node: N): string;
 
-    /*
+    /**
      * @param{N} node   The HTML node whose inner HTML string is to be obtained
      * @return{string}  The serialized content of the node
      */
     innerHTML(node: N): string;
 
-    /*
+    /**
      * @param{N} node   The HTML node whose outer HTML string is to be obtained
      * @return{string}  The serialized node and its content
      */
     outerHTML(node: N): string;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose attribute is to be set
      * @param{string} name   The name of the attribute to set
      * @param{string} value  The new value of the attribute
      */
     setAttribute(node: N, name: string, value: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose attribute is to be obtained
      * @param{string} name   The name of the attribute to get
      * @return{string}       The value of the given attribute of the given node
      */
     getAttribute(node: N, name: string): string;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose attribute is to be removed
      * @param{string} name   The name of the attribute to remove
      */
     removeAttribute(node: N, name: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose attribute is to be tested
      * @param{string} name   The name of the attribute to test
      * @return{boolean}      True of the node has the given attribute defined
      */
     hasAttribute(node: N, name: string): boolean;
 
-    /*
+    /**
      * @param{N} node           The HTML node whose attributes are to be returned
      * @return{AttributeData[]} The list of attributes
      */
     allAttributes(node: N): AttributeData[];
 
-    /*
+    /**
      * @param{N} node        The HTML node whose class is to be augmented
      * @param{string} name   The class to be added
      */
     addClass(node: N, name: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose class is to be changed
      * @param{string} name   The class to be removed
      */
     removeClass(node: N, name: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose class is to be tested
      * @param{string} name   The class to test
      * @return{boolean}      True if the node has the given class
      */
     hasClass(node: N, name: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose class list is needed
      * @return{string[]}     An array of the class names for this node
      */
     allClasses(node: N): string[];
 
-    /*
+    /**
      * @param{N} node        The HTML node whose style is to be changed
      * @param{string} name   The style to be set
      * @param{string} name   The new value of the style
      */
     setStyle(node: N, name: string, value: string): void;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose style is to be obtained
      * @param{string} name   The style to be obtained
      * @return{string}       The value of the style
      */
     getStyle(node: N, name: string): string;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose styles are to be returned
      * @return{string}       The cssText for the styles
      */
     allStyles(node: N): string;
 
-    /*
+    /**
      * @param{N} node        The HTML node whose font size is to be determined
      * @return{number}       The font size (in pixels) of the node
      */
     fontSize(node: N): number;
 
-    /*
+    /**
      * @param{N} node            The HTML node whose dimensions are to be determined
      * @return{[number, number]} The width and height (in pixels) of the element
      */
@@ -308,23 +306,21 @@ export interface DOMAdaptor<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Abstract DOMAdaptor class for creating HTML elements
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D> {
 
-    /*
+    /**
      * The document in which the HTML nodes will be created
      */
     public document: D;
 
-    /*
+    /**
      * @param{D} document  The document in which the nodes will be created
      * @constructor
      */
@@ -332,12 +328,12 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
         this.document = document;
     }
 
-    /*
+    /**
      * @override
      */
     public abstract parse(text: string, format?: string): D;
 
-    /*
+    /**
      * @override
      */
     public node(type: string, def: OptionList = {}, children: (N | T)[] = []) {
@@ -349,18 +345,18 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
         return node as N;
     }
 
-    /*
+    /**
      * @param{string} type  The type of the node to create
      * @return{N}           The created node
      */
     protected abstract create(type: string): N;
 
-    /*
+    /**
      * @override
      */
     public abstract text(text: string): T;
 
-    /*
+    /**
      * @param{N} node           The HTML element whose attributes are to be set
      * @param{OptionList} def   The attributes to set on that node
      */
@@ -382,52 +378,52 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
         }
     }
 
-    /*
+    /**
      * @override
      */
     public abstract head(doc: D): N;
 
-    /*
+    /**
      * @override
      */
     public abstract body(doc: D): N;
 
-    /*
+    /**
      * @override
      */
     public abstract root(doc: D): N;
 
-    /*
+    /**
      * @override
      */
     public abstract tags(node: N, name: string, ns?: string): N[];
 
-    /*
+    /**
      * @override
      */
     public abstract getElements(nodes: (string | N | N[])[], document: D): N[];
 
-    /*
+    /**
      * @override
      */
     public abstract parent(node: N | T): N;
 
-    /*
+    /**
      * @override
      */
     public abstract append(node: N, child: N | T): N | T;
 
-    /*
+    /**
      * @override
      */
     public abstract insert(nchild: N | T, ochild: N | T): void;
 
-    /*
+    /**
      * @override
      */
     public abstract remove(child: N | T): N | T;
 
-    /*
+    /**
      * @override
      */
     public replace(nnode: N | T, onode: N | T) {
@@ -436,115 +432,115 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
         return onode;
     }
 
-    /*
+    /**
      * @override
      */
     public abstract clone(node: N):  N;
 
-    /*
+    /**
      * @override
      */
     public abstract split(node: T, n: number): T;
 
-    /*
+    /**
      * @override
      */
     public abstract next(node: N | T): N | T;
 
-    /*
+    /**
      * @override
      */
     public abstract previous(node: N | T): N | T;
 
-    /*
+    /**
      * @override
      */
     public abstract firstChild(node: N): N | T;
 
-    /*
+    /**
      * @override
      */
     public abstract lastChild(node: N): N | T;
 
-    /*
+    /**
      * @override
      */
     public abstract childNodes(node: N): (N | T)[];
 
-    /*
+    /**
      * @override
      */
     public childNode(node: N, i: number) {
         return this.childNodes(node)[i];
     }
 
-    /*
+    /**
      * @override
      */
     public abstract kind(node: N | T): string;
 
-    /*
+    /**
      * @override
      */
     public abstract value(node: N | T): string;
 
-    /*
+    /**
      * @override
      */
     public abstract textContent(node: N): string;
 
-    /*
+    /**
      * @override
      */
     public abstract innerHTML(node: N): string;
 
-    /*
+    /**
      * @override
      */
     public abstract outerHTML(node: N): string;
 
-    /*
+    /**
      * @override
      */
     public abstract setAttribute(node: N, name: string, value: string): void;
 
-    /*
+    /**
      * @override
      */
     public abstract getAttribute(node: N, name: string): string;
 
-    /*
+    /**
      * @override
      */
     public abstract removeAttribute(node: N, name: string): void;
 
-    /*
+    /**
      * @override
      */
     public abstract hasAttribute(node: N, name: string): boolean;
 
 
-    /*
+    /**
      * @override
      */
     public abstract allAttributes(node: N): AttributeData[];
 
-    /*
+    /**
      * @override
      */
     public abstract addClass(node: N, name: string): void;
 
-    /*
+    /**
      * @override
      */
     public abstract removeClass(node: N, name: string): void;
 
-    /*
+    /**
      * @override
      */
     public abstract hasClass(node: N, name: string): boolean;
 
-    /*
+    /**
      * @override
      */
     public allClasses(node: N) {
@@ -552,27 +548,27 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
         return classes.replace(/  +/g, ' ').replace(/^ /, '').replace(/ $/, '').split(/ /);
     }
 
-    /*
+    /**
      * @override
      */
     public abstract setStyle(node: N, name: string, value: string): void;
 
-    /*
+    /**
      * @override
      */
     public abstract getStyle(node: N, name: string): string;
 
-    /*
+    /**
      * @override
      */
     public abstract allStyles(node: N): string;
 
-    /*
+    /**
      * @override
      */
     public abstract fontSize(node: N): number;
 
-    /*
+    /**
      * @override
      */
     public abstract nodeSize(node: N): [number, number];

--- a/mathjax3-ts/core/FindMath.ts
+++ b/mathjax3-ts/core/FindMath.ts
@@ -25,17 +25,15 @@ import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
 import {ProtoItem} from './MathItem.js';
 
 /*****************************************************************/
-/*
+/**
  *  The FindMath interface
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface FindMath<N, T, D> {
-    /*
+    /**
      * One of two possibilities:  Look through a DOM element,
      *   or look through an array of strings for delimited math.
      */
@@ -44,28 +42,28 @@ export interface FindMath<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The FindMath abstract class
  */
 
-/*
+/**
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export abstract class AbstractFindMath<N, T, D> implements FindMath<N, T, D> {
 
-    /*
+    /**
      * The default options for FindMath
      */
     public static OPTIONS: OptionList = {};
 
-    /*
+    /**
      * The actual options for this instance
      */
     protected options: OptionList;
 
-    /*
+    /**
      * @param {OptionList} options  The user options for this instance
      */
     constructor(options: OptionList) {
@@ -73,7 +71,7 @@ export abstract class AbstractFindMath<N, T, D> implements FindMath<N, T, D> {
         this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     }
 
-    /*
+    /**
      * Locate math in an Element or a string array;
      *
      * @param{Element | string[]} where  The node or string array to search for math

--- a/mathjax3-ts/core/FindMath.ts
+++ b/mathjax3-ts/core/FindMath.ts
@@ -74,8 +74,8 @@ export abstract class AbstractFindMath<N, T, D> implements FindMath<N, T, D> {
     /**
      * Locate math in an Element or a string array;
      *
-     * @param{Element | string[]} where  The node or string array to search for math
-     * @return{ProtoItem[]}              The array of proto math items found
+     * @param {Element | string[]} where  The node or string array to search for math
+     * @return {ProtoItem[]}              The array of proto math items found
      */
     public abstract findMath(where: N | string[]): ProtoItem<N, T>[];
 

--- a/mathjax3-ts/core/Handler.ts
+++ b/mathjax3-ts/core/Handler.ts
@@ -26,33 +26,31 @@ import {OptionList} from '../util/Options.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 
 /*****************************************************************/
-/*
+/**
  *  The Handler interface
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface Handler<N, T, D> {
-    /*
+    /**
      * The name of the handler class
      */
     name: string;
 
-    /*
+    /**
      * The DOM Adaptor to use for managing HTML elements
      */
     adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * The priority for the handler when handlers are polled
      *   to see which one can process a given document.
      */
     priority: number;
 
-    /*
+    /**
      * Checks to see if the handler can process a given document
      *
      * @param{any} document  The document to be processed (string, window, etc.)
@@ -60,7 +58,7 @@ export interface Handler<N, T, D> {
      */
     handlesDocument(document: any): boolean;
 
-    /*
+    /**
      * Creates a MathDocument for the given handler
      *
      * @param{any} document        The document to be handled
@@ -72,11 +70,9 @@ export interface Handler<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The default MathDocument class (subclasses use their own)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -84,33 +80,31 @@ export interface Handler<N, T, D> {
 class DefaultMathDocument<N, T, D> extends AbstractMathDocument<N, T, D> {}
 
 /*****************************************************************/
-/*
+/**
  *  The Handler interface
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
 
-    /*
+    /**
      * The name of this class
      */
     public static NAME: string = 'generic';
 
-    /*
+    /**
      * The DOM Adaptor to use for managing HTML elements
      */
     public adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * The priority for this handler
      */
     public priority: number;
 
-    /*
+    /**
      * @param{number} priority  The priority to use for this handler
      *
      * @constructor
@@ -120,21 +114,21 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
         this.priority = priority;
     }
 
-    /*
+    /**
      * @return{string}  The name of this handler class
      */
     public get name() {
         return (this.constructor as typeof AbstractHandler).NAME;
     }
 
-    /*
+    /**
      * @override
      */
     public handlesDocument(document: any) {
         return false;
     }
 
-    /*
+    /**
      * @override
      */
     public create(document: any, options: OptionList) {

--- a/mathjax3-ts/core/Handler.ts
+++ b/mathjax3-ts/core/Handler.ts
@@ -53,18 +53,18 @@ export interface Handler<N, T, D> {
     /**
      * Checks to see if the handler can process a given document
      *
-     * @param{any} document  The document to be processed (string, window, etc.)
-     * @return{boolean}      True if this handler can process the given document
+     * @param {any} document  The document to be processed (string, window, etc.)
+     * @return {boolean}      True if this handler can process the given document
      */
     handlesDocument(document: any): boolean;
 
     /**
      * Creates a MathDocument for the given handler
      *
-     * @param{any} document        The document to be handled
-     * @param{DOMAdaptor} adaptor  The DOM adaptor for managing HTML elements
-     * @param{OptionList} options  The options for the handling of the document
-     * @return{MathDocument}       The MathDocument object that manages the processing
+     * @param {any} document        The document to be handled
+     * @param {DOMAdaptor} adaptor  The DOM adaptor for managing HTML elements
+     * @param {OptionList} options  The options for the handling of the document
+     * @return {MathDocument}       The MathDocument object that manages the processing
      */
     create(document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList): MathDocument<N, T, D>;
 }
@@ -105,7 +105,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
     public priority: number;
 
     /**
-     * @param{number} priority  The priority to use for this handler
+     * @param {number} priority  The priority to use for this handler
      *
      * @constructor
      */
@@ -115,7 +115,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
     }
 
     /**
-     * @return{string}  The name of this handler class
+     * @return {string}  The name of this handler class
      */
     public get name() {
         return (this.constructor as typeof AbstractHandler).NAME;

--- a/mathjax3-ts/core/HandlerList.ts
+++ b/mathjax3-ts/core/HandlerList.ts
@@ -28,22 +28,20 @@ import {MathDocument} from './MathDocument.js';
 import {DOMAdaptor} from './DOMAdaptor.js';
 
 /*****************************************************************/
-/*
+/**
  *  The HandlerList class (extends PrioritizedList of Handlers)
  *
  *  This list is used to find the handler for a given document
  *  by asking each handler to test if it can handle the document,
  *  and when one can, it is asked to create its associated MathDocument.
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>>  {
 
-    /*
+    /**
      * @param{Handler} handler  The handler to register
      * @return{PrioritizedListItem<Handler>}  The list item created for the handler
      */
@@ -51,14 +49,14 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>>  {
         return this.add(handler, handler.priority);
     }
 
-    /*
+    /**
      * @param{Handler} Handler  The handler to remove from the list
      */
     public unregister(handler: Handler<N, T, D>) {
         this.remove(handler);
     }
 
-    /*
+    /**
      * @param{any} document  The document (string, window, DOM element, etc) to be handled
      * @return{handler}      The handler from the list that can process the given document
      */
@@ -72,7 +70,7 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>>  {
         throw new Error("Can't find handler for document");
     }
 
-    /*
+    /**
      * @param{any} document        The document to be processed
      * @param{OptionList} options  The options for the handler
      * @return{MathDocument}       The MathDocument created by the handler for this document

--- a/mathjax3-ts/core/HandlerList.ts
+++ b/mathjax3-ts/core/HandlerList.ts
@@ -42,23 +42,23 @@ import {DOMAdaptor} from './DOMAdaptor.js';
 export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>>  {
 
     /**
-     * @param{Handler} handler  The handler to register
-     * @return{PrioritizedListItem<Handler>}  The list item created for the handler
+     * @param {Handler} handler  The handler to register
+     * @return {PrioritizedListItem<Handler>}  The list item created for the handler
      */
     public register(handler: Handler<N, T, D>) {
         return this.add(handler, handler.priority);
     }
 
     /**
-     * @param{Handler} Handler  The handler to remove from the list
+     * @param {Handler} Handler  The handler to remove from the list
      */
     public unregister(handler: Handler<N, T, D>) {
         this.remove(handler);
     }
 
     /**
-     * @param{any} document  The document (string, window, DOM element, etc) to be handled
-     * @return{handler}      The handler from the list that can process the given document
+     * @param {any} document  The document (string, window, DOM element, etc) to be handled
+     * @return {handler}      The handler from the list that can process the given document
      */
     public handlesDocument(document: any) {
         for (const item of this) {
@@ -71,9 +71,9 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>>  {
     }
 
     /**
-     * @param{any} document        The document to be processed
-     * @param{OptionList} options  The options for the handler
-     * @return{MathDocument}       The MathDocument created by the handler for this document
+     * @param {any} document        The document to be processed
+     * @param {OptionList} options  The options for the handler
+     * @return {MathDocument}       The MathDocument created by the handler for this document
      */
     public document(document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList = null) {
         return this.handlesDocument(document).create(document, adaptor, options);

--- a/mathjax3-ts/core/InputJax.ts
+++ b/mathjax3-ts/core/InputJax.ts
@@ -28,49 +28,47 @@ import {FunctionList} from '../util/FunctionList.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 
 /*****************************************************************/
-/*
+/**
  *  The InputJax interface
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface InputJax<N, T, D> {
-    /*
+    /**
      * The name of the input jax subclass (e.g,. 'TeX')
      */
     name: string;
 
-    /*
+    /**
      * Whether this input jax processes string arrays or DOM nodes
      * (TeX and AsciiMath process strings, MathML processes DOM nodes)
      */
     processStrings: boolean;
 
-    /*
+    /**
      * The options for this input jax instance
      */
     options: OptionList;
 
-    /*
+    /**
      * Lists of pre- and post-filters to call before and after processing the input
      */
     preFilters: FunctionList;
     postFilters: FunctionList;
 
-    /*
+    /**
      * The DOM adaptor for managing HTML elements
      */
     adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * @param{DOMAdaptor}  The adaptor to use in this jax
      */
     setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 
-    /*
+    /**
      * Finds the math within the DOM or the list of strings
      *
      * @param{N | string[]} which   The element or array of strings to be searched for math
@@ -80,7 +78,7 @@ export interface InputJax<N, T, D> {
      */
     findMath(which: N | string[], options?: OptionList): ProtoItem<N, T>[];
 
-    /*
+    /**
      * Convert the math in a math item into the internal format
      *
      * @param{MathItem} math  The MathItem whose math content is to processed
@@ -90,11 +88,9 @@ export interface InputJax<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The abstract InputJax class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -109,7 +105,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     public postFilters: FunctionList;
     public adaptor: DOMAdaptor<N, T, D> = null;  // set by the handler
 
-    /*
+    /**
      * @param{OptionList} options  The options to applyt to this input jax
      *
      * @constructor
@@ -121,40 +117,40 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
         this.postFilters = new FunctionList();
     }
 
-    /*
+    /**
      * @return{string}  The name of this input jax class
      */
     public get name() {
         return (this.constructor as typeof AbstractInputJax).NAME;
     }
 
-    /*
+    /**
      * @override
      */
     public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
         this.adaptor = adaptor;
     }
 
-    /*
+    /**
      * @return{boolean}  True means find math in string array, false means in DOM element
      */
     public get processStrings() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     public findMath(node: N | string[], options?: OptionList) {
         return [] as ProtoItem<N, T>[];
     }
 
-    /*
+    /**
      * @override
      */
     public abstract compile(math: MathItem<N, T, D>): MmlNode;
 
-    /*
+    /**
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *

--- a/mathjax3-ts/core/InputJax.ts
+++ b/mathjax3-ts/core/InputJax.ts
@@ -64,16 +64,16 @@ export interface InputJax<N, T, D> {
     adaptor: DOMAdaptor<N, T, D>;
 
     /**
-     * @param{DOMAdaptor}  The adaptor to use in this jax
+     * @param {DOMAdaptor}  The adaptor to use in this jax
      */
     setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 
     /**
      * Finds the math within the DOM or the list of strings
      *
-     * @param{N | string[]} which   The element or array of strings to be searched for math
-     * @param{OptionList} options   The options for the search, if any
-     * @return{ProtoItem[]}         Array of proto math items found (further processed by the
+     * @param {N | string[]} which   The element or array of strings to be searched for math
+     * @param {OptionList} options   The options for the search, if any
+     * @return {ProtoItem[]}         Array of proto math items found (further processed by the
      *                                handler to produce actual MathItem objects)
      */
     findMath(which: N | string[], options?: OptionList): ProtoItem<N, T>[];
@@ -81,8 +81,8 @@ export interface InputJax<N, T, D> {
     /**
      * Convert the math in a math item into the internal format
      *
-     * @param{MathItem} math  The MathItem whose math content is to processed
-     * @return{MmlNode}       The resulting internal node tree for the math
+     * @param {MathItem} math  The MathItem whose math content is to processed
+     * @return {MmlNode}       The resulting internal node tree for the math
      */
     compile(math: MathItem<N, T, D>): MmlNode;
 }
@@ -106,7 +106,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     public adaptor: DOMAdaptor<N, T, D> = null;  // set by the handler
 
     /**
-     * @param{OptionList} options  The options to applyt to this input jax
+     * @param {OptionList} options  The options to applyt to this input jax
      *
      * @constructor
      */
@@ -118,7 +118,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     }
 
     /**
-     * @return{string}  The name of this input jax class
+     * @return {string}  The name of this input jax class
      */
     public get name() {
         return (this.constructor as typeof AbstractInputJax).NAME;
@@ -132,7 +132,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     }
 
     /**
-     * @return{boolean}  True means find math in string array, false means in DOM element
+     * @return {boolean}  True means find math in string array, false means in DOM element
      */
     public get processStrings() {
         return true;
@@ -154,10 +154,10 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *
-     * @param{FunctionList} filters  The list of functions to be performed
-     * @param{MathItem} math         The math item that is being processed
-     * @param{any} data              Whatever other data is needed
-     * @return{any}                  The (possibly modidied) data
+     * @param {FunctionList} filters  The list of functions to be performed
+     * @param {MathItem} math         The math item that is being processed
+     * @param {any} data              Whatever other data is needed
+     * @return {any}                  The (possibly modidied) data
      */
     protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>, data: any) {
         let args = {math: math, data: data};

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -31,7 +31,7 @@ import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 
 /*****************************************************************/
-/*
+/**
  *  The MathDocument interface
  *
  *  The MathDocument is created by MathJax.Document() and holds the
@@ -48,57 +48,55 @@ import {DOMAdaptor} from '../core/DOMAdaptor.js';
  *
  *  The MathDocument is the main interface for page authors to
  *  interact with MathJax.
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface MathDocument<N, T, D> {
-    /*
+    /**
      * The document being processed (e.g., DOM document, or Markdown string)
      */
     document: D;
 
-    /*
+    /**
      * The kind of MathDocument (e.g., "HTML")
      */
     kind: string;
 
-    /*
+    /**
      * The options for the document
      */
     options: OptionList;
 
-    /*
+    /**
      * The list of MathItems found in this page
      */
     math: MathList<N, T, D>;
 
-    /*
+    /**
      * This object tracks what operations have been performed, so that (when
      *  asynchronous operations are used), the ones that have already been
      *  completed won't be performed again.
      */
     processed: {[name: string]: boolean};
 
-    /*
+    /**
      * An array of input jax to run on the document
      */
     inputJax: InputJax<N, T, D>[];
 
-    /*
+    /**
      * The output jax to use for the document
      */
     outputJax: OutputJax<N, T, D>;
 
-    /*
+    /**
      * The DOM adaotor to use for input and output
      */
     adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * Locates the math in the document and constructs the MathList
      *  for the document.
      *
@@ -107,35 +105,35 @@ export interface MathDocument<N, T, D> {
      */
     findMath(options?: OptionList): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Calls the input jax to process the MathItems in the MathList
      *
      * @return{MathDocument}  The math document instance
      */
     compile(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Gets the metric information for the MathItems
      *
      * @return{MathDocument}  The math document instance
      */
     getMetrics(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Calls the output jax to process the compiled math in the MathList
      *
      * @return{MathDocument}  The math document instance
      */
     typeset(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Updates the document to include the typeset math
      *
      * @return{MathDocument}  The math document instance
      */
     updateDocument(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Removes the typeset math from the document
      *
      * @param{boolean} restore  True if the original math should be put
@@ -144,7 +142,7 @@ export interface MathDocument<N, T, D> {
      */
     removeFromDocument(restore?: boolean): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Set the state of the document (allowing you to roll back
      *  the state to a previous one, if needed).
      *
@@ -154,14 +152,14 @@ export interface MathDocument<N, T, D> {
      */
     state(state: number, restore?: boolean): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Clear the processed values so that the document can be reprocessed
      *
      * @return{MathDocument}  The math document instance
      */
     reset(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Reset the processed values and clear the MathList (so that new math
      * can be processed in the document).
      *
@@ -169,7 +167,7 @@ export interface MathDocument<N, T, D> {
      */
     clear(): MathDocument<N, T, D>;
 
-    /*
+    /**
      * Merges a MathList into the list for this document.
      *
      * @param{MathList} list   The MathList to be merged into this document's list
@@ -180,7 +178,7 @@ export interface MathDocument<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The booleans used to keep track of what processing has been
  *  performed.
  */
@@ -194,25 +192,32 @@ export type MathProcessed = {
     [name: string]: boolean;
 };
 
-/*
- * Defaults used when input and output jax aren't specified
- */
-/*
+/**
+ * Defaults used when input jax isn't specified
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 class DefaultInputJax<N, T, D> extends AbstractInputJax<N, T, D> {
+    /**
+     * @override
+     */
     public compile(math: MathItem<N, T, D>) {
         return null as MmlNode;
     }
 }
-/*
+/**
+ * Defaults used when ouput jax isn't specified
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
+    /**
+     * @override
+     */
     public typeset(math: MathItem<N, T, D>, document: MathDocument<N, T, D> = null) {
         return null as N;
     }
@@ -220,7 +225,9 @@ class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
         return null as N;
     }
 }
-/*
+/**
+ * Default for the MathList when one isn't specified
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -231,11 +238,9 @@ let errorFactory = new MmlFactory();
 
 
 /*****************************************************************/
-/*
+/**
  *  Implements the abstract MathDocument class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -265,7 +270,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     public adaptor: DOMAdaptor<N, T, D>;
 
 
-    /*
+    /**
      * @param{any} document        The document (HTML string, parsed DOM, etc.) to be processed
      * @param{OptionList} options  The options for this document
      * @constructor
@@ -296,14 +301,14 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         this.inputJax.map(jax => jax.setAdaptor(adaptor));
     }
 
-    /*
+    /**
      * @return{string}  The kind of document
      */
     public get kind() {
         return (this.constructor as typeof AbstractMathDocument).KIND;
     }
 
-    /*
+    /**
      * @override
      */
     public findMath(options: OptionList = null) {
@@ -311,7 +316,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public compile() {
@@ -332,7 +337,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * Produce an error using MmlNodes
      *
      * @param{MathItem} math  The MathItem producing the error
@@ -351,7 +356,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         }
     }
 
-    /*
+    /**
      * @override
      */
     public typeset() {
@@ -372,7 +377,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * Produce an error using HTML
      *
      * @param{MathItem} math  The MathItem producing the error
@@ -384,7 +389,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
                                              [this.adaptor.text('Math output error')]);
     }
 
-    /*
+    /**
      * @override
      */
     public getMetrics() {
@@ -395,7 +400,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public updateDocument() {
@@ -408,14 +413,14 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public removeFromDocument(restore: boolean = false) {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public state(state: number, restore: boolean = false) {
@@ -435,7 +440,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public reset() {
@@ -445,7 +450,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public clear() {
@@ -454,7 +459,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public concat(list: MathList<N, T, D>) {

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -100,45 +100,45 @@ export interface MathDocument<N, T, D> {
      * Locates the math in the document and constructs the MathList
      *  for the document.
      *
-     * @param{OptionList} options  The options for locating the math
-     * @return{MathDocument}       The math document instance
+     * @param {OptionList} options  The options for locating the math
+     * @return {MathDocument}       The math document instance
      */
     findMath(options?: OptionList): MathDocument<N, T, D>;
 
     /**
      * Calls the input jax to process the MathItems in the MathList
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     compile(): MathDocument<N, T, D>;
 
     /**
      * Gets the metric information for the MathItems
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     getMetrics(): MathDocument<N, T, D>;
 
     /**
      * Calls the output jax to process the compiled math in the MathList
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     typeset(): MathDocument<N, T, D>;
 
     /**
      * Updates the document to include the typeset math
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     updateDocument(): MathDocument<N, T, D>;
 
     /**
      * Removes the typeset math from the document
      *
-     * @param{boolean} restore  True if the original math should be put
+     * @param {boolean} restore  True if the original math should be put
      *                            back into the document as well
-     * @return{MathDocument}    The math document instance
+     * @return {MathDocument}    The math document instance
      */
     removeFromDocument(restore?: boolean): MathDocument<N, T, D>;
 
@@ -146,16 +146,16 @@ export interface MathDocument<N, T, D> {
      * Set the state of the document (allowing you to roll back
      *  the state to a previous one, if needed).
      *
-     * @param{boolean} restore  True if the original math should be put
+     * @param {boolean} restore  True if the original math should be put
      *                            back into the document during the rollback
-     * @return{MathDocument}    The math document instance
+     * @return {MathDocument}    The math document instance
      */
     state(state: number, restore?: boolean): MathDocument<N, T, D>;
 
     /**
      * Clear the processed values so that the document can be reprocessed
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     reset(): MathDocument<N, T, D>;
 
@@ -163,15 +163,15 @@ export interface MathDocument<N, T, D> {
      * Reset the processed values and clear the MathList (so that new math
      * can be processed in the document).
      *
-     * @return{MathDocument}  The math document instance
+     * @return {MathDocument}  The math document instance
      */
     clear(): MathDocument<N, T, D>;
 
     /**
      * Merges a MathList into the list for this document.
      *
-     * @param{MathList} list   The MathList to be merged into this document's list
-     * @return{MathDocument}   The math document instance
+     * @param {MathList} list   The MathList to be merged into this document's list
+     * @return {MathDocument}   The math document instance
      */
     concat(list: MathList<N, T, D>): MathDocument<N, T, D>;
 
@@ -271,8 +271,8 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
 
 
     /**
-     * @param{any} document        The document (HTML string, parsed DOM, etc.) to be processed
-     * @param{OptionList} options  The options for this document
+     * @param {any} document        The document (HTML string, parsed DOM, etc.) to be processed
+     * @param {OptionList} options  The options for this document
      * @constructor
      */
     constructor (document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
@@ -302,7 +302,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     }
 
     /**
-     * @return{string}  The kind of document
+     * @return {string}  The kind of document
      */
     public get kind() {
         return (this.constructor as typeof AbstractMathDocument).KIND;
@@ -340,8 +340,8 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     /**
      * Produce an error using MmlNodes
      *
-     * @param{MathItem} math  The MathItem producing the error
-     * @param{Error} err      The Error object for the error
+     * @param {MathItem} math  The MathItem producing the error
+     * @param {Error} err      The Error object for the error
      */
     public compileError(math: MathItem<N, T, D>, err: Error) {
         math.root = errorFactory.create('math', {'data-mjx-error': err.message}, [
@@ -380,8 +380,8 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     /**
      * Produce an error using HTML
      *
-     * @param{MathItem} math  The MathItem producing the error
-     * @param{Error} err      The Error object for the error
+     * @param {MathItem} math  The MathItem producing the error
+     * @param {Error} err      The Error object for the error
      */
     public typesetError(math: MathItem<N, T, D>, err: Error) {
         math.typesetRoot = this.adaptor.node('span',

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -132,28 +132,28 @@ export interface MathItem<N, T, D> {
     /**
      * Converts the expression into the internal format by calling the input jax
      *
-     * @param{MathDocument} document  The MathDocument in which the math resides
+     * @param {MathDocument} document  The MathDocument in which the math resides
      */
     compile(document: MathDocument<N, T, D>): void;
 
     /**
      * Converts the internal format to the typeset version by caling the output jax
      *
-     * @param{MathDocument} document  The MathDocument in which the math resides
+     * @param {MathDocument} document  The MathDocument in which the math resides
      */
     typeset(document: MathDocument<N, T, D>): void;
 
     /**
      * Rerenders an already rendered item and re-inserts it into the document
      *
-     * @param{MathDocument} document  The MathDocument in which the math resides
+     * @param {MathDocument} document  The MathDocument in which the math resides
      */
     rerender(document: MathDocument<N, T, D>): void;
 
     /**
      * Inserts the typeset version in place of the original form in the document
      *
-     * @param{MathDocument} document  The MathDocument in which the math resides
+     * @param {MathDocument} document  The MathDocument in which the math resides
      */
     updateDocument(document: MathDocument<N, T, D>): void;
 
@@ -161,18 +161,18 @@ export interface MathItem<N, T, D> {
      * Removes the typeset version from the document, optionally replacing the original
      * form of the expression and its delimiters.
      *
-     * @param{boolena} restore  True if the original version is to be restored
+     * @param {boolena} restore  True if the original version is to be restored
      */
     removeFromDocument(restore: boolean): void;
 
     /**
      * Sets the metric information for this expression
      *
-     * @param{number} em      The size of 1 em in pixels
-     * @param{number} ex      The size of 1 ex in pixels
-     * @param{number} cwidth  The container width in pixels
-     * @param{number} lwidth  The line breaking width in pixels
-     * @param{number} scale   The scaling factor (unitless)
+     * @param {number} em      The size of 1 em in pixels
+     * @param {number} ex      The size of 1 ex in pixels
+     * @param {number} cwidth  The container width in pixels
+     * @param {number} lwidth  The line breaking width in pixels
+     * @param {number} scale   The scaling factor (unitless)
      */
     setMetrics(em: number, ex: number, cwidth: number, lwidth: number, scale: number): void;
 
@@ -181,8 +181,8 @@ export interface MathItem<N, T, D> {
      * optionally restoring the document if rolling back an expression
      * that has been added to the document.
      *
-     * @param{number} state    The state to set for the expression
-     * @param{number} restore  True if the original form should be restored
+     * @param {number} state    The state to set for the expression
+     * @param {number} restore  True if the original form should be restored
      *                           when rolling back a typeset version
      */
     state(state?: number, restore?: boolean): number;
@@ -255,11 +255,11 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
     public outputData: OptionList = {};
 
     /**
-     * @param{string} math      The math expression for this item
-     * @param{Inputjax} jax     The input jax to use for this item
-     * @param{boolean} display  True if display mode, false if inline
-     * @param{Location} start   The starting position of the math in the document
-     * @param{Location} end     The ending position of the math in the document
+     * @param {string} math      The math expression for this item
+     * @param {Inputjax} jax     The input jax to use for this item
+     * @param {boolean} display  True if display mode, false if inline
+     * @param {Location} start   The starting position of the math in the document
+     * @param {Location} end     The ending position of the math in the document
      * @constructor
      */
     constructor (math: string, jax: InputJax<N, T, D>, display: boolean = true,

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -27,14 +27,12 @@ import {OptionList} from '../util/Options.js';
 import {MmlNode} from './MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  The Location gives a location of a position in a document
  *  (either a node and character position within it, or
  *  an index into a string array, the character position within
  *  the string, and the delimiter at that location).
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -46,11 +44,10 @@ export type Location<N, T> = {
 };
 
 /*****************************************************************/
-/*
+/**
  *  The Metrics object includes the data needed to typeset
  *  a MathItem.
  */
-
 export type Metrics = {
     em: number;
     ex: number;
@@ -60,17 +57,16 @@ export type Metrics = {
 };
 
 /*****************************************************************/
-/*
+/**
  *  The BBox object contains the data about the bounding box
  *  for the typeset element.
  */
-
 export type BBox = {
     // will be defined later
 };
 
 /*****************************************************************/
-/*
+/**
  *  The MathItem interface
  *
  *  The MathItem is the object that holds the information about a
@@ -78,92 +74,90 @@ export type BBox = {
  *  where it is in the document, its compiled version (in the
  *  internal format), its typeset version, its bounding box,
  *  and so on.
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface MathItem<N, T, D> {
-    /*
+    /**
      * The string represeting the expression to be processed
      */
     math: string;
 
-    /*
+    /**
      * The input jax used to process the math
      */
     inputJax: InputJax<N, T, D>;
 
-    /*
+    /**
      * Whether the math is in display mode or inline mode
      */
     display: boolean;
 
-    /*
+    /**
      * The start and ending locations in the document of
      *   this expression
      */
     start: Location<N, T>;
     end: Location<N, T>;
 
-    /*
+    /**
      * The internal format for this expression (onece compiled)
      */
     root: MmlNode;
 
-    /*
+    /**
      * The typeset version of the expression (once typeset)
      */
     typesetRoot: N;
 
-    /*
+    /**
      * The metric information at the location of the math
      * (the em-size, scaling factor, etc.)
      */
     metrics: Metrics;
 
-    /*
+    /**
      * The bounding box for the typeset math (once typeset)
      */
     bbox: BBox;
 
-    /*
+    /**
      * Extra data needed by the input or output jax, as needed
      */
     inputData: OptionList;
     outputData: OptionList;
 
-    /*
+    /**
      * Converts the expression into the internal format by calling the input jax
      *
      * @param{MathDocument} document  The MathDocument in which the math resides
      */
     compile(document: MathDocument<N, T, D>): void;
 
-    /*
+    /**
      * Converts the internal format to the typeset version by caling the output jax
      *
      * @param{MathDocument} document  The MathDocument in which the math resides
      */
     typeset(document: MathDocument<N, T, D>): void;
 
-    /*
+    /**
      * Rerenders an already rendered item and re-inserts it into the document
      *
      * @param{MathDocument} document  The MathDocument in which the math resides
      */
     rerender(document: MathDocument<N, T, D>): void;
 
-    /*
+    /**
      * Inserts the typeset version in place of the original form in the document
      *
      * @param{MathDocument} document  The MathDocument in which the math resides
      */
     updateDocument(document: MathDocument<N, T, D>): void;
 
-    /*
+    /**
      * Removes the typeset version from the document, optionally replacing the original
      * form of the expression and its delimiters.
      *
@@ -171,7 +165,7 @@ export interface MathItem<N, T, D> {
      */
     removeFromDocument(restore: boolean): void;
 
-    /*
+    /**
      * Sets the metric information for this expression
      *
      * @param{number} em      The size of 1 em in pixels
@@ -182,7 +176,7 @@ export interface MathItem<N, T, D> {
      */
     setMetrics(em: number, ex: number, cwidth: number, lwidth: number, scale: number): void;
 
-    /*
+    /**
      * Set or return the current processing state of this expression,
      * optionally restoring the document if rolling back an expression
      * that has been added to the document.
@@ -196,16 +190,14 @@ export interface MathItem<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The ProtoItem interface
  *
  *  This is what is returned by the FindMath class, giving the location
  *  of math within the document, and is used to produce the full
  *  MathItem later (e.g., when the position within a string array
  *  is translated back into the actual node location in the DOM).
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -219,11 +211,9 @@ export type ProtoItem<N, T> = {
     display: boolean;        // True means display mode, false is inline mode
 };
 
-/*
+/**
  *  Produce a proto math item that can be turned into a MathItem
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  */
@@ -235,11 +225,9 @@ export function protoItem<N, T>(open: string, math: string, close: string, n: nu
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MathItem class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -266,7 +254,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
     public inputData: OptionList = {};
     public outputData: OptionList = {};
 
-    /*
+    /**
      * @param{string} math      The math expression for this item
      * @param{Inputjax} jax     The input jax to use for this item
      * @param{boolean} display  True if display mode, false if inline
@@ -290,7 +278,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         this.outputData = {};
     }
 
-    /*
+    /**
      * @override
      */
     public compile(document: MathDocument<N, T, D>) {
@@ -300,7 +288,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public typeset(document: MathDocument<N, T, D>) {
@@ -310,7 +298,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public rerender(document: MathDocument<N, T, D>) {
@@ -319,17 +307,17 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         this.updateDocument(document);
     }
 
-    /*
+    /**
      * @override
      */
     public updateDocument(document: MathDocument<N, T, D>) {}
 
-    /*
+    /**
      * @override
      */
     public removeFromDocument(restore: boolean = false) {}
 
-    /*
+    /**
      * @override
      */
     public setMetrics(em: number, ex: number, cwidth: number, lwidth: number, scale: number) {
@@ -341,7 +329,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         };
     }
 
-    /*
+    /**
      * @override
      */
     public state(state: number = null, restore: boolean = false) {

--- a/mathjax3-ts/core/MathList.ts
+++ b/mathjax3-ts/core/MathList.ts
@@ -36,8 +36,8 @@ export interface MathList<N, T, D> extends LinkedList<MathItem<N, T, D>> {
     /**
      * Test if one math item is before the other in the document (a < b)
      *
-     * @param{MathItem} a   The first MathItem
-     * @param{MathItem} b   The second MathItem
+     * @param {MathItem} a   The first MathItem
+     * @param {MathItem} b   The second MathItem
      */
     isBefore(a: MathItem<N, T, D>, b: MathItem<N, T, D>): boolean;
 }

--- a/mathjax3-ts/core/MathList.ts
+++ b/mathjax3-ts/core/MathList.ts
@@ -25,17 +25,15 @@ import {LinkedList} from '../util/LinkedList.js';
 import {MathItem, AbstractMathItem} from './MathItem.js';
 
 /*****************************************************************/
-/*
+/**
  *  The MathList interface (extends LinkedList<MathItem>)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface MathList<N, T, D> extends LinkedList<MathItem<N, T, D>> {
-    /*
+    /**
      * Test if one math item is before the other in the document (a < b)
      *
      * @param{MathItem} a   The first MathItem
@@ -45,11 +43,9 @@ export interface MathList<N, T, D> extends LinkedList<MathItem<N, T, D>> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The MathList abstract class (extends LinkedList<MathItem>)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -57,7 +53,7 @@ export interface MathList<N, T, D> extends LinkedList<MathItem<N, T, D>> {
 export abstract class AbstractMathList<N, T, D>
     extends LinkedList<MathItem<N, T, D>> implements MathList<N, T, D> {
 
-    /*
+    /**
      * @override
      */
     public isBefore(a: MathItem<N, T, D>, b: MathItem<N, T, D>) {

--- a/mathjax3-ts/core/MmlTree/Attributes.ts
+++ b/mathjax3-ts/core/MmlTree/Attributes.ts
@@ -23,13 +23,13 @@
 
 import {PropertyList, Property} from '../Tree/Node.js';
 
-/*
+/**
  * A constant for when a property should be inherited from the global defaults lists
  */
 export const INHERIT = '_inherit_';
 
 /******************************************************************/
-/*
+/**
  * Implements the Attributes class for MmlNodes
  *  (These can be set explicitly, inherited from parent nodes,
  *   taken from a default list of values, or taken from global
@@ -42,7 +42,7 @@ export class Attributes {
     protected defaults: PropertyList;
     protected global: PropertyList;
 
-    /*
+    /**
      * @param {PropertyList} defaults  The defaults for this node type
      * @param {PropertyList} global    The global properties (from the math node)
      *
@@ -56,7 +56,7 @@ export class Attributes {
         Object.assign(this.defaults, defaults);
     }
 
-    /*
+    /**
      * @param {string} name     The name of the attribute to set
      * @param {Property} value  The value to give the named attribute
      */
@@ -64,14 +64,14 @@ export class Attributes {
         this.attributes[name] = value;
     }
 
-    /*
+    /**
      * @param {PropertyList} list  An object containing the properties to set
      */
     public setList(list: PropertyList) {
         Object.assign(this.attributes, list);
     }
 
-    /*
+    /**
      * @param {string} name  The name of the attribute whose value is to be returned
      * @return {Property}    The value of the named attribute (including inheritance and defaults)
      */
@@ -83,7 +83,7 @@ export class Attributes {
         return value;
     }
 
-    /*
+    /**
      * @param {string} name  The value of the attribute whose value is to be returned
      * @return {Property}    The attribute whose name was given if it is explicit on the
      *                       node (not inherited or defaulted), null otherwise
@@ -95,7 +95,7 @@ export class Attributes {
         return this.attributes[name];
     }
 
-    /*
+    /**
      * @param {string[]} names  The names of attributes whose values are to be returned
      * @return {PropertyList}   An object containing the attributes and their values
      */
@@ -107,7 +107,7 @@ export class Attributes {
         return values;
     }
 
-    /*
+    /**
      * @param {string} name  The name of an inherited attribute to be set
      * @param {Property} value  The value to assign to the named attribute
      */
@@ -115,7 +115,7 @@ export class Attributes {
         this.inherited[name] = value;
     }
 
-    /*
+    /**
      * @param {string} name  The name of an inherited attribute whose value is to be returned
      * @return {Property}    The value of the named attribute if it is inherited, null otherwise
      */
@@ -123,7 +123,7 @@ export class Attributes {
         return this.inherited[name];
     }
 
-    /*
+    /**
      * @param {string} name  The name of a default attribute whose value is to be returned
      * @return {Property}    The value of the named attribute if a default exists for it, null otherwise
      */
@@ -131,7 +131,7 @@ export class Attributes {
         return this.defaults[name];
     }
 
-    /*
+    /**
      * @param {string} name  The name of a attribute to check
      * @return {boolena}     True if attribute is set explicitly or inherited
      *                         from an explicit mstyle or math attribute
@@ -140,7 +140,7 @@ export class Attributes {
         return this.attributes.hasOwnProperty(name) || this.inherited.hasOwnProperty(name);
     }
 
-    /*
+    /**
      * @param {string} name  The name of an attribute to test for the existance of a default
      * @return {boolean}     True of there is a default for the named attribute, false otherwise
      */
@@ -148,56 +148,56 @@ export class Attributes {
         return (name in this.defaults);
     }
 
-    /*
+    /**
      * @return {string[]}  The names of all the attributes explicitly set on the node
      */
     public getExplicitNames() {
         return Object.keys(this.attributes);
     }
 
-    /*
+    /**
      * @return {string[]}  The names of all the inherited attributes for the node
      */
     public getInheritedNames() {
         return Object.keys(this.inherited);
     }
 
-    /*
+    /**
      * @return {string[]}  The names of all the default attributes for the node
      */
     public getDefaultNames() {
         return Object.keys(this.defaults);
     }
 
-    /*
+    /**
      * @return {string[]}  The names of all the global attributes
      */
     public getGlobalNames() {
         return Object.keys(this.global);
     }
 
-    /*
+    /**
      * @return {PropertyList}  The attribute object
      */
     public getAllAttributes() {
         return this.attributes;
     }
 
-    /*
+    /**
      * @return {PropertyList}  The inherited object
      */
     public getAllInherited() {
         return this.inherited;
     }
 
-    /*
+    /**
      * @return {PropertyList}  The defaults object
      */
     public getAllDefaults() {
         return this.defaults;
     }
 
-    /*
+    /**
      * @return {PropertyList}  The global object
      */
     public getAllGlobals() {

--- a/mathjax3-ts/core/MmlTree/JsonMmlVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/JsonMmlVisitor.ts
@@ -39,12 +39,12 @@ export type MmlJSON = {
 };
 
 /*****************************************************************/
-/*
+/**
  *  Implements the JsonMmlVisitor (subclass of MmlVisitor)
  */
 
 export class JsonMmlVisitor extends MmlVisitor {
-    /*
+    /**
      * Convert the tree rooted at a particular node into a JSON structure
      *
      * @param {MmlNode} node  The node to use as the root of the tree to traverse
@@ -54,7 +54,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return this.visitNode(node);
     }
 
-    /*
+    /**
      * @param {TextNode} node   The text node to visit
      * @return {MmlJSON}        The JSON for the text element
      */
@@ -62,7 +62,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return {kind: node.kind, text: node.getText()};
     }
 
-    /*
+    /**
      * @param {XMLNode} node  The XML node to visit
      * @return {MmlJSON}      The JSON for the XML node
      */
@@ -70,7 +70,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return {kind: node.kind, xml: node.getXML()};
     }
 
-    /*
+    /**
      * The generic visiting function:
      *   Create a DOM node of the correct type.
      *   Add its explicit attributes.
@@ -101,7 +101,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return json;
     }
 
-    /*
+    /**
      * @param {MmlNode} node    The node whose children are to be copied
      * @return {MmlJSON[]}      The array of child JSON objects
      */
@@ -113,7 +113,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return children;
     }
 
-    /*
+    /**
      * @param {MmlNode} node    The node whose attributes are to be copied
      * @return {PropertyList}   The object containing the attributes;
      */
@@ -121,7 +121,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return Object.assign({}, node.attributes.getAllAttributes());
     }
 
-    /*
+    /**
      * @param {MmlNode} node    The node whose inherited attributes are to be copied
      * @return {PropertyList}   The object containing the inherited attributes;
      */
@@ -129,7 +129,7 @@ export class JsonMmlVisitor extends MmlVisitor {
         return Object.assign({}, node.attributes.getAllInherited());
     }
 
-    /*
+    /**
      * @param {MmlNode} node    The node whose properties are to be copied
      * @return {PropertyList}   The object containing the properties;
      */

--- a/mathjax3-ts/core/MmlTree/LegacyMmlVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/LegacyMmlVisitor.ts
@@ -24,20 +24,20 @@
 import {MmlVisitor} from './MmlVisitor.js';
 import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
 
-/*
+/**
  *  Get access to legacy MML Element Jax
  */
 declare var MathJax: any;
 let MML = MathJax.ElementJax.mml;
 
 /*****************************************************************/
-/*
+/**
  *  Implements the LegacyMmlVisitor (subclass of MmlVisitor)
  */
 
 export class LegacyMmlVisitor extends MmlVisitor {
 
-    /*
+    /**
      * Convert the tree rooted at a particular node into the old-style
      * internal format used by MathJax v2.
      *
@@ -52,7 +52,7 @@ export class LegacyMmlVisitor extends MmlVisitor {
         return root;
     }
 
-    /*
+    /**
      * @param {TextNode} node  The text node to visit
      * @param {any} parent  The old-style parent to which this node should be added
      */
@@ -60,7 +60,7 @@ export class LegacyMmlVisitor extends MmlVisitor {
         parent.Append(MML.chars(node.getText()));
     }
 
-    /*
+    /**
      * @param {XMLNode} node  The XML node to visit
      * @param {any} parent  The old-style parent to which this node should be added
      */
@@ -68,7 +68,7 @@ export class LegacyMmlVisitor extends MmlVisitor {
         parent.Append(MML.xml(node.getXML()));
     }
 
-    /*
+    /**
      * Visit an inferred mrow, but don't add the inferred row itself (the old-style
      * nodes will add one automatically).
      *
@@ -81,7 +81,7 @@ export class LegacyMmlVisitor extends MmlVisitor {
         }
     }
 
-    /*
+    /**
      * The generic visiting function:
      *   Create a node of the correct type.
      *   Add its explicit attributes.
@@ -101,7 +101,8 @@ export class LegacyMmlVisitor extends MmlVisitor {
         }
         parent.Append(mml);
     }
-    /*
+
+    /**
      * @param {MmlNode} node  The node who attributes are to be copied
      * @param {any} mml  The old-style node to which attributes are being added
      */
@@ -112,7 +113,8 @@ export class LegacyMmlVisitor extends MmlVisitor {
             mml[name] = attributes.getExplicit(name);
         }
     }
-    /*
+
+    /**
      * @param {MmlNode} node  The node whose properties are to be copied
      * @param {any} mml  The old-stype node to which the properties are being copied
      */

--- a/mathjax3-ts/core/MmlTree/MML.ts
+++ b/mathjax3-ts/core/MmlTree/MML.ts
@@ -63,7 +63,7 @@ import {TeXAtom} from './MmlNodes/TeXAtom.js';
 import {mathchoice} from './MmlNodes/mathchoice.js';
 
 /************************************************************************/
-/*
+/**
  *  This object collects all the MathML node types together so that
  *  they can be used to seed an MmlNodeFactory.  One could copy this
  *  object to override existing classes with subclasses, or to add new

--- a/mathjax3-ts/core/MmlTree/MathMLVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/MathMLVisitor.ts
@@ -26,17 +26,17 @@ import {MmlFactory} from './MmlFactory.js';
 import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MathMLVisitor (subclass of MmlVisitor)
  */
 
 export class MathMLVisitor extends MmlVisitor {
-    /*
+    /**
      * The document in which the nodes are being made
      */
     protected document: Document = null;
 
-    /*
+    /**
      * Convert the tree rooted at a particular node into DOM nodes.
      *
      * @param {MmlNode} node  The node to use as the root of the tree to traverse
@@ -51,7 +51,7 @@ export class MathMLVisitor extends MmlVisitor {
         return root.firstChild;
     }
 
-    /*
+    /**
      * @param {TextNode} node  The text node to visit
      * @param {Element} parent  The DOM parent to which this node should be added
      */
@@ -59,7 +59,7 @@ export class MathMLVisitor extends MmlVisitor {
         parent.appendChild(this.document.createTextNode(node.getText()));
     }
 
-    /*
+    /**
      * @param {XMLNode} node  The XML node to visit
      * @param {Element} parent  The DOM parent to which this node should be added
      */
@@ -67,7 +67,7 @@ export class MathMLVisitor extends MmlVisitor {
         parent.appendChild((node.getXML() as Element).cloneNode(true));
     }
 
-    /*
+    /**
      * Visit an inferred mrow, but don't add the inferred row itself (since
      * it is supposed to be inferred).
      *
@@ -80,7 +80,7 @@ export class MathMLVisitor extends MmlVisitor {
         }
     }
 
-    /*
+    /**
      * The generic visiting function:
      *   Create a DOM node of the correct type.
      *   Add its explicit attributes.
@@ -98,7 +98,7 @@ export class MathMLVisitor extends MmlVisitor {
         }
         parent.appendChild(mml);
     }
-    /*
+    /**
      * @param {MmlNode} node  The node who attributes are to be copied
      * @param {Element} mml  The MathML DOM node to which attributes are being added
      */

--- a/mathjax3-ts/core/MmlTree/MmlFactory.ts
+++ b/mathjax3-ts/core/MmlTree/MmlFactory.ts
@@ -27,14 +27,14 @@ import {MmlNode, MmlNodeClass} from './MmlNode.js';
 import {MML} from './MML.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlFactory (subclass of NodeFactory)
  */
 
 export class MmlFactory extends AbstractNodeFactory<MmlNode, MmlNodeClass> {
     public static defaultNodes = MML;
 
-    /*
+    /**
      * @return {object}  The list of node-creation functions (similar to the
      *                   MML object from MathJax v2).
      */

--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -25,12 +25,12 @@ import {Attributes, INHERIT} from './Attributes.js';
 import {Property, PropertyList, Node, AbstractNode, AbstractEmptyNode, NodeClass} from '../Tree/Node.js';
 import {MmlFactory} from './MmlFactory.js';
 
-/*
+/**
  *  Used in setInheritedAttributes() to pass originating node kind as well as property value
  */
 export type AttributeList = {[attribute: string]: [string, Property]};
 
-/*
+/**
  *  These are the TeX classes for spacing computations
  */
 export const TEXCLASS = {
@@ -48,12 +48,12 @@ export const TEXCLASS = {
 
 export const TEXCLASSNAMES = ['ORD', 'OP', 'BIN', 'REL', 'OPEN', 'CLOSE', 'PUNCT', 'INNER', 'VCENTER'];
 
-/*
+/**
  *  The spacing sizes used by the TeX spacing table below.
  */
 const TEXSPACELENGTH = ['', 'thinmathspace', 'mediummathspace', 'thickmathspace'];
 
-/*
+/**
  * See TeXBook Chapter 18 (p. 170)
  */
 const TEXSPACE = [
@@ -67,7 +67,7 @@ const TEXSPACE = [
     [ 1, -1,  2,  3,  1,  0,  1,  1]  // INNER
 ];
 
-/*
+/**
  * Attributes used to determine indentation and shifting
  */
 export const indentAttributes = [
@@ -77,12 +77,12 @@ export const indentAttributes = [
 
 
 /*****************************************************************/
-/*
+/**
  *  The MmlNode interface (extends Node interface)
  */
 
 export interface MmlNode extends Node {
-    /*
+    /**
      * Test various properties of MathML nodes
      */
     readonly isToken: boolean;
@@ -90,70 +90,70 @@ export interface MmlNode extends Node {
     readonly isSpacelike: boolean;
     readonly linebreakContainer: boolean;
     readonly hasNewLine: boolean;
-    /*
+    /**
      *  The expected number of children (-1 means use inferred mrow)
      */
     readonly arity: number;
     readonly isInferred: boolean;
-    /*
+    /**
      *  Get the parent node (skipping inferred mrows and
      *    other nodes marked as notParent)
      */
     readonly Parent: MmlNode;
     readonly notParent: boolean;
-    /*
+    /**
      * The actual parent in the tree
      */
     parent: MmlNode;
-    /*
+    /**
      *  values needed for TeX spacing computations
      */
     texClass: number;
     prevClass: number;
     prevLevel: number;
 
-    /*
+    /**
      *  The attributes (explicit and inherited) for this node
      */
     attributes: Attributes;
 
-    /*
+    /**
      * @return {MmlNode}  For embellished operators, the child node that contains the
      *                    core <mo> node.  For non-embellished nodes, the original node.
      */
     core(): MmlNode;
-    /*
+    /**
      * @return {MmlNode}  For embellished operators, the core <mo> element (at whatever
      *                    depth).  Fod non-embellished nodes, the original node itself.
      */
     coreMO(): MmlNode;
-    /*
+    /**
      * @return {number}   For embellished operators, the index of the child node containing
      *                    the core <mo>.  For non-embellished nodes, 0.
      */
     coreIndex(): number;
-    /*
+    /**
      * @return {number}  The index of this node in its parent's childNodes array.
      */
     childPosition(): number;
 
-    /*
+    /**
      * @param {MmlNode} prev  The node that is before this one for TeX spacing purposes
      *                        (not all nodes count in TeX measurements)
      * @return {MmlNode}  The node that should be the previous node for the next one
      *                    in the tree (usually, either the last child, or the node itself)
      */
     setTeXclass(prev: MmlNode): MmlNode;
-    /*
+    /**
      * @return {string}  The spacing to use before this element (one of TEXSPACELENGTH array above)
      */
     texSpacing(): string;
-    /*
+    /**
      * @return {boolean}  The core mo element has an explicit 'form', 'lspace', or 'rspace' attribute
      */
     hasSpacingAttributes(): boolean;
 
-    /*
+    /**
      * Sets the nodes inherited attributes, and pushes them to the nodes children.
      *
      * @param {AttributeList} attributes  The list of inheritable attributes (with the node kinds
@@ -164,7 +164,7 @@ export interface MmlNode extends Node {
      */
     setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean): void;
 
-    /*
+    /**
      * Replace the current node with an error message (or the name of the node)
      *
      * @param {string} message         The error message to use
@@ -173,7 +173,7 @@ export interface MmlNode extends Node {
      */
     mError(message: string, options: PropertyList, short?: boolean): void;
 
-    /*
+    /**
      * Check integrity of MathML structure
      *
      * @param {PropertyList} options  The options controlling the check
@@ -183,16 +183,16 @@ export interface MmlNode extends Node {
 
 
 /*****************************************************************/
-/*
+/**
  *  The MmlNode class interface (extends the NodeClass)
  */
 
 export interface MmlNodeClass extends NodeClass {
-    /*
+    /**
      *  The list of default attribute values for nodes of this class
      */
     defaults?: PropertyList;
-    /*
+    /**
      * An MmlNode takes a NodeFactory (so it can create additional nodes as needed), a list
      *   of attributes, and an array of children and returns the desired MmlNode with
      *   those attributes and children
@@ -207,13 +207,13 @@ export interface MmlNodeClass extends NodeClass {
 
 
 /*****************************************************************/
-/*
+/**
  *  The abstract MmlNode class (extends the AbstractNode class and implements
  *  the IMmlNode interface)
  */
 
 export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
-    /*
+    /**
      * The properties common to all MathML nodes
      */
     public static defaults: PropertyList = {
@@ -223,7 +223,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
                             //    scale all spaces, fractions, etc.
         dir: INHERIT
     };
-    /*
+    /**
      *  This lists properties that do NOT get inherited between specific kinds
      *  of nodes.  The outer keys are the node kinds that are being inherited FROM,
      *  while the second level of keys are the nodes that INHERIT the values.  Any
@@ -241,7 +241,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             mtable: {groupalign: true}
         }
     };
-    /*
+    /**
      * This is the list of options for the verifyTree() method
      */
     public static verifyDefaults: PropertyList = {
@@ -252,7 +252,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         fixMtables: true
     };
 
-    /*
+    /**
      * These default to being unset (the node doesn't participate in spacing calculations).
      * The correct values are produced when the setTeXclass() method is called on the tree.
      */
@@ -262,7 +262,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
 
     public attributes: Attributes;
 
-    /*
+    /**
      *  Child nodes are MmlNodes (special case of Nodes).
      *  The parent is an MmlNode.
      */
@@ -270,7 +270,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
     public parent: MmlNode;
     public factory: MmlFactory;
 
-    /*
+    /**
      *  Create an MmlNode:
      *    If the arity is -1, add the inferred row (created by the factory)
      *    Add the children, if any
@@ -292,42 +292,42 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         this.attributes.setList(attributes);
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is a token node
      */
     public get isToken() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is an embellished operator
      */
     public get isEmbellished() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is a space-like node
      */
     public get isSpacelike() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is a node that supports linebreaks in its children
      */
     public get linebreakContainer() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this node contains a line break
      */
     public get hasNewLine() {
         return false;
     }
 
-    /*
+    /**
      * @return {number}  The number of children allowed, or Infinity for any number,
      *                   or -1 for when an inferred row is needed for the children.
      *                   Special case is 1, meaning at least one (other numbers
@@ -337,14 +337,14 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return Infinity;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is an inferred mrow
      */
     public get isInferred() {
         return false;
     }
 
-    /*
+    /**
      * @return {MmlNode}  The logial parent of this node (skipping over inferred rows
      *                      some other node types)
      */
@@ -356,14 +356,14 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return parent;
     }
 
-    /*
+    /**
      * @return {boolean}  true if this is a node that doesn't count as a parent node in Parent()
      */
     public get notParent() {
         return false;
     }
 
-    /*
+    /**
      * If there is an inferred row, the the children of that instead
      *
      * @override
@@ -374,7 +374,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
         return super.setChildren(children);
     }
-    /*
+    /**
      * If there is an inferred row, append to that instead
      *
      * @override
@@ -386,7 +386,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
         return super.appendChild(child);
     }
-    /*
+    /**
      * If there is an inferred row, remove the child from there
      *
      * @override
@@ -399,28 +399,28 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return super.replaceChild(newChild, oldChild);
     }
 
-    /*
+    /**
      * @override
      */
     public core(): MmlNode {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO(): MmlNode {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public coreIndex() {
         return 0;
     }
 
-    /*
+    /**
      * @override
      */
     public childPosition() {
@@ -442,14 +442,14 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return null;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode): MmlNode {
         this.getPrevClass(prev);
         return (this.texClass != null ? this : prev);
     }
-    /*
+    /**
      * For embellished operators, get the data from the core and clear the core
      *
      * @param {MmlNode} core  The core <mo> for this node
@@ -462,7 +462,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             this.texClass = core.texClass;
         }
     }
-    /*
+    /**
      * Get the previous element's texClass and scriptlevel
      *
      * @param {MmlNode} prev  The previous node to this one
@@ -474,7 +474,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
     }
 
-    /*
+    /**
      * @return {string}  returns the spacing to use before this node
      */
     public texSpacing() {
@@ -496,14 +496,14 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return TEXSPACELENGTH[Math.abs(space)];
     }
 
-    /*
+    /**
      * @return {boolean}  The core mo element has an explicit 'form' attribute
      */
     public hasSpacingAttributes() {
         return this.isEmbellished && this.coreMO().hasSpacingAttributes();
     }
 
-    /*
+    /**
      * Sets the inherited propertis for this node, and pushes inherited properties to the children
      *
      *   For each inheritable attribute:
@@ -557,7 +557,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
         this.setChildInheritedAttributes(attributes, display, level, prime);
     }
-    /*
+    /**
      * Apply inherited attributes to all children
      * (Some classes override this to handle changes in displaystyle and scriptlevel)
      *
@@ -572,7 +572,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             child.setInheritedAttributes(attributes, display, level, prime);
         }
     }
-    /*
+    /**
      * Used by subclasses to add add their own attributes to the inherited list
      * (e.g., mstyle uses this to augment the inhertied attibutes)
      *
@@ -589,7 +589,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         return updated;
     }
 
-    /*
+    /**
      * Verify the attributes, and that there are the right number of children.
      * Then verify the children.
      *
@@ -611,7 +611,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         this.verifyChildren(options);
     }
 
-    /*
+    /**
      * Verify that all the attributes are valid (i.e., have defaults)
      *
      * @param {PropertyList} options   The options telling how much to verify
@@ -634,7 +634,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
     }
 
-    /*
+    /**
      * Verify the children.
      *
      * @param {PropertyList} options   The options telling how much to verify
@@ -645,7 +645,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
         }
     }
 
-    /*
+    /**
      * Replace the current node with an error message (or the name of the node)
      *
      * @param {string} message         The error message to use
@@ -673,13 +673,13 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The abstract MmlNode Token node class (extends the AbstractMmlNode)
  */
 
 export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
 
-    /*
+    /**
      * Add the attributes common to all token nodes
      */
     public static defaults: PropertyList = {
@@ -688,14 +688,14 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
         mathsize: INHERIT
     };
 
-    /*
+    /**
      * @override
      */
     public get isToken() {
         return true;
     }
 
-    /*
+    /**
      * Get the text of the token node (skipping mglyphs, and combining
      *   multiple text nodes)
      */
@@ -709,7 +709,7 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
         return text;
     }
 
-    /*
+    /**
      * Only inherit to child nodes that are AbstractMmlNodes (not TextNodes)
      *
      * @override
@@ -722,7 +722,7 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
         }
     }
 
-    /*
+    /**
      * Only step into children that are AbstractMmlNodes (not TextNodes)
      * @override
      */
@@ -740,7 +740,7 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
 
 
 /*****************************************************************/
-/*
+/**
  *  The abstract MmlNode Layout class (extends the AbstractMmlNode)
  *
  *  These have inferred mrows (so only one child) and can be
@@ -749,47 +749,47 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
 
 export abstract class AbstractMmlLayoutNode extends AbstractMmlNode {
 
-    /*
+    /**
      * Use the same defaults as AbstractMmlNodes
      */
     public static defaults: PropertyList = AbstractMmlNode.defaults;
 
-    /*
+    /**
      * @override
      */
     public get isSpacelike() {
         return this.childNodes[0].isSpacelike;
     }
 
-    /*
+    /**
      * @override
      */
     public get isEmbellished() {
         return this.childNodes[0].isEmbellished;
     }
 
-    /*
+    /**
      * @override
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      * @override
      */
     public core() {
         return this.childNodes[0];
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO() {
         return this.childNodes[0].coreMO();
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -800,7 +800,7 @@ export abstract class AbstractMmlLayoutNode extends AbstractMmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The abstract MmlNode-with-base-node Class (extends the AbstractMmlNode)
  *
  *  These have a base element and other elemetns, (e.g., script elements for msubsup).
@@ -810,33 +810,33 @@ export abstract class AbstractMmlLayoutNode extends AbstractMmlNode {
 
 export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
 
-    /*
+    /**
      * Use the same defaults as AbstractMmlNodes
      */
     public static defaults: PropertyList = AbstractMmlNode.defaults;
 
-    /*
+    /**
      * @override
      */
     public get isEmbellished() {
         return this.childNodes[0].isEmbellished;
     }
 
-    /*
+    /**
      * @override
      */
     public core() {
         return this.childNodes[0];
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO() {
         return this.childNodes[0].coreMO();
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -864,7 +864,7 @@ export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The abstract MmlNode Empty Class (extends AbstractEmptyNode, implements MmlNode)
  *
  *  These have no children and no attributes (TextNode and XMLNode), so we
@@ -874,159 +874,159 @@ export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
 
 export abstract class AbstractMmlEmptyNode extends AbstractEmptyNode implements MmlNode {
 
-    /*
+    /**
      * @return {boolean}  Not a token element
      */
     public get isToken() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  Not embellished
      */
     public get isEmbellished() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  Not space-like
      */
     public get isSpacelike() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  Not a container of any kind
      */
     public get linebreakContainer() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  Does not contain new lines
      */
     public get hasNewLine() {
         return false;
     }
 
-    /*
+    /**
      * @return {number}  No children
      */
     public get arity() {
         return 0;
     }
 
-    /*
+    /**
      * @return {boolean}  Is not an inferred row
      */
     public get isInferred() {
         return false;
     }
 
-    /*
+    /**
      * @return {boolean}  Is not a container element
      */
     public get notParent() {
         return false;
     }
 
-    /*
+    /**
      * @return {MmlNode}  Parent is the actual parent
      */
     public get Parent() {
         return this.parent;
     }
 
-    /*
+    /**
      * @return {number}  No TeX class
      */
     public get texClass() {
         return TEXCLASS.NONE;
     }
 
-    /*
+    /**
      * @return {number}  No previous element
      */
     public get prevClass() {
         return TEXCLASS.NONE;
     }
 
-    /*
+    /**
      * @return {number}  No previous element
      */
     public get prevLevel() {
         return 0;
     }
 
-    /*
+    /**
      * @return {boolean}  The core mo element has an explicit 'form' attribute
      */
     public hasSpacingAttributes() {
         return false;
     }
 
-    /*
+    /**
      * return {Attributes}  No attributes, so don't store one
      */
     public get attributes(): Attributes {
         return null;
     }
 
-    /*
+    /**
      *  Parent is an MmlNode
      */
     public parent: MmlNode;
 
 
-    /*
+    /**
      * @override
      */
     public core(): MmlNode {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO(): MmlNode {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public coreIndex() {
         return 0;
     }
 
-    /*
+    /**
      * @override
      */
     public childPosition() {
         return 0;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
         return prev;
     }
-    /*
+    /**
      * @override
      */
     public texSpacing() {
         return '';
     }
 
-    /*
+    /**
      * No children or attributes, so ignore this call.
      *
      * @override
      */
     public setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {}
 
-    /*
+    /**
      * No children or attributes, so ignore this call.
      *
      * @param {MmlNode} node          The node tree to be checked
@@ -1034,7 +1034,7 @@ export abstract class AbstractMmlEmptyNode extends AbstractEmptyNode implements 
      */
     public verifyTree(options: PropertyList) {}
 
-    /*
+    /**
      *  @override
      */
     public mError(message: string, options: PropertyList, short: boolean = false) {}
@@ -1042,31 +1042,31 @@ export abstract class AbstractMmlEmptyNode extends AbstractEmptyNode implements 
 }
 
 /*****************************************************************/
-/*
+/**
  *  The TextNode Class (extends AbstractMmlEmptyNode)
  */
 
 export class TextNode extends AbstractMmlEmptyNode {
-    /*
+    /**
      * The text for this node
      */
     protected text: string = '';
 
-    /*
+    /**
      * @override
      */
     public get kind() {
         return 'text';
     }
 
-    /*
+    /**
      * @return {string}  Return the node's text
      */
     public getText(): string {
         return this.text;
     }
 
-    /*
+    /**
      * @param {string} text  The text to use for the node
      * @return {TextNode}  The text node (for chaining of method calls)
      */
@@ -1075,7 +1075,7 @@ export class TextNode extends AbstractMmlEmptyNode {
         return this;
     }
 
-    /*
+    /**
      * Just use the text
      */
     public toString() {
@@ -1086,31 +1086,31 @@ export class TextNode extends AbstractMmlEmptyNode {
 
 
 /*****************************************************************/
-/*
+/**
  *  The XMLNode Class (extends AbstractMmlEmptyNode)
  */
 
 export class XMLNode extends AbstractMmlEmptyNode {
-    /*
+    /**
      * The XML content for this node
      */
     protected xml: Object = null;
 
-    /*
+    /**
      * @override
      */
     public get kind() {
         return 'XML';
     }
 
-    /*
+    /**
      * @return {Object}  Return the node's XML content
      */
     public getXML(): Object {
         return this.xml;
     }
 
-    /*
+    /**
      * @param {object} xml  The XML content to be saved
      * @return {XMLNode}  The XML node (for chaining of method calls)
      */
@@ -1119,7 +1119,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
         return this;
     }
 
-    /*
+    /**
      * Just indicate that this is XML data
      */
     public toString() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -26,7 +26,7 @@ import {AbstractMmlBaseNode, MmlNode, TEXCLASS} from '../MmlNode.js';
 import {MmlMo} from './mo.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the TeXAtom node class (subclass of AbstractMmlBaseNode)
  */
 
@@ -36,28 +36,28 @@ export class TeXAtom extends AbstractMmlBaseNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      *  @return {string}  The TeXAtom kind
      */
     public get kind() {
         return 'TeXAtom';
     }
 
-    /*
+    /**
      *  @return {number}  Inferred mrow with any number of children
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      *  @return {boolean}  This element is not considered a MathML container
      */
     public get notParent() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -65,7 +65,7 @@ export class TeXAtom extends AbstractMmlBaseNode {
         return this.adjustTeXclass(prev);
     }
 
-    /*
+    /**
      * (Replaced below by the version from the MmlMo node)
      *
      * @override
@@ -74,7 +74,7 @@ export class TeXAtom extends AbstractMmlBaseNode {
         return prev;
     }
 }
-/*
+/**
  *  Use the method from the MmlMo class
  */
 TeXAtom.prototype.adjustTeXclass = MmlMo.prototype.adjustTeXclass;

--- a/mathjax3-ts/core/MmlTree/MmlNodes/maction.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/maction.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMaction node class (subclass of AbstractMmlNode)
  */
 
@@ -36,21 +36,21 @@ export class MmlMaction extends AbstractMmlNode {
         selection: 1
     };
 
-    /*
+    /**
      *  @return {string}  The maction kind
      */
     public get kind() {
         return 'maction';
     }
 
-    /*
+    /**
      * @return {number}  At least one child
      */
     public get arity() {
         return 1;
     }
 
-    /*
+    /**
      * @return {MmlNode}  The selected child node (or an mrow if none selected)
      */
     public get selected(): MmlNode {
@@ -59,35 +59,35 @@ export class MmlMaction extends AbstractMmlNode {
         return this.childNodes[i] || this.factory.create('mrow');
     }
 
-    /*
+    /**
      * @override
      */
     public get isEmbellished() {
         return this.selected.isEmbellished;
     }
 
-    /*
+    /**
      * @override
      */
     public get isSpacelike() {
         return this.selected.isSpacelike;
     }
 
-    /*
+    /**
      * @override
      */
     public core(): MmlNode {
         return this.selected.core();
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO(): MmlNode {
         return this.selected.coreMO();
     }
 
-    /*
+    /**
      * @override
      */
     protected verifyAttributes(options: PropertyList) {
@@ -99,7 +99,7 @@ export class MmlMaction extends AbstractMmlNode {
         }
     }
 
-    /*
+    /**
      * Get the TeX class from the selceted node
      * For tooltips, set TeX classes within the tip as a separate math list
      *
@@ -115,7 +115,7 @@ export class MmlMaction extends AbstractMmlNode {
         return prev;
     }
 
-    /*
+    /**
      * Select the next child for a toggle action
      */
     public nextToggleSelection() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/maligngroup.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/maligngroup.ts
@@ -26,7 +26,7 @@ import {AbstractMmlNode, AttributeList} from '../MmlNode.js';
 import {INHERIT} from '../Attributes.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMaligngroup node class (subclass of AbstractMmlNode)
  */
 
@@ -36,21 +36,21 @@ export class MmlMaligngroup extends AbstractMmlNode {
         groupalign: INHERIT
     };
 
-    /*
+    /**
      * @return {string}  The maligngroup kind
      */
     public get kind() {
         return 'maligngroup';
     }
 
-    /*
+    /**
      * @return {boolean}  <maligngroup> is space-like
      */
     public get isSpacelike() {
         return true;
     }
 
-    /*
+    /**
      * Children can inherit from <maligngroup>
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/malignmark.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/malignmark.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlNode} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMalignmark node class (subclass of AbstractMmlNode)
  */
 
@@ -35,21 +35,21 @@ export class MmlMalignmark extends AbstractMmlNode {
         edge: 'left'
     };
 
-    /*
+    /**
      * @return {string}  The malignmark kind
      */
     public get kind() {
         return 'malignmark';
     }
 
-    /*
+    /**
      * @return {number}  No children allowed
      */
     public get arity() {
         return 0;
     }
 
-    /*
+    /**
      * @return {boolen} <malignmark> is space-like
      */
     public get isSpacelike() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/math.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/math.ts
@@ -25,12 +25,12 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlLayoutNode, AttributeList} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMath node class (subclass of AbstractMmlLayoutNode)
  */
 
 export class MmlMath extends AbstractMmlLayoutNode {
-    /*
+    /**
      *  These are used as the defaults for any attributes marked INHERIT in other classes
      */
     public static defaults: PropertyList = {
@@ -65,21 +65,21 @@ export class MmlMath extends AbstractMmlLayoutNode {
         indentshiftlast:  'indentshift'
     };
 
-    /*
+    /**
      * @return {string}  The math kind
      */
     public get kind() {
         return 'math';
     }
 
-    /*
+    /**
      * @return {boolean} Linebreaking can occur in math nodes
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * The attributes of math nodes are inherited, so add them into the list.
      * The displaystyle attribute comes from the display attribute if not given explicitly
      * The scriptlevel comes from the scriptlevel attribute or default

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mathchoice.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mathchoice.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlBaseNode, MmlNode, TEXCLASS, AttributeList} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the mathchoice node class (subclass of AbstractMmlBaseNode)
  *
  *  This is used by TeX's \mathchoice macro, but removes itself
@@ -37,28 +37,28 @@ export class mathchoice extends AbstractMmlBaseNode {
         ...AbstractMmlBaseNode.defaults
     };
 
-    /*
+    /**
      *  @return {string}  The mathcoice kind
      */
     public get kind() {
         return 'mathchoice';
     }
 
-    /*
+    /**
      *  @return {number}  4 children (display, text, script, and scriptscript styles)
      */
     public get arity() {
         return 4;
     }
 
-    /*
+    /**
      *  @return {boolean}  This element is not considered a MathML container
      */
     public get notParent() {
         return true;
     }
 
-    /*
+    /**
      * Replace the mathchoice node with the selected on based on the displaystyle and scriptlevel settings
      * (so the mathchoice never ends up in a finished MmlNode tree)
      *

--- a/mathjax3-ts/core/MmlTree/MmlNodes/menclose.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/menclose.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlEnclose node class (subclass of AbstractMmlNode)
  */
 
@@ -36,28 +36,28 @@ export class MmlMenclose extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The menclose kind
      */
     public get kind() {
         return 'menclose';
     }
 
-    /*
+    /**
      * @return {number}  <menclose> has an inferred mrow
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      * @return {boolean}  <menclose> is a linebreak container
      */
     public get linebreakContininer() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/merror.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/merror.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMerror node class (subclass of AbstractMmlNode)
  */
 
@@ -35,21 +35,21 @@ export class MmlMerror extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The merror kind
      */
     public get kind() {
         return 'merror';
     }
 
-    /*
+    /**
      * @return {number}  <merror> gets an inferred mrow
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      * @return {boolean}  <merror> can contain line breaks
      */
     public get linebreakContainer() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mfenced.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mfenced.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, TextNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMfenced node class (subclass of AbstractMmlNode)
  */
 
@@ -38,21 +38,21 @@ export class MmlMfenced extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.INNER;
 
-    /*
+    /**
      *  Storage for "fake" nodes for the delimiters and separators
      */
     public separators: MmlNode[] = [];
     public open: MmlNode = null;
     public close: MmlNode = null;
 
-    /*
+    /**
      * @return {string}  The mfenced kind
      */
     public get kind() {
         return 'mfenced';
     }
 
-    /*
+    /**
      * Include the fake nodes in the process, since they will be used
      *  to produce the output.
      *
@@ -81,7 +81,7 @@ export class MmlMfenced extends AbstractMmlNode {
         return prev;
     }
 
-    /*
+    /**
      * Create the fake nodes and do their inheritance
      * Then do inheridence of usual children
      *
@@ -97,7 +97,7 @@ export class MmlMfenced extends AbstractMmlNode {
         super.setChildInheritedAttributes(attributes, display, level, prime);
     }
 
-    /*
+    /**
      * Create <mo> elements for the open and close delimiters, and for the separators (if any)
      */
     protected addFakeNodes() {
@@ -134,7 +134,7 @@ export class MmlMfenced extends AbstractMmlNode {
         }
     }
 
-    /*
+    /**
      * @param {string} c                 The character for the text of the node
      * @param {PropertyList} properties  The attributes for the node
      * @param {number} texClass          The TeX class for the node

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mfrac.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mfrac.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlBaseNode, AttributeList} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMfrac node class (subclass of AbstractMmlBaseNode)
  */
 
@@ -38,28 +38,28 @@ export class MmlMfrac extends AbstractMmlBaseNode {
         bevelled: false
     };
 
-    /*
+    /**
      * @return {string}  The mfrac kind
      */
     public get kind() {
         return 'mfrac';
     }
 
-    /*
+    /**
      * @return {number}  <mfrac> requires two children
      */
     public get arity() {
         return 2;
     }
 
-    /*
+    /**
      * @return {boolean}  The children of <mfrac> can include line breaks
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * Update the children separately, and if embellished, update from the core
      *
      * @override
@@ -75,7 +75,7 @@ export class MmlMfrac extends AbstractMmlBaseNode {
         return this;
     }
 
-    /*
+    /**
      * Adjust the display level, and use prime style in denominator
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mglyph.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mglyph.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMglyph node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -40,7 +40,7 @@ export class MmlMglyph extends AbstractMmlTokenNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mglyph kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mi.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mi.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMi node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -33,7 +33,7 @@ export class MmlMi extends AbstractMmlTokenNode {
     public static defaults: PropertyList = {
         ...AbstractMmlTokenNode.defaults
     };
-    /*
+    /**
      * Patterns for operator names and single-character texts
      */
     public static operatorName: RegExp = /^[a-z][a-z0-9]*$/i;
@@ -41,14 +41,14 @@ export class MmlMi extends AbstractMmlTokenNode {
 
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mi kind
      */
     public get kind() {
         return 'mi';
     }
 
-    /*
+    /**
      * Do the usual inheritance, then check the text length to see
      *   if mathvariant should be normal or italic.
      *
@@ -63,7 +63,7 @@ export class MmlMi extends AbstractMmlTokenNode {
         }
     }
 
-    /*
+    /**
      * Mark multi-character texts as OP rather than ORD for spacing purposes
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mmultiscripts.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mmultiscripts.ts
@@ -26,7 +26,7 @@ import {AbstractMmlNode, AttributeList} from '../MmlNode.js';
 import {MmlMsubsup} from './msubsup.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMmultiscripts node class (subclass of MmlMsubsup)
  */
 
@@ -35,21 +35,21 @@ export class MmlMmultiscripts extends MmlMsubsup {
         ...MmlMsubsup.defaults
     };
 
-    /*
+    /**
      * @return {string}  The mmultiscripts kind
      */
     public get kind() {
         return 'mmultiscripts';
     }
 
-    /*
+    /**
      * @return {number}  <mmultiscripts> requires at least one child (the base)
      */
     public get arity() {
         return 1;
     }
 
-    /*
+    /**
      * Push the inherited values to the base
      * Make sure the number of pre- and post-scripts are even by adding mrows, if needed.
      * For the scripts, use displaystyle = false, scriptlevel + 1, and
@@ -84,7 +84,7 @@ export class MmlMmultiscripts extends MmlMsubsup {
         }
     }
 
-    /*
+    /**
      * Check that mprescripts only occurs once, and that the number of pre- and post-scripts are even.
      *
      * @override
@@ -113,7 +113,7 @@ export class MmlMmultiscripts extends MmlMsubsup {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMprescripts node class (subclass of AbstractMmlNode)
  */
 
@@ -122,21 +122,21 @@ export class MmlMprescripts extends AbstractMmlNode {
         ...AbstractMmlNode.defaults
     };
 
-    /*
+    /**
      * @return {string}  The mprescripts kind
      */
     public get kind() {
         return 'mprescripts';
     }
 
-    /*
+    /**
      * @return {number}  <mprescripts> can have no children
      */
     public get arity() {
         return 0;
     }
 
-    /*
+    /**
      * Check that parent is mmultiscripts
      *
      * @override
@@ -150,7 +150,7 @@ export class MmlMprescripts extends AbstractMmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlNone node class (subclass of AbstractMmlNode)
  */
 
@@ -159,21 +159,21 @@ export class MmlNone extends AbstractMmlNode {
         ...AbstractMmlNode.defaults
     };
 
-    /*
+    /**
      * @return {string}  The none kind
      */
     public get kind() {
         return 'none';
     }
 
-    /*
+    /**
      * @return {number}  <none> can have no children
      */
     public get arity() {
         return 0;
     }
 
-    /*
+    /**
      * Check that parent is mmultiscripts
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mn.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mn.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMn node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -35,7 +35,7 @@ export class MmlMn extends AbstractMmlTokenNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mn kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
@@ -143,7 +143,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     }
 
     /**
-     * @return{boolean}  True is this mo is an accent in an munderover construction
+     * @return {boolean}  True is this mo is an accent in an munderover construction
      */
     get isAccent() {
         let accent = false;
@@ -305,8 +305,8 @@ export class MmlMo extends AbstractMmlTokenNode {
     }
 
     /**
-     * @param{string[]} forms     The three forms in the default order they are to be tested
-     * @return{string[]}          The forms in the new order, if there is an explicit form attribute
+     * @param {string[]} forms     The three forms in the default order they are to be tested
+     * @return {string[]}          The forms in the new order, if there is an explicit form attribute
      */
     protected handleExplicitForm(forms: string[]) {
         if (this.attributes.isSet('form')) {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
@@ -28,7 +28,7 @@ import {MmlMover, MmlMunder, MmlMunderover} from './munderover.js';
 import {OperatorList, OPTABLE, RangeDef, RANGES, MMLSPACING} from '../OperatorDictionary.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMo node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -59,50 +59,50 @@ export class MmlMo extends AbstractMmlTokenNode {
         indentshiftlast: 'indentshift'
     };
 
-    /*
+    /**
      * Unicode ranges and their default TeX classes and MathML spacing
      */
     public static RANGES = RANGES;
     public static MMLSPACING = MMLSPACING;
 
-    /*
+    /**
      * The Operator Dictionary.
      */
     public static OPTABLE: {[form: string]: OperatorList} = OPTABLE;
 
-    /*
+    /**
      * The TeX class of the node is set to REL for MathML, but TeX sets it explicitly in setTeXclass()
      */
     public texClass = TEXCLASS.REL;
 
-    /*
+    /**
      * The default MathML spacing on the left and right
      */
     public lspace = 5/18;
     public rspace = 5/18;
 
-    /*
+    /**
      * @return {string}  The mo kind
      */
     public get kind() {
         return 'mo';
     }
 
-    /*
+    /**
      * @return {boolean}  All <mo> are considered embellished
      */
     public get isEmbellished() {
         return true;
     }
 
-    /*
+    /**
      * @return {boolean}  Is <mo> marked as an explicit linebreak?
      */
     public get hasNewLine() {
         return this.attributes.get('linebreak') === 'newline';
     }
 
-    /*
+    /**
      * @return {MmlNode}  The node that is the outermost embellished operator
      *                    with this node as its core
      */
@@ -115,7 +115,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return parent;
     }
 
-    /*
+    /**
      * @param {MmlNode} parent  The node whose core text is to be obtained
      * @return {string}         The text of the core MO of the given parent element
      */
@@ -134,7 +134,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return (parent.isToken ? (parent as AbstractMmlTokenNode).getText() : '');
     }
 
-    /*
+    /**
      * @override
      */
     public hasSpacingAttributes() {
@@ -142,7 +142,7 @@ export class MmlMo extends AbstractMmlTokenNode {
                this.attributes.isSet('rspace');
     }
 
-    /*
+    /**
      * @return{boolean}  True is this mo is an accent in an munderover construction
      */
     get isAccent() {
@@ -169,7 +169,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return accent;
     }
 
-    /*
+    /**
      * Produce the texClass based on the operator dictionary values
      *
      * @override
@@ -198,7 +198,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         }
         return this.adjustTeXclass(prev);
     }
-    /*
+    /**
      * Follow the TeXBook rules for adjusting the TeX class once its neighbors are known
      *
      * @param {MmlNode} prev  The node appearing before this one in the output
@@ -246,7 +246,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return this;
     }
 
-    /*
+    /**
      * Do the normal inheritance, then look up the attributes from the operator dictionary.
      * If there is no dictionary entry, get the TeX class from the Unicode range list.
      *  (FIXME: if using MathML spacing, fake lspace and rspace as well)
@@ -279,7 +279,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         }
     }
 
-    /*
+    /**
      * @return {[string, string, string]}  The list of form attribute values in the
      *                                     order they should be tested, based on the
      *                                     position of the element in its parent.
@@ -304,7 +304,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return ['infix', 'prefix', 'postfix'];
     }
 
-    /*
+    /**
      * @param{string[]} forms     The three forms in the default order they are to be tested
      * @return{string[]}          The forms in the new order, if there is an explicit form attribute
      */
@@ -316,7 +316,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         return forms;
     }
 
-    /*
+    /**
      * @param {string} mo  The character to look up in the range table
      * @return {RangeDef}  The unicode range in which the character falls, or null
      */

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mpadded.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mpadded.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlLayoutNode} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMpadded node class (subclass of AbstractMmlLayoutNode)
  */
 
@@ -39,7 +39,7 @@ export class MmlMpadded extends AbstractMmlLayoutNode {
         voffset: 0
     };
 
-    /*
+    /**
      * @return {string}  The mpadded kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mphantom.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mphantom.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlLayoutNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMphantom node class (subclass of AbstractMmlLayoutNode)
  */
 
@@ -35,7 +35,7 @@ export class MmlMphantom extends AbstractMmlLayoutNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mphantom kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mroot.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mroot.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMroot node class (subclass of AbstractMmlNode)
  */
 
@@ -35,21 +35,21 @@ export class MmlMroot extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mroot kind
      */
     public get kind() {
         return 'mroot';
     }
 
-    /*
+    /**
      * @return {number}  <mroot> requires two children
      */
     public get arity() {
         return 2;
     }
 
-    /*
+    /**
      * Set the children display/level/prime for the base and root.
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mrow.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMrow node class (subclass of AbstractMmlNode)
  */
 
@@ -34,19 +34,19 @@ export class MmlMrow extends AbstractMmlNode {
         ...AbstractMmlNode.defaults
     };
 
-    /*
+    /**
      * The index of the core child, when acting as an embellish mrow
      */
     protected _core: number = null;
 
-    /*
+    /**
      * @return {string}  The mrow kind
      */
     public get kind() {
         return 'mrow';
     }
 
-    /*
+    /**
      * An mrow is space-like if all its children are.
      *
      * @override
@@ -60,7 +60,7 @@ export class MmlMrow extends AbstractMmlNode {
         return true;
     }
 
-    /*
+    /**
      * An mrow is embellished if it contains one embellished operator
      * and any number of space-like nodes
      *
@@ -85,7 +85,7 @@ export class MmlMrow extends AbstractMmlNode {
         return embellished;
     }
 
-    /*
+    /**
      * @override
      */
     public core(): MmlNode {
@@ -95,7 +95,7 @@ export class MmlMrow extends AbstractMmlNode {
         return this.childNodes[this._core];
     }
 
-    /*
+    /**
      * @override
      */
     public coreMO(): MmlNode {
@@ -105,7 +105,7 @@ export class MmlMrow extends AbstractMmlNode {
         return this.childNodes[this._core].coreMO();
     }
 
-    /*
+    /**
      * @return {number}  The number of non-spacelike child nodes
      */
     public nonSpaceLength() {
@@ -118,7 +118,7 @@ export class MmlMrow extends AbstractMmlNode {
         return n;
     }
 
-    /*
+    /**
      * @return {MmlNode}  The first non-space-like child node
      */
     public firstNonSpace() {
@@ -130,7 +130,7 @@ export class MmlMrow extends AbstractMmlNode {
         return null;
     }
 
-    /*
+    /**
      * @return {MmlNode}  The last non-space-like child node
      */
     public lastNonSpace() {
@@ -144,7 +144,7 @@ export class MmlMrow extends AbstractMmlNode {
         return null;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -182,35 +182,35 @@ export class MmlMrow extends AbstractMmlNode {
 
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlInferredMrow node class (subclass of MmlMrow)
  */
 
 export class MmlInferredMrow extends MmlMrow {
     public static defaults: PropertyList = MmlMrow.defaults;
 
-    /*
+    /**
      * @return {string}  The inferred-mrow kind
      */
     public get kind() {
         return 'inferredMrow';
     }
 
-    /*
+    /**
      * @return {boolean}  This is inferred
      */
     public get isInferred() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     public get notParent() {
         return true;
     }
 
-    /*
+    /**
      * Show the child nodes in brackets
      */
     public toString() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/ms.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/ms.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMs node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -37,7 +37,7 @@ export class MmlMs extends AbstractMmlTokenNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The ms kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mspace.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMspace node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -39,28 +39,28 @@ export class MmlMspace extends AbstractMmlTokenNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  the mspace kind
      */
     public get kind() {
         return 'mspace';
     }
 
-    /*
+    /**
      * @return {number}  mspace can't have children
      */
     public get arity() {
         return 0;
     }
 
-    /*
+    /**
      * @override
      */
     public get isSpacelike() {
         return true;
     }
 
-    /*
+    /**
      * Only process linebreak if the space has no explicit dimensions (according to spec)
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/msqrt.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/msqrt.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMsqrt node class (subclass of AbstractMmlNode)
  */
 
@@ -35,28 +35,28 @@ export class MmlMsqrt extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The msqrt kind
      */
     public get kind() {
         return 'msqrt';
     }
 
-    /*
+    /**
      * @return {number}  <msqrt> has an inferred mrow
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      * @return {boolean}  <msqrt> can contain line breaks
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -65,7 +65,7 @@ export class MmlMsqrt extends AbstractMmlNode {
         return this;
     }
 
-    /*
+    /**
      * The contents of sqrt are in TeX prime style.
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -26,7 +26,7 @@ import {AbstractMmlLayoutNode, AttributeList} from '../MmlNode.js';
 import {INHERIT} from '../Attributes.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMstyle node class (subclass of AbstractMmlLayoutNode)
  */
 
@@ -43,14 +43,14 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
         infixlinebreakstyle: 'before'
     };
 
-    /*
+    /**
      * @return {string}  The mstyle kind
      */
     public get kind() {
         return 'mstyle';
     }
 
-    /*
+    /**
      * Handle scriptlevel changes, and add mstyle attributes to the ones being inherited.
      *
      * @override

--- a/mathjax3-ts/core/MmlTree/MmlNodes/msubsup.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/msubsup.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlBaseNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMsubsup node class (subclass of AbstractMmlBaseNode)
  */
 
@@ -36,42 +36,42 @@ export class MmlMsubsup extends AbstractMmlBaseNode {
         superscriptshift: ''
     };
 
-    /*
+    /**
      * @return {string}  The msubsup kind
      */
     public get kind() {
         return 'msubsup';
     }
 
-    /*
+    /**
      * @return {number}  <msubsup> requires three children
      */
     public get arity() {
         return 3;
     }
 
-    /*
+    /**
      * @return {number}  The position of the base element
      */
     public get base() {
         return 0;
     }
 
-    /*
+    /**
      * @return {number}  The position of the subscript (overriden in msup below)
      */
     public get sub() {
         return 1;
     }
 
-    /*
+    /**
      * @return {number}  The position of the superscript (overriden in msup below)
      */
     public get sup() {
         return 2;
     }
 
-    /*
+    /**
      * Super- and subscripts are not in displaymode, have scriptlevel increased, and prime style in subscripts.
      *
      * @override
@@ -88,7 +88,7 @@ export class MmlMsubsup extends AbstractMmlBaseNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMsub node class (subclass of MmlMsubsup)
  */
 
@@ -97,14 +97,14 @@ export class MmlMsub extends MmlMsubsup {
         ...MmlMsubsup.defaults
     };
 
-    /*
+    /**
      * @return {string}  The msub kind
      */
     public get kind() {
         return 'msub';
     }
 
-    /*
+    /**
      * @return {number}  <msub> only gets two children
      */
     public get arity() {
@@ -113,7 +113,7 @@ export class MmlMsub extends MmlMsubsup {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMsup node class (subclass of MmlMsubsup)
  */
 
@@ -122,28 +122,28 @@ export class MmlMsup extends MmlMsubsup {
         ...MmlMsubsup.defaults
     };
 
-    /*
+    /**
      * @return {string}  The msup kind
      */
     public get kind() {
         return 'msup';
     }
 
-    /*
+    /**
      * @return {number}  <msup> only gets two children
      */
     get arity() {
         return 2;
     }
 
-    /*
+    /**
      * @return {number}  child 1 is superscript
      */
     get sup() {
         return 1;
     }
 
-    /*
+    /**
      * @return {number}  child 2 is null (no subscript)
      */
     get sub() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtable.ts
@@ -26,7 +26,7 @@ import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS, indentAttributes} fro
 import {split} from '../../../util/string.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMtable node class (subclass of AbstractMmlNode)
  */
 
@@ -57,21 +57,21 @@ export class MmlMtable extends AbstractMmlNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mtable kind
      */
     public get kind() {
         return 'mtable';
     }
 
-    /*
+    /**
      * @return {boolean}  Linebreaks are allowed in tables
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
@@ -90,7 +90,7 @@ export class MmlMtable extends AbstractMmlNode {
         super.setInheritedAttributes(attributes, display, level, prime);
     };
 
-    /*
+    /**
      * Make sure all children are mtr or mlabeledtr nodes
      * Inherit the table attributes, and set the display attribute based on the table's displaystyle attribute
      *
@@ -115,7 +115,7 @@ export class MmlMtable extends AbstractMmlNode {
         }
     }
 
-    /*
+    /**
      * Check that children are mtr or mlabeledtr
      *
      * @override
@@ -131,7 +131,7 @@ export class MmlMtable extends AbstractMmlNode {
         super.verifyChildren(options);
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtd.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtd.ts
@@ -26,7 +26,7 @@ import {AbstractMmlBaseNode, MmlNode} from '../MmlNode.js';
 import {INHERIT} from '../Attributes.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMtd node class (subclass of AbstractMmlBaseNode)
  */
 
@@ -40,28 +40,28 @@ export class MmlMtd extends AbstractMmlBaseNode {
         groupalign: INHERIT
     };
 
-    /*
+    /**
      * @return {string}  The mtd kind
      */
     public get kind() {
         return 'mtd';
     }
 
-    /*
+    /**
      * @return {number}  <mtd> has an inferred mrow
      */
     public get arity() {
         return -1;
     }
 
-    /*
+    /**
      * @return {boolean}  <mtd> can contain line breaks
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * Check that parent is mtr
      *
      * @override
@@ -74,7 +74,7 @@ export class MmlMtd extends AbstractMmlBaseNode {
         super.verifyChildren(options);
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtext.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtext.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMtext node class (subclass of AbstractMmlTokenNode)
  */
 
@@ -35,14 +35,14 @@ export class MmlMtext extends AbstractMmlTokenNode {
     };
     public texClass = TEXCLASS.ORD;
 
-    /*
+    /**
      * @return {string}  The mtext kind
      */
     public get kind() {
         return 'mtext';
     }
 
-    /*
+    /**
      * @return {boolean}  <mtext> is always space-like according to the spec
      */
     public get isSpacelike() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mtr.ts
@@ -27,7 +27,7 @@ import {INHERIT} from '../Attributes.js';
 import {split} from '../../../util/string.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMtr node class (subclass of AbstractMmlNode)
  */
 
@@ -39,21 +39,21 @@ export class MmlMtr extends AbstractMmlNode {
         groupalign: INHERIT
     };
 
-    /*
+    /**
      * @return {string}  The mtr kind
      */
     public get kind() {
         return 'mtr';
     }
 
-    /*
+    /**
      * @return {boolean}  <mtr> can contain linebreaks
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * Inherit the mtr attributes
      *
      * @override
@@ -79,7 +79,7 @@ export class MmlMtr extends AbstractMmlNode {
         }
     }
 
-    /*
+    /**
      * Check that parent is mtable and children are mtd
      *
      * @override
@@ -100,7 +100,7 @@ export class MmlMtr extends AbstractMmlNode {
         super.verifyChildren(options);
     }
 
-    /*
+    /**
      * @override
      */
     public setTeXclass(prev: MmlNode) {
@@ -113,20 +113,20 @@ export class MmlMtr extends AbstractMmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMlabeledtr node class (subclass of MmlMtr)
  */
 
 export class MmlMlabeledtr extends MmlMtr {
 
-    /*
+    /**
      * @return {string}  The mtr kind
      */
     public get kind() {
         return 'mlabeledtr';
     }
 
-    /*
+    /**
      * @return {number}  <mlabeledtr> requires at least one child (the label)
      */
     get arity() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/munderover.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/munderover.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlBaseNode, AttributeList} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMunderover node class (subclass of AbstractMmlNode)
  */
 
@@ -36,54 +36,54 @@ export class MmlMunderover extends AbstractMmlBaseNode {
         accentunder: false,
         align: 'center'
     };
-    /*
+    /**
      * The names of attributes controling accents for each child node (reversed for mover below)
      */
     protected static ACCENTS = ['', 'accentunder', 'accent'];
 
-    /*
+    /**
      * @return {string}  The munderover kind
      */
     public get kind() {
         return 'munderover';
     }
 
-    /*
+    /**
      * @return {number}  <munderover> requires three children
      */
     public get arity() {
         return 3;
     }
 
-    /*
+    /**
      * @return {number}  The base is child 0
      */
     public get base() {
         return 0;
     }
 
-    /*
+    /**
      * @return {number}  Child 1 goes under (overriden by mover below)
      */
     public get under() {
         return 1;
     }
 
-    /*
+    /**
      * @return {number}  Child 2 goes over (overriden by mover below)
      */
     public get over() {
         return 2;
     }
 
-    /*
+    /**
      * @return {boolean}  <munderover> can contain line breaks
      */
     public get linebreakContainer() {
         return true;
     }
 
-    /*
+    /**
      * Base is in prime style if there is an over node
      * Force scriptlevel change if converted to sub-sup by movablelimits on the base in non-display mode
      * Adjust displaystyle, scriptlevel, and primestyle for the uncer/over nodes and check if accent
@@ -109,7 +109,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
         this.setInheritedAccent(2, ACCENTS[2], display, level, prime, force);
     }
 
-    /*
+    /**
      * @param {string} accent  The name of the accent attribute to check ("accent" or "accentunder")
      * @param {boolean} force  True if the scriptlevel change is to be forced to occur
      * @param {number} level   The current scriptlevel
@@ -122,7 +122,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
         return level;
     }
 
-    /*
+    /**
      * Check if an under or over accent should cause the appropriate accent attribute to eb inherited
      *   on the munderover node, and if it is not the default, re-inherit the scriptlevel, since that
      *   is affected by the accent attribute
@@ -148,7 +148,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMunder node class (subclass of MmlMunderover)
  */
 
@@ -157,14 +157,14 @@ export class MmlMunder extends MmlMunderover {
         ...MmlMunderover.defaults
     };
 
-    /*
+    /**
      * @return {string}  The munder kind
      */
     public get kind() {
         return 'munder';
     }
 
-    /*
+    /**
      * @return {number}  <munder> has only two children
      */
     public get arity() {
@@ -173,7 +173,7 @@ export class MmlMunder extends MmlMunderover {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMover node class (subclass of MmlMunderover)
  */
 
@@ -181,33 +181,33 @@ export class MmlMover extends MmlMunderover {
     public static defaults: PropertyList = {
         ...MmlMunderover.defaults
     };
-    /*
+    /**
      *  The first child is the over accent (second never occurs)
      */
     protected static ACCENTS = ['', 'accent', 'accentunder'];
 
-    /*
+    /**
      * @return {string}  The mover kind
      */
     public get kind() {
         return 'mover';
     }
 
-    /*
+    /**
      * @return {number}  <mover> has only two children
      */
     get arity() {
         return 2;
     }
 
-    /*
+    /**
      * @return {number}  Child 1 is the over node
      */
     public get over() {
         return 1;
     }
 
-    /*
+    /**
      * @return {number}  Child 2 is the null (the under node)
      */
     public get under() {

--- a/mathjax3-ts/core/MmlTree/MmlNodes/semantics.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/semantics.ts
@@ -25,7 +25,7 @@ import {PropertyList} from '../../Tree/Node.js';
 import {MmlNode, AbstractMmlNode, AbstractMmlBaseNode} from '../MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMroot node class (subclass of AbstractMmlBaseNode)
  */
 
@@ -36,21 +36,21 @@ export class MmlSemantics extends AbstractMmlBaseNode {
         encoding: null
     };
 
-    /*
+    /**
      * @return {string}  The semantics kind
      */
     public get kind() {
         return 'semantics';
     }
 
-    /*
+    /**
      * @return {number}  <semantics> requires at least one node
      */
     public get arity() {
         return 1;
     }
 
-    /*
+    /**
      * @return {boolean}  Ignore <semantics> when looking for partent node
      */
     public get notParent() {
@@ -60,7 +60,7 @@ export class MmlSemantics extends AbstractMmlBaseNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMroot node class (subclass of AbstractMmlNode)
  */
 
@@ -74,14 +74,14 @@ export class MmlAnnotationXML extends AbstractMmlNode {
         src: null
     };
 
-    /*
+    /**
      * @return {string}  The annotation-xml kind
      */
     public get kind() {
         return 'annotation-xml';
     }
 
-    /*
+    /**
      * Children are XMLNodes, so don't bother inheritting to them
      *
      * @override
@@ -90,7 +90,7 @@ export class MmlAnnotationXML extends AbstractMmlNode {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlMroot node class (subclass of MmlAnnotationXML)
  */
 
@@ -102,7 +102,7 @@ export class MmlAnnotation extends MmlAnnotationXML {
         isChars: true
     };
 
-    /*
+    /**
      * @return {string}  The annotation-xml kind
      */
     public get kind() {

--- a/mathjax3-ts/core/MmlTree/MmlVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/MmlVisitor.ts
@@ -26,13 +26,13 @@ import {MmlFactory} from './MmlFactory.js';
 import {AbstractVisitor} from '../Tree/Visitor.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MmlVisitor (subclass of Visitor, and base class
  *  for visitors that accept MmlNode trees)
  */
 
 export class MmlVisitor extends AbstractVisitor {
-    /*
+    /**
      * @param {MmlFactory} factory  The MmlNode factory (defaults to MmlFactory if not given)
      *
      * @constructor
@@ -46,17 +46,18 @@ export class MmlVisitor extends AbstractVisitor {
     }
 
     /***********************************************/
-    /*
+    /**
      * Stubs for overriding in subclasses
      */
 
-    /*
+    /**
      * @param {TextNode} node  The TextNode to visit
      * @param {any[]} args  Any arguments needed by the visitor
      * @return {any}  Any return value needed for the visitor
      */
     public visitTextNode(node: TextNode, ...args: any[]): any {}
-    /*
+
+    /**
      * @param {XMLNode} node  The XMLNode to visit
      * @param {any[]} args  Any arguments needed by the visitor
      * @return {any}  Any return value needed for the visitor

--- a/mathjax3-ts/core/MmlTree/OperatorDictionary.ts
+++ b/mathjax3-ts/core/MmlTree/OperatorDictionary.ts
@@ -32,11 +32,11 @@ export type OperatorList = {[name: string]: OperatorDef};
 export type RangeDef = [number, number, number, string];
 
 /**
- * @param{number} lspace            The operator's MathML left-hand spacing
- * @param{number} rspace            The operator's MathML right-hand spacing
- * @param{number} texClass          The default TeX class for the operator
- * @param{PropertyList} properties  Any default properties from the operator dictionary
- * @return{OperatorDef}             The operator definition array
+ * @param {number} lspace            The operator's MathML left-hand spacing
+ * @param {number} rspace            The operator's MathML right-hand spacing
+ * @param {number} texClass          The default TeX class for the operator
+ * @param {PropertyList} properties  Any default properties from the operator dictionary
+ * @return {OperatorDef}             The operator definition array
  */
 export function OPDEF(lspace: number, rspace: number, texClass: number = TEXCLASS.BIN,
                       properties: PropertyList = null): OperatorDef {

--- a/mathjax3-ts/core/MmlTree/OperatorDictionary.ts
+++ b/mathjax3-ts/core/MmlTree/OperatorDictionary.ts
@@ -24,18 +24,26 @@
 import {PropertyList} from '../Tree/Node.js';
 import {TEXCLASS} from './MmlNode.js';
 
-/*
+/**
  * Types needed for the operator dictionary
  */
 export type OperatorDef = [number, number, number, PropertyList];
 export type OperatorList = {[name: string]: OperatorDef};
 export type RangeDef = [number, number, number, string];
 
-export function OPDEF(lspace: number, rspace: number, texClass: number = TEXCLASS.BIN, properties: PropertyList = null): OperatorDef {
+/**
+ * @param{number} lspace            The operator's MathML left-hand spacing
+ * @param{number} rspace            The operator's MathML right-hand spacing
+ * @param{number} texClass          The default TeX class for the operator
+ * @param{PropertyList} properties  Any default properties from the operator dictionary
+ * @return{OperatorDef}             The operator definition array
+ */
+export function OPDEF(lspace: number, rspace: number, texClass: number = TEXCLASS.BIN,
+                      properties: PropertyList = null): OperatorDef {
     return [lspace, rspace, texClass, properties] as OperatorDef;
 }
 
-/*
+/**
  *  The various kinds of operators in the dictionary
  */
 export const MO = {
@@ -68,7 +76,7 @@ export const MO = {
     WIDEACCENT: OPDEF(0, 0, TEXCLASS.ORD, {accent: true, stretchy: true})
 };
 
-/*
+/**
  *  The default TeX classes for the various unicode blocks, and their names
  */
 export const RANGES: RangeDef[] = [
@@ -102,7 +110,7 @@ export const RANGES: RangeDef[] = [
     [0x1D400, 0x1D7FF, TEXCLASS.ORD, 'MathAlphabets']
 ];
 
-/*
+/**
  * The default MathML spacing for the various TeX classes.
  */
 export const MMLSPACING = [
@@ -115,7 +123,7 @@ export const MMLSPACING = [
     [0, 3]   // PUNCT
 ];
 
-/*
+/**
  *  The operator dictionary, with sections for the three forms:  prefix, postfix, and infix
  */
 export const OPTABLE: {[form: string]: OperatorList} = {

--- a/mathjax3-ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -27,13 +27,13 @@ import {MmlFactory} from './MmlFactory.js';
 import {MmlNode, TextNode, XMLNode, TEXCLASSNAMES} from './MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the SerializedMmlVisitor (subclass of MmlVisitor)
  */
 
 export class SerializedMmlVisitor extends MmlVisitor {
 
-    /*
+    /**
      * Convert the tree rooted at a particular node into a serialized MathML string
      *
      * @param {MmlNode} node  The node to use as the root of the tree to traverse
@@ -43,7 +43,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         return this.visitNode(node, '');
     }
 
-    /*
+    /**
      * @param {TextNode} node  The text node to visit
      * @param {string} space  The amount of indenting for this node
      * @return {string}  The text of the node
@@ -52,7 +52,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         return node.getText();
     }
 
-    /*
+    /**
      * @param {XMLNode} node  The XML node to visit
      * @param {string} space  The amount of indenting for this node
      * @return {string}  The serialization of the XML node (not implemented yet).
@@ -61,7 +61,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         return '[XML Node not implemented]';
     }
 
-    /*
+    /**
      * Visit an inferred mrow, but don't add the inferred row itself (since
      * it is supposed to be inferred).
      *
@@ -98,7 +98,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
       return mml;
     }
 
-    /*
+    /**
      * The generic visiting function:
      *   Make the string versino of the open tag, properly indented, with it attributes
      *   Increate the indentation level
@@ -120,7 +120,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         return mml;
     }
 
-    /*
+    /**
      * @param {MmlNode} node  The node whose attributes are to be produced
      * @return {string}  The attribute list as a string
      */
@@ -133,7 +133,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         return ATTR;
     }
 
-    /*
+    /**
      *  Convert HTML special characters to entities (&amp;, &lt;, &gt;, &quot;)
      *  Convert multi-character Unicode characters to entities
      *  Convert non-ASCII characters to entities.

--- a/mathjax3-ts/core/MmlTree/TestMmlVisitor.ts
+++ b/mathjax3-ts/core/MmlTree/TestMmlVisitor.ts
@@ -29,13 +29,13 @@ import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
 import {PropertyList} from '../Tree/Node.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the TestMmlVisitor (subclass of SerializedMmlVisitor)
  */
 
 export class TestMmlVisitor extends SerializedMmlVisitor {
 
-    /*
+    /**
      * The generic visiting function:
      *   Make the string versino of the open tag with it attributes (explicit and
      *     inherited) and properties
@@ -65,7 +65,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
         return mml;
     }
 
-    /*
+    /**
      * @param {MmlNode} node  The node whose attributes are to be produced
      * @return {string}  The attribute list as a string
      */
@@ -73,7 +73,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
         return this.attributeString(node.attributes.getAllAttributes(), '', '');
     }
 
-    /*
+    /**
      * @param {MmlNode} node  The node whose inherited attributes are to be produced
      * @return {string}  The inhertited attribute list as a string (with each in [...])
      */
@@ -81,7 +81,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
         return this.attributeString(node.attributes.getAllInherited(), '[', ']');
     }
 
-    /*
+    /**
      * @param {MmlNode} node  The node whose properties are to be produced
      * @return {string}  The property list as a string (with each in [[...]])
      */
@@ -89,7 +89,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
         return this.attributeString(node.getAllProperties(), '[[', ']]');
     }
 
-    /*
+    /**
      * @param {PropertyList} attributes  The attributes to be made into a list
      * @param {string} open  The opening delimiter to add before each attribute
      * @param {string} close  The closing delimiter to add after each attribute

--- a/mathjax3-ts/core/OutputJax.ts
+++ b/mathjax3-ts/core/OutputJax.ts
@@ -57,39 +57,39 @@ export interface OutputJax<N, T, D> {
     adaptor: DOMAdaptor<N, T, D>;
 
     /**
-     * @param{DOMAdaptor}  The adaptor to use in this jax
+     * @param {DOMAdaptor}  The adaptor to use in this jax
      */
     setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 
     /**
      * Typset a given MathItem
      *
-     * @param{MathItem} math          The MathItem to be typeset
-     * @param{MathDocument} document  The MathDocument in which the typesetting should occur
-     * @return{N}                     The DOM tree for the typeset math
+     * @param {MathItem} math          The MathItem to be typeset
+     * @param {MathDocument} document  The MathDocument in which the typesetting should occur
+     * @return {N}                     The DOM tree for the typeset math
      */
     typeset(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
     /**
      * Handle an escaped character (e.g., \$ from the TeX input jax preventing it from being a delimiter)
      *
-     * @param{MathItem} math          The MathItem to be escaped
-     * @param{MathDocument} document  The MathDocument in which the math occurs
-     * @return{N}                     The DOM tree for the escaped item
+     * @param {MathItem} math          The MathItem to be escaped
+     * @param {MathDocument} document  The MathDocument in which the math occurs
+     * @return {N}                     The DOM tree for the escaped item
      */
     escaped(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
     /**
      * Get the metric information for all math in the given document
      *
-     * @param{MathDocument} document  The MathDocument being processed
+     * @param {MathDocument} document  The MathDocument being processed
      */
     getMetrics(document: MathDocument<N, T, D>): void;
 
     /**
      * Produce the stylesheet needed for this output jax
      *
-     * @param{MathDocument} document  The MathDocument being processed
+     * @param {MathDocument} document  The MathDocument being processed
      */
     styleSheet(document: MathDocument<N, T, D>): N;
 }
@@ -113,7 +113,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
     public adaptor: DOMAdaptor<N, T, D> = null;  // set by the handler
 
     /**
-     * @param{OptionList} options  The options for this instance
+     * @param {OptionList} options  The options for this instance
      */
     constructor(options: OptionList = {}) {
         let CLASS = this.constructor as typeof AbstractOutputJax;
@@ -122,7 +122,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
     }
 
     /**
-     * @return{string}  The name for this output jax class
+     * @return {string}  The name for this output jax class
      */
     public get name() {
         return (this.constructor as typeof AbstractOutputJax).NAME;
@@ -162,10 +162,10 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *
-     * @param{FunctionList} filters  The list of functions to be performed
-     * @param{MathItem} math         The math item that is being processed
-     * @param{any} data              Whatever other data is needed
-     * @return{any}                  The (possibly modified) data
+     * @param {FunctionList} filters  The list of functions to be performed
+     * @param {MathItem} math         The math item that is being processed
+     * @param {any} data              Whatever other data is needed
+     * @return {any}                  The (possibly modified) data
      */
     protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>, data: any) {
         let args = {math: math, data: data};

--- a/mathjax3-ts/core/OutputJax.ts
+++ b/mathjax3-ts/core/OutputJax.ts
@@ -28,42 +28,40 @@ import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {FunctionList} from '../util/FunctionList.js';
 
 /*****************************************************************/
-/*
+/**
  *  The OutputJax interface
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export interface OutputJax<N, T, D> {
-    /*
+    /**
      * The name of this output jax class
      */
     name: string;
 
-    /*
+    /**
      * The options for the instance
      */
     options: OptionList;
 
-    /*
+    /**
      * Lists of post-filters to call after typesetting the math
      */
     postFilters: FunctionList;
 
-    /*
+    /**
      * The DOM adaptor for managing HTML elements
      */
     adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * @param{DOMAdaptor}  The adaptor to use in this jax
      */
     setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 
-    /*
+    /**
      * Typset a given MathItem
      *
      * @param{MathItem} math          The MathItem to be typeset
@@ -72,7 +70,7 @@ export interface OutputJax<N, T, D> {
      */
     typeset(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
-    /*
+    /**
      * Handle an escaped character (e.g., \$ from the TeX input jax preventing it from being a delimiter)
      *
      * @param{MathItem} math          The MathItem to be escaped
@@ -81,14 +79,14 @@ export interface OutputJax<N, T, D> {
      */
     escaped(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
-    /*
+    /**
      * Get the metric information for all math in the given document
      *
      * @param{MathDocument} document  The MathDocument being processed
      */
     getMetrics(document: MathDocument<N, T, D>): void;
 
-    /*
+    /**
      * Produce the stylesheet needed for this output jax
      *
      * @param{MathDocument} document  The MathDocument being processed
@@ -98,11 +96,9 @@ export interface OutputJax<N, T, D> {
 
 
 /*****************************************************************/
-/*
+/**
  *  The OutputJax abstract class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -116,7 +112,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
     public postFilters: FunctionList;
     public adaptor: DOMAdaptor<N, T, D> = null;  // set by the handler
 
-    /*
+    /**
      * @param{OptionList} options  The options for this instance
      */
     constructor(options: OptionList = {}) {
@@ -125,44 +121,44 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
         this.postFilters = new FunctionList();
     }
 
-    /*
+    /**
      * @return{string}  The name for this output jax class
      */
     public get name() {
         return (this.constructor as typeof AbstractOutputJax).NAME;
     }
 
-    /*
+    /**
      * @override
      */
     public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
         this.adaptor = adaptor;
     }
 
-    /*
+    /**
      * @override
      */
     public abstract typeset(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
-    /*
+    /**
      * @override
      */
     public abstract escaped(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
 
-    /*
+    /**
      * @override
      */
     public getMetrics(document: MathDocument<N, T, D>) {
     }
 
-    /*
+    /**
      * @override
      */
     public styleSheet(document: MathDocument<N, T, D>) {
         return null as N;
     }
 
-    /*
+    /**
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -35,9 +35,9 @@ export interface FactoryNode {
  */
 export interface FactoryNodeClass<N extends FactoryNode> {
     /**
-     * @param{Factory<N, FactoryNodeClass<N>>} factory  The factory for creating more nodes
-     * @param{any[]} args  Any additional arguments needed by the node
-     * @return{N}  The newly created node
+     * @param {Factory<N, FactoryNodeClass<N>>} factory  The factory for creating more nodes
+     * @param {any[]} args  Any additional arguments needed by the node
+     * @return {N}  The newly created node
      */
     new(factory: Factory<N, FactoryNodeClass<N>>, ...args: any[]): N;
 }

--- a/mathjax3-ts/core/Tree/Factory.ts
+++ b/mathjax3-ts/core/Tree/Factory.ts
@@ -22,7 +22,7 @@
  */
 
 /*****************************************************************/
-/*
+/**
  * The Factory node interfaces (one for the node instance, one for the node class)
  */
 
@@ -30,11 +30,11 @@ export interface FactoryNode {
     readonly kind: string;
 }
 
-/*
+/**
  * @template N  The Node type being created by the factory
  */
 export interface FactoryNodeClass<N extends FactoryNode> {
-    /*
+    /**
      * @param{Factory<N, FactoryNodeClass<N>>} factory  The factory for creating more nodes
      * @param{any[]} args  Any additional arguments needed by the node
      * @return{N}  The newly created node
@@ -43,7 +43,7 @@ export interface FactoryNodeClass<N extends FactoryNode> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The Factory interface
  *
  * Factory<N, C> takes a node type N and a node class C, which give
@@ -52,20 +52,18 @@ export interface FactoryNodeClass<N extends FactoryNode> {
  * since N is a type not an object, and if N has static members, we
  * may want to access them from the results of getNodeClass(kind)
  * (this is done in MmlNodes, for example).
- */
-
-/*
+ *
  * @template N  The node type created by the factory
  * @template C  The class of the node being constructed (for access to static properties)
  */
 export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
-    /*
+    /**
      * @param {string} kind  The kind of node to create
      * @return {N}  The newly created node of the given kind
      */
     create(kind: string): N;
 
-    /*
+    /**
      * Defines a class for a given node kind
      *
      * @param {string} kind  The kind whose class is being defined
@@ -73,25 +71,25 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
      */
     setNodeClass(kind: string, nodeClass: C): void;
 
-    /*
+    /**
      * @param {string} kind  The kind of node whose class is to be returned
      * @return {C}  The class object for the given kind
      */
     getNodeClass(kind: string): C;
 
-    /*
+    /**
      * @param {string} kind  The kind whose definition is to be deleted
      */
     deleteNodeClass(kind: string): void;
 
-    /*
+    /**
      * @param {N} node  The node to test if it is of a given kind
      * @param {string} kind  The kind to test for
      * @return {boolean}  True if the node is of the given kind, false otherwise
      */
     nodeIsKind(node: N, kind: string): boolean;
 
-    /*
+    /**
      * @return {string[]}  The names of all the available kinds of nodes
      */
     getKinds(): string[];
@@ -99,12 +97,10 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
 
 
 /*****************************************************************/
-/*
+/**
  * The generic AbstractFactoryClass interface
  *   (needed for access to defaultNodes via the constructor)
- */
-
-/*
+ *
  * @template N  The node type created by the factory
  * @template C  The class of the node being constructed (for access to static properties)
  */
@@ -114,37 +110,35 @@ interface AbstractFactoryClass<N extends FactoryNode, C extends FactoryNodeClass
 
 
 /*****************************************************************/
-/*
+/**
  * The generic AbstractFactory class
- */
-
-/*
+ *
  * @template N  The node type created by the factory
  * @template C  The class of the node being constructed (for access to static properties)
  */
 export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNodeClass<N>> implements Factory<N, C> {
 
-    /*
+    /**
      * The default collection of objects to use for the node map
      */
     public static defaultNodes = {};
 
-    /*
+    /**
      * The default kind
      */
     public defaultKind = 'unknown';
 
-    /*
+    /**
      * The map of node kinds to node classes
      */
     protected nodeMap: Map<string, C> = new Map();
 
-    /*
+    /**
      * An object containing functions for creating the various node kinds
      */
     protected node: {[kind: string]: (...args: any[]) => N} = {};
 
-    /*
+    /**
      * @override
      */
     constructor(nodes: {[kind: string]: C} = null) {
@@ -156,14 +150,14 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
         }
     }
 
-    /*
+    /**
      * @override
      */
     public create(kind: string, ...args: any[]) {
         return (this.node[kind] || this.node[this.defaultKind])(...args);
     }
 
-    /*
+    /**
      * @override
      */
     public setNodeClass(kind: string, nodeClass: C) {
@@ -174,14 +168,14 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
             return new KIND(THIS, ...args);
         };
     }
-    /*
+    /**
      * @override
      */
     public getNodeClass(kind: string): C {
         return this.nodeMap.get(kind);
     }
 
-    /*
+    /**
      * @override
      */
     public deleteNodeClass(kind: string) {
@@ -189,14 +183,14 @@ export abstract class AbstractFactory<N extends FactoryNode, C extends FactoryNo
         delete this.node[kind];
     }
 
-    /*
+    /**
      * @override
      */
     public nodeIsKind(node: N, kind: string) {
         return (node instanceof this.getNodeClass(kind));
     }
 
-    /*
+    /**
      * @override
      */
     public getKinds() {

--- a/mathjax3-ts/core/Tree/Node.ts
+++ b/mathjax3-ts/core/Tree/Node.ts
@@ -23,7 +23,7 @@
 
 import {NodeFactory} from './NodeFactory.js';
 
-/*
+/**
  *  PropertyList and Property are for string data like
  *  attributes and other properties
  */
@@ -31,7 +31,7 @@ export type Property = string | number | boolean;
 export type PropertyList = {[key: string]: Property};
 
 /*********************************************************/
-/*
+/**
  *  The generic Node interface
  */
 
@@ -40,71 +40,71 @@ export interface Node {
     parent: Node;
     childNodes: Node[];
 
-    /*
+    /**
      * @param {string} name     The name of the property to set
      * @param {Property} value  The value to which the property will be set
      */
     setProperty(name: string, value: Property): void;
 
-    /*
+    /**
      * @param {string} name  The name of the property to get
      * @return {Property}   The value of the named property
      */
     getProperty(name: string): Property;
 
-    /*
+    /**
      * @return {string[]}  An array of the names of every property currently defined
      */
     getPropertyNames(): string[];
 
-    /*
+    /**
      * @return {PropertyList}  The propery list containing all the properties of the node
      */
     getAllProperties(): PropertyList;
 
-    /*
+    /**
      * @param {string[]} names  The names of the properties to be removed
      */
     removeProperty(...names: string[]): void;
 
 
-    /*
+    /**
      * @param {string} kind  The type of node to test for
      * @return {boolean}     True when the node is of the given type
      */
     isKind(kind: string): boolean;
 
-    /*
+    /**
      * @param {Node[]} children  The child nodes to add to this node
      */
     setChildren(children: Node[]): void;
 
-    /*
+    /**
      * @param {Node} child  A node to add to this node's children
      * @return {Node}       The child node that was added
      */
     appendChild(child: Node): Node;
 
-    /*
+    /**
      * @param {Node} newChild  A child node to be inserted
      * @param {Node} oldChild  A child node to be replaced
      * @return {Node}          The old child node that was removed
      */
     replaceChild(newChild: Node, oldChild: Node): Node;
 
-    /*
+    /**
      * @param {Node} child  A child node whose index in childNodes is desired
      * @return {number}     The index of the child in childNodes, or null if not found
      */
     childIndex(child: Node): number;
 
-    /*
+    /**
      * @param {string} kind  The kind of nodes to be located in the tree
      * @return {Node[]}      An array of nodes that are children (at any depth) of the given kind
      */
     findNodes(kind: string): Node[];
 
-    /*
+    /**
      * @param {Function} func  A function to apply to each node in the tree rooted at this node
      * @param {any} data       Data to pass to the function (as state information)
      */
@@ -112,12 +112,12 @@ export interface Node {
 }
 
 /*********************************************************/
-/*
+/**
  *  The generic Node class interface
  */
 
 export interface NodeClass {
-    /*
+    /**
      * @param {NodeFactory} factory  The NodeFactory to use to create new nodes when needed
      * @param {PropertyList} properties  Any properties to be added to the node, if any
      * @param {Node[]} children  The initial child nodes, if any
@@ -127,33 +127,33 @@ export interface NodeClass {
 }
 
 /*********************************************************/
-/*
+/**
  *  The abstract Node class
  */
 
 export abstract class AbstractNode implements Node {
 
-    /*
+    /**
      * The parent node for this one
      */
     public parent: Node = null;
 
-    /*
+    /**
      * The properties for this node
      */
     protected properties: PropertyList = {};
 
-    /*
+    /**
      * The NodeFactory to use to create additional nodes, as needed
      */
     protected _factory: NodeFactory<Node, NodeClass> = null;
 
-    /*
+    /**
      * The children for this node
      */
     public childNodes: Node[] = [];
 
-    /*
+    /**
      * @param {NodeFactory} factory  The NodeFactory to use to create new nodes when needed
      * @param {PropertyList} properties  Any properties to be added to the node, if any
      * @param {Node[]} children  The initial child nodes, if any
@@ -172,49 +172,49 @@ export abstract class AbstractNode implements Node {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public get factory () {
         return this._factory;
     }
 
-    /*
+    /**
      * @override
      */
     public get kind() {
         return 'unknown';
     }
 
-    /*
+    /**
      * @override
      */
     public setProperty(name: string, value: Property) {
         this.properties[name] = value;
     }
 
-    /*
+    /**
      * @override
      */
     public getProperty(name: string) {
         return this.properties[name];
     }
 
-    /*
+    /**
      * @override
      */
     public getPropertyNames() {
         return Object.keys(this.properties);
     }
 
-    /*
+    /**
      * @override
      */
     public getAllProperties() {
         return this.properties;
     }
 
-    /*
+    /**
      * @override
      */
     public removeProperty(...names: string[]) {
@@ -224,7 +224,7 @@ export abstract class AbstractNode implements Node {
     }
 
 
-    /*
+    /**
      * @override
      */
     public isKind(kind: string): boolean {
@@ -232,7 +232,7 @@ export abstract class AbstractNode implements Node {
     }
 
 
-    /*
+    /**
      * @override
      */
     public setChildren(children: Node[]) {
@@ -242,7 +242,7 @@ export abstract class AbstractNode implements Node {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public appendChild(child: Node) {
@@ -251,7 +251,7 @@ export abstract class AbstractNode implements Node {
         return child;
     }
 
-    /*
+    /**
      * @override
      */
     public replaceChild(newChild: Node, oldChild: Node) {
@@ -265,7 +265,7 @@ export abstract class AbstractNode implements Node {
     }
 
 
-    /*
+    /**
      * @override
      */
     public childIndex(node: Node) {
@@ -274,7 +274,7 @@ export abstract class AbstractNode implements Node {
     }
 
 
-    /*
+    /**
      * @override
      */
     public findNodes(kind: string) {
@@ -288,7 +288,7 @@ export abstract class AbstractNode implements Node {
     }
 
 
-    /*
+    /**
      * @override
      */
     public walkTree(func: (node: Node, data?: any) => void, data?: any) {
@@ -299,7 +299,7 @@ export abstract class AbstractNode implements Node {
         return data;
     }
 
-    /*
+    /**
      * Simple string version for debugging, just to get the structure.
      */
     public toString() {
@@ -309,43 +309,43 @@ export abstract class AbstractNode implements Node {
 }
 
 /*********************************************************/
-/*
+/**
  *  The abstract EmptyNode class
  */
 
 export abstract class AbstractEmptyNode extends AbstractNode {
-    /*
+    /**
      *  We don't have children, so ignore these methods
      */
 
-    /*
+    /**
      * @override
      */
     public setChildren(children: Node[]) {
     }
 
-    /*
+    /**
      * @override
      */
     public appendChild(child: Node) {
         return child;
     }
 
-    /*
+    /**
      * @override
      */
     public replaceChild(newChild: Node, oldChild: Node) {
         return oldChild;
     }
 
-    /*
+    /**
      * @override
      */
     public childIndex(node: Node) {
         return null as number;
     }
 
-    /*
+    /**
      * Don't step into children (there aren't any)
      *
      * @override
@@ -355,7 +355,7 @@ export abstract class AbstractEmptyNode extends AbstractNode {
         return data;
     }
 
-    /*
+    /**
      * Simple string version for debugging, just to get the structure.
      */
     public toString() {

--- a/mathjax3-ts/core/Tree/NodeFactory.ts
+++ b/mathjax3-ts/core/Tree/NodeFactory.ts
@@ -25,16 +25,14 @@ import {Node, NodeClass, PropertyList} from './Node.js';
 import {Factory, FactoryNodeClass, AbstractFactory} from './Factory.js';
 
 /*****************************************************************/
-/*
+/**
  * The NodeFactory interface
- */
-
-/*
+ *
  * @template N  The node type created by the factory
  * @template C  The class of the node being constructed (for access to static properties)
  */
 export interface NodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends Factory<N, C> {
-    /*
+    /**
      * @param {string} kind  The kind of node to create
      * @param {PropertyList} properties  The list of initial properties for the node (if any)
      * @param {N[]} children  The array of initial child nodes (if any)
@@ -44,16 +42,14 @@ export interface NodeFactory<N extends Node, C extends FactoryNodeClass<N>> exte
 }
 
 /*****************************************************************/
-/*
+/**
  * The generic NodeFactory class
- */
-
-/*
+ *
  * @template N  The node type created by the factory
  * @template C  The class of the node being constructed (for access to static properties)
  */
 export abstract class AbstractNodeFactory<N extends Node, C extends FactoryNodeClass<N>> extends AbstractFactory<N, C> {
-    /*
+    /**
      * @override
      */
     public create(kind: string, properties: PropertyList = {}, children: N[] = []) {

--- a/mathjax3-ts/core/Tree/Visitor.ts
+++ b/mathjax3-ts/core/Tree/Visitor.ts
@@ -24,19 +24,19 @@
 import {Node, NodeClass, AbstractNode} from './Node.js';
 import {NodeFactory} from './NodeFactory.js';
 
-/*
+/**
  * The type for the functions associated with each node class
  */
 export type VisitorFunction = (visitor: NodeFactory<Node, NodeClass>, node: Node, ...args: any[]) => any;
 
 /*****************************************************************/
-/*
+/**
  *  Implements the Visitor interface
  */
 
 export interface Visitor {
 
-    /*
+    /**
      * Visit the tree rooted at the given node (passing along any needed parameters)
      *
      * @param {Node} tree   The node that is the root of the tree
@@ -45,7 +45,7 @@ export interface Visitor {
      */
     visitTree(tree: Node, ...args: any[]): any;
 
-    /*
+    /**
      * Visit a node by calling the visitor function for the givn type of node
      *  (passing along any needed parameters)
      *
@@ -55,7 +55,7 @@ export interface Visitor {
      */
     visitNode(node: Node, ...args: any[]): any;
 
-    /*
+    /**
      * The default visitor function for when no node-specific function is defined
      *
      * @param {Node} node   The node to visit
@@ -64,7 +64,7 @@ export interface Visitor {
      */
     visitDefault(node: Node, ...args: any[]): any;
 
-    /*
+    /**
      * Define a visitor function for a given node kind
      *
      * @param {string} kind  The node kind for which the handler is being defined
@@ -72,31 +72,31 @@ export interface Visitor {
      */
     setNodeHandler(kind: string, handler: VisitorFunction): void;
 
-    /*
+    /**
      * Remove the visitor function for a given node kind
      *
      * @param {string} kind  The node kind whose visitor function is to be removed
      */
     removeNodeHandler(kind: string): void;
 
-    /*
+    /**
      * The various visitor functions implemented by the subclasses, and any data they need
      */
     [property: string]: any;
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the generic Visitor object
  */
 
 export abstract class AbstractVisitor implements Visitor {
-    /*
+    /**
      * Holds the mapping from node kinds to visitor funcitons
      */
     protected nodeHandlers: Map<string, VisitorFunction> = new Map();
 
-    /*
+    /**
      *  Visitor functions are named "visitKindNode" where "Kind" is replaced by
      *    the node kind; e.g., visitTextNode for kind = text.
      *
@@ -107,7 +107,7 @@ export abstract class AbstractVisitor implements Visitor {
         return 'visit' + kind.charAt(0).toUpperCase() + kind.substr(1) + 'Node';
     }
 
-    /*
+    /**
      * Create the node handler map by looking for methods with the correct names
      *   based on the node kinds available from the factory.
      *
@@ -123,14 +123,14 @@ export abstract class AbstractVisitor implements Visitor {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public visitTree(tree: Node, ...args: any[]) {
         return this.visitNode(tree, ...args);
     }
 
-    /*
+    /**
      * @override
      */
     public visitNode(node: Node, ...args: any[]) {
@@ -138,7 +138,7 @@ export abstract class AbstractVisitor implements Visitor {
         return handler.call(this, node, ...args);
     }
 
-    /*
+    /**
      * @override
      */
     public visitDefault(node: Node, ...args: any[]) {
@@ -149,14 +149,14 @@ export abstract class AbstractVisitor implements Visitor {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public setNodeHandler(kind: string, handler: VisitorFunction) {
         this.nodeHandlers.set(kind, handler);
     }
 
-    /*
+    /**
      * @override
      */
     public removeNodeHandler(kind: string) {

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -25,13 +25,11 @@ import {Node} from './Node.js';
 import {WrapperFactory} from './WrapperFactory.js';
 
 /*********************************************************/
-/*
+/**
  *  The Wrapper interface
  *
  *  It points to a Node object.  Subclasses add methods for the visitor to call.
- */
-
-/*
+ *
  * @template N  The Node type being wrapped
  * @template W  The Wrapper type being produced
  */
@@ -39,7 +37,7 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
     node: N;
     readonly kind: string;
 
-    /*
+    /**
      * @param {Node} node  A node to be wrapped
      * @param{any[]} args  Any additional arguments needed when creating the wrapper
      * @return {Wrapper}   The wrapped node
@@ -48,16 +46,14 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
 }
 
 /*********************************************************/
-/*
+/**
  *  The Wrapper class interface
- */
-
-/*
+ *
  * @template N  The Node type being wrapped
  * @template W  The Wrapper type being produced
  */
 export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
-    /*
+    /**
      * @param{WrapperFactory} factory  The factory used to create more wrappers
      * @param{N} node  The node to be wrapped
      * @param{any[]} args  Any additional arguments needed when creating the wrapper
@@ -67,33 +63,31 @@ export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
 }
 
 /*********************************************************/
-/*
+/**
  *  The abstract Wrapper class
- */
-
-/*
+ *
  * @template N  The Node type being created by the factory
  * @template W  The Wrapper type being produced
  */
 export class AbstractWrapper<N extends Node, W extends Wrapper<N, W>> implements Wrapper<N, W> {
-    /*
+    /**
      * The Node object associated with this instance
      */
     public node: N;
 
-    /*
+    /**
      * The WrapperFactory to use to wrap child nodes, as needed
      */
     protected factory: WrapperFactory<N, W, WrapperClass<N, W>>;
 
-    /*
+    /**
      * The kind of this wrapper
      */
     get kind() {
         return this.node.kind;
     }
 
-    /*
+    /**
      * @param {WrapperFactory} factory  The WrapperFactory to use to wrap child nodes when needed
      * @param {Node} node               The node to wrap
      * @return {Wrapper}                The newly created wrapped node
@@ -106,7 +100,7 @@ export class AbstractWrapper<N extends Node, W extends Wrapper<N, W>> implements
         this.node = node;
     }
 
-    /*
+    /**
      * @override
      */
     public wrap(node: N) {

--- a/mathjax3-ts/core/Tree/Wrapper.ts
+++ b/mathjax3-ts/core/Tree/Wrapper.ts
@@ -39,7 +39,7 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
 
     /**
      * @param {Node} node  A node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when creating the wrapper
+     * @param {any[]} args  Any additional arguments needed when creating the wrapper
      * @return {Wrapper}   The wrapped node
      */
     wrap(node: N, ...args: any[]): W;
@@ -54,10 +54,10 @@ export interface Wrapper<N extends Node, W extends Wrapper<N, W>> {
  */
 export interface WrapperClass<N extends Node, W extends Wrapper<N, W>> {
     /**
-     * @param{WrapperFactory} factory  The factory used to create more wrappers
-     * @param{N} node  The node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when creating the wrapper
-     * @return{W}  The wrapped node
+     * @param {WrapperFactory} factory  The factory used to create more wrappers
+     * @param {N} node  The node to be wrapped
+     * @param {any[]} args  Any additional arguments needed when creating the wrapper
+     * @return {W}  The wrapped node
      */
     new(factory: WrapperFactory<N, W, WrapperClass<N, W>>, node: N, ...args: any[]): W;
 }

--- a/mathjax3-ts/core/Tree/WrapperFactory.ts
+++ b/mathjax3-ts/core/Tree/WrapperFactory.ts
@@ -26,18 +26,16 @@ import {Wrapper, WrapperClass} from './Wrapper.js';
 import {Factory, AbstractFactory} from './Factory.js';
 
 /*****************************************************************/
-/*
+/**
  * The generic WrapperFactory class
- */
-
-/*
+ *
  * @template N  The Node type being created by the factory
  * @template W  The Wrapper type being produced (instance type)
  * @template C  The Wrapper class (for static values)
  */
 export interface WrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends Factory<W, C> {
-    /*
+    /**
      * @param{N} node  The node to be wrapped
      * @param{any[]} args  Any additional arguments needed when wrapping the node
      * @return{W}  The newly wrapped node
@@ -46,18 +44,16 @@ extends Factory<W, C> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The generic WrapperFactory class
- */
-
-/*
+ *
  * @template N  The Node type being created by the factory
  * @template W  The Wrapper type being produced (instance type)
  * @template C  The Wrapper class (for static values)
  */
 export abstract class AbstractWrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends AbstractFactory<W, C> implements WrapperFactory<N, W, C> {
-    /*
+    /**
      * @param{N} node  The node to be wrapped
      * @param{any[]} args  Any additional arguments needed when wrapping the node
      * @return{W}  The newly wrapped node

--- a/mathjax3-ts/core/Tree/WrapperFactory.ts
+++ b/mathjax3-ts/core/Tree/WrapperFactory.ts
@@ -36,9 +36,9 @@ import {Factory, AbstractFactory} from './Factory.js';
 export interface WrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends Factory<W, C> {
     /**
-     * @param{N} node  The node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when wrapping the node
-     * @return{W}  The newly wrapped node
+     * @param {N} node  The node to be wrapped
+     * @param {any[]} args  Any additional arguments needed when wrapping the node
+     * @return {W}  The newly wrapped node
      */
     wrap(node: N, ...args: any[]): W;
 }
@@ -54,9 +54,9 @@ extends Factory<W, C> {
 export abstract class AbstractWrapperFactory<N extends Node, W extends Wrapper<N, W>, C extends WrapperClass<N, W>>
 extends AbstractFactory<W, C> implements WrapperFactory<N, W, C> {
     /**
-     * @param{N} node  The node to be wrapped
-     * @param{any[]} args  Any additional arguments needed when wrapping the node
-     * @return{W}  The newly wrapped node
+     * @param {N} node  The node to be wrapped
+     * @param {any[]} args  Any additional arguments needed when wrapping the node
+     * @return {W}  The newly wrapped node
      */
     public wrap(node: N, ...args: any[]) {
         return this.create(node.kind, node, ...args);

--- a/mathjax3-ts/handlers/html.ts
+++ b/mathjax3-ts/handlers/html.ts
@@ -25,7 +25,7 @@ import {MathJax} from '../mathjax.js';
 import {HTMLHandler} from './html/HTMLHandler.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 
-/*
+/**
  * Create the HTML handler object and register it with MathJax.
  *
  * @param{DOMAdaptor<N,T,D>} adaptor  The DOM adaptor to use with HTML

--- a/mathjax3-ts/handlers/html.ts
+++ b/mathjax3-ts/handlers/html.ts
@@ -28,7 +28,7 @@ import {DOMAdaptor} from '../core/DOMAdaptor.js';
 /**
  * Create the HTML handler object and register it with MathJax.
  *
- * @param{DOMAdaptor<N,T,D>} adaptor  The DOM adaptor to use with HTML
+ * @param {DOMAdaptor<N,T,D>} adaptor  The DOM adaptor to use with HTML
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class

--- a/mathjax3-ts/handlers/html/HTMLDocument.ts
+++ b/mathjax3-ts/handlers/html/HTMLDocument.ts
@@ -69,7 +69,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     /**
      * @override
      * @constructor
-     * @extends{AbstractMathDocument}
+     * @extends {AbstractMathDocument}
      */
     constructor(document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
         let [html, dom] = separateOptions(options, HTMLDomStrings.OPTIONS);
@@ -83,11 +83,11 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
      *  of the array of strings searched for math, recovering the original DOM node where the delimiter
      *  was found.
      *
-     * @param{number} N             The index of the string in the string array
-     * @param{number} index         The position within the N's string that needs to be found
-     * @param{string} delim         The delimiter for this position
-     * @param{HTMLNodeArray} nodes  The list of node lists representing the string array
-     * @return{Location}            The Location object for the position of the delimiter in the document
+     * @param {number} N             The index of the string in the string array
+     * @param {number} index         The position within the N's string that needs to be found
+     * @param {string} delim         The delimiter for this position
+     * @param {HTMLNodeArray} nodes  The list of node lists representing the string array
+     * @return {Location}            The Location object for the position of the delimiter in the document
      */
     protected findPosition(N: number, index: number, delim: string, nodes: HTMLNodeArray<N, T>): Location<N, T> {
         for (const list of nodes[N]) {
@@ -104,10 +104,10 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
      * Convert a ProtoItem to a MathItem (i.e., determine the actual Location
      *  objects for its start and end)
      *
-     * @param{ProtoItem} item       The proto math item to turn into an actual MathItem
-     * @param{InputJax} jax         The input jax to use for the MathItem
-     * @param{HTMLNodeArray} nodes  The array of node lists that produced the string array
-     * @return{HTMLMathItem}        The MathItem for the given proto item
+     * @param {ProtoItem} item       The proto math item to turn into an actual MathItem
+     * @param {InputJax} jax         The input jax to use for the MathItem
+     * @param {HTMLNodeArray} nodes  The array of node lists that produced the string array
+     * @return {HTMLMathItem}        The MathItem for the given proto item
      */
     protected mathItem(item: ProtoItem<N, T>, jax: InputJax<N, T, D>, nodes: HTMLNodeArray<N, T>) {
         let math = item.math;
@@ -184,9 +184,9 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     }
 
     /**
-     * @param{N} head     The document <head>
-     * @param{string} id  The id of the stylesheet to find
-     * @param{N|null}     The stylesheet with the given ID
+     * @param {N} head     The document <head>
+     * @param {string} id  The id of the stylesheet to find
+     * @param {N|null}     The stylesheet with the given ID
      */
     protected findSheet(head: N, id: string) {
         if (id) {

--- a/mathjax3-ts/handlers/html/HTMLDocument.ts
+++ b/mathjax3-ts/handlers/html/HTMLDocument.ts
@@ -31,7 +31,7 @@ import {InputJax} from '../../core/InputJax.js';
 import {MathItem, ProtoItem, Location} from '../../core/MathItem.js';
 
 /*****************************************************************/
-/*
+/**
  * List of Lists of pairs consisting of a DOM node and its text length
  *
  * These represent the Text elements that make up a single
@@ -44,7 +44,7 @@ import {MathItem, ProtoItem, Location} from '../../core/MathItem.js';
 export type HTMLNodeArray<N, T> = [N | T, number][][];
 
 /*****************************************************************/
-/*
+/**
  *  The HTMLDocument class (extends AbstractMathDocument)
  *
  * @template N  The HTMLElement node class
@@ -61,12 +61,12 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     };
     public static STATE = AbstractMathDocument.STATE;
 
-    /*
+    /**
      * The DomString parser for locating the text in DOM trees
      */
     public domStrings: HTMLDomStrings<N, T, D>;
 
-    /*
+    /**
      * @override
      * @constructor
      * @extends{AbstractMathDocument}
@@ -78,7 +78,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         this.domStrings.adaptor = adaptor;
     }
 
-    /*
+    /**
      * Creates a Location object for a delimiter at the position given by index in the N's string
      *  of the array of strings searched for math, recovering the original DOM node where the delimiter
      *  was found.
@@ -100,7 +100,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return {node: null, n: 0, delim: delim};
     }
 
-    /*
+    /**
      * Convert a ProtoItem to a MathItem (i.e., determine the actual Location
      *  objects for its start and end)
      *
@@ -116,7 +116,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return new HTMLMathItem(math, jax, item.display, start, end);
     }
 
-    /*
+    /**
      * Find math within the document:
      *  Get the list of containers (default is document.body), and for each:
      *    For each input jax:
@@ -162,7 +162,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public updateDocument() {
@@ -183,7 +183,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return this;
     }
 
-    /*
+    /**
      * @param{N} head     The document <head>
      * @param{string} id  The id of the stylesheet to find
      * @param{N|null}     The stylesheet with the given ID
@@ -199,7 +199,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return null as N;
     }
 
-    /*
+    /**
      * @override
      */
     public removeFromDocument(restore: boolean = false) {
@@ -214,14 +214,14 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         return this;
     }
 
-    /*
+    /**
      * @override
      */
     public documentStyleSheet() {
         return this.outputJax.styleSheet(this);
     }
 
-    /*
+    /**
      * Temporary function for testing purposes.  Will be removed
      */
     public TestMath(text: string, display: boolean = true) {

--- a/mathjax3-ts/handlers/html/HTMLDomStrings.ts
+++ b/mathjax3-ts/handlers/html/HTMLDomStrings.ts
@@ -109,7 +109,7 @@ export class HTMLDomStrings<N, T, D> {
     public adaptor: DOMAdaptor<N, T, D>;
 
     /**
-     * @param{OptionList} options  The user-supplied options
+     * @param {OptionList} options  The user-supplied options
      * @constructor
      */
     constructor(options: OptionList = null) {
@@ -158,8 +158,8 @@ export class HTMLDomStrings<N, T, D> {
      * Add more text to the current string, and record the
      * node and its position in the string.
      *
-     * @param{T} node        The node to be pushed
-     * @param{string} text   The text to be added (it may not be the actual text
+     * @param {T} node        The node to be pushed
+     * @param {string} text   The text to be added (it may not be the actual text
      *                         of the node, if it is one of the nodes that gets
      *                         translated to text, like <br> to a newline).
      */
@@ -171,9 +171,9 @@ export class HTMLDomStrings<N, T, D> {
     /**
      * Handle a #text node (add its text to the current string)
      *
-     * @param{T} node          The Text node to process
-     * @param{boolean} ignore  Whether we are currently ignoring content
-     * @return{N}              The next element to process
+     * @param {T} node          The Text node to process
+     * @param {boolean} ignore  Whether we are currently ignoring content
+     * @return {N}              The next element to process
      */
     protected handleText(node: T, ignore: boolean) {
         if (!ignore) {
@@ -185,9 +185,9 @@ export class HTMLDomStrings<N, T, D> {
     /**
      * Handle a BR, WBR, or #comment element (or others in the includeTag object).
      *
-     * @param{N} node          The node to process
-     * @param{boolean} ignore  Whether we are currently ignoring content
-     * @return{N}              The next element to process
+     * @param {N} node          The node to process
+     * @param {boolean} ignore  Whether we are currently ignoring content
+     * @return {N}              The next element to process
      */
     protected handleTag(node: N, ignore: boolean) {
         if (!ignore) {
@@ -209,9 +209,9 @@ export class HTMLDomStrings<N, T, D> {
      *     Move on to the next sibling
      *   Return the next node to process and the ignore state
      *
-     * @param{N} node               The node to process
-     * @param{boolean} ignore       Whether we are currently ignoring content
-     * @return{[N|T, boolean]}      The next element to process and whether to ignore its content
+     * @param {N} node               The node to process
+     * @param {boolean} ignore       Whether we are currently ignoring content
+     * @return {[N|T, boolean]}      The next element to process and whether to ignore its content
      */
     protected handleContainer(node: N, ignore: boolean) {
         this.pushString();
@@ -247,8 +247,8 @@ export class HTMLDomStrings<N, T, D> {
      *   Clear the internal values (so the memory can be freed)
      *   Return the strings and node lists
      *
-     * @param{N} node                       The node to search
-     * @return{[string[], HTMLNodeList[]]}  The array of strings and their associated lists of nodes
+     * @param {N} node                       The node to search
+     * @return {[string[], HTMLNodeList[]]}  The array of strings and their associated lists of nodes
      */
     public find(node: N | T) {
         this.init();

--- a/mathjax3-ts/handlers/html/HTMLDomStrings.ts
+++ b/mathjax3-ts/handlers/html/HTMLDomStrings.ts
@@ -24,7 +24,7 @@
 import {userOptions, defaultOptions, OptionList, makeArray} from '../../util/Options.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 
-/*
+/**
  *  List of consecutive text nodes and their text lengths
  *
  * @template N  The HTMLElement node class
@@ -33,13 +33,11 @@ import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 export type HTMLNodeList<N, T> = [N | T, number][];
 
 /*****************************************************************/
-/*
+/**
  *  The HTMLDocument class (extends AbstractMathDocument)
  *
  *  A class for extracting the text from DOM trees
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -66,38 +64,38 @@ export class HTMLDomStrings<N, T, D> {
                                           // so be sure to quote any regexp special characters
     };
 
-    /*
+    /**
      * The options for this instance
      */
     protected options: OptionList;
 
-    /*
+    /**
      * The array of strings found in the DOM
      */
     protected strings: string[];
 
-    /*
+    /**
      * The string currently being constructed
      */
     protected string: string;
 
-    /*
+    /**
      * The list of nodes and lengths for the string being constructed
      */
     protected snodes: HTMLNodeList<N, T>;
 
-    /*
+    /**
      * The list of node lists corresponding to the strings in this.strings
      */
     protected nodes: HTMLNodeList<N, T>[];
 
-    /*
+    /**
      * The container nodes that are currently being traversed, and whether their
      *  contents are being ignored or not
      */
     protected stack: [N | T, boolean][];
 
-    /*
+    /**
      * Regular expressions for the tags to be skipped, and which classes should start/stop
      *  processing of math
      */
@@ -105,12 +103,12 @@ export class HTMLDomStrings<N, T, D> {
     protected ignoreClass: RegExp;
     protected processClass: RegExp;
 
-    /*
+    /**
      * The DOM Adaptor to managing HTML elements
      */
     public adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * @param{OptionList} options  The user-supplied options
      * @constructor
      */
@@ -121,7 +119,7 @@ export class HTMLDomStrings<N, T, D> {
         this.getPatterns();
     }
 
-    /*
+    /**
      * Set the initial values of the main properties
      */
     protected init() {
@@ -132,7 +130,7 @@ export class HTMLDomStrings<N, T, D> {
         this.stack = [];
     }
 
-    /*
+    /**
      * Create the search patterns for skipTags, ignoreClass, and processClass
      */
     protected getPatterns() {
@@ -144,7 +142,7 @@ export class HTMLDomStrings<N, T, D> {
         this.processClass = new RegExp('(?:^| )(?:' + process + ')(?: |$)');
     }
 
-    /*
+    /**
      * Add a string to the string array and record its node list
      */
     protected pushString() {
@@ -156,7 +154,7 @@ export class HTMLDomStrings<N, T, D> {
         this.snodes = [];
     }
 
-    /*
+    /**
      * Add more text to the current string, and record the
      * node and its position in the string.
      *
@@ -170,7 +168,7 @@ export class HTMLDomStrings<N, T, D> {
         this.string += text;
     }
 
-    /*
+    /**
      * Handle a #text node (add its text to the current string)
      *
      * @param{T} node          The Text node to process
@@ -184,7 +182,7 @@ export class HTMLDomStrings<N, T, D> {
         return this.adaptor.next(node);
     }
 
-    /*
+    /**
      * Handle a BR, WBR, or #comment element (or others in the includeTag object).
      *
      * @param{N} node          The node to process
@@ -199,7 +197,7 @@ export class HTMLDomStrings<N, T, D> {
         return this.adaptor.next(node);
     }
 
-    /*
+    /**
      * Handle an arbitrary DOM node:
      *   Check the class to see if it matches the processClass regex
      *   If the node has a child and is not marked as created by MathJax (data-MJX)
@@ -234,7 +232,7 @@ export class HTMLDomStrings<N, T, D> {
         return [next, ignore] as [N | T, boolean];
     }
 
-    /*
+    /**
      * Find the strings for a given DOM element:
      *   Initialize the state
      *   Get the element where we stop processing

--- a/mathjax3-ts/handlers/html/HTMLHandler.ts
+++ b/mathjax3-ts/handlers/html/HTMLHandler.ts
@@ -27,11 +27,9 @@ import {HTMLDocument} from './HTMLDocument.js';
 import {OptionList} from '../../util/Options.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the HTMLHandler class (extends AbstractHandler)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -40,7 +38,7 @@ export class HTMLHandler<N, T, D> extends AbstractHandler<N, T, D> {
 
     adaptor: MinHTMLAdaptor<N, T, D>;
 
-    /*
+    /**
      * @override
      */
     public handlesDocument(document: any) {
@@ -57,7 +55,7 @@ export class HTMLHandler<N, T, D> extends AbstractHandler<N, T, D> {
         return false;
     }
 
-    /*
+    /**
      * If the document isn't already a Document object, create one
      * using the given data
      *

--- a/mathjax3-ts/handlers/html/HTMLMathItem.ts
+++ b/mathjax3-ts/handlers/html/HTMLMathItem.ts
@@ -27,11 +27,9 @@ import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 import {HTMLDocument} from './HTMLDocument.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the HTMLMathItem class (extends AbstractMathItem)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -40,14 +38,14 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
 
     public static STATE = AbstractMathItem.STATE;
 
-    /*
+    /**
      * Easy access to DOM adaptor
      */
     get adaptor() {
         return this.inputJax.adaptor;
     }
 
-    /*
+    /**
      * @override
      */
     constructor(math: string, jax: InputJax<N, T, D>, display: boolean = true,
@@ -56,7 +54,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
         super(math, jax, display, start, end);
     }
 
-    /*
+    /**
      * Insert the typeset MathItem into the document at the right location
      *   If the starting and ending nodes are the same:
      *     Split the text to isolate the math and its delimiters
@@ -106,7 +104,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Remove the typeset math from the document, and put back the original
      *  expression and its delimiters, if requested.
      *

--- a/mathjax3-ts/handlers/html/HTMLMathList.ts
+++ b/mathjax3-ts/handlers/html/HTMLMathList.ts
@@ -24,7 +24,7 @@
 import {AbstractMathList} from '../../core/MathList.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implement the HTMLMathList class (extends AbstractMathList)
  *
  * @template N  The HTMLElement node class

--- a/mathjax3-ts/input/asciimath.ts
+++ b/mathjax3-ts/input/asciimath.ts
@@ -29,11 +29,9 @@ import {MathItem} from '../core/MathItem.js';
 import {FindAsciiMath} from './asciimath/FindAsciiMath.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the AsciiMath class (extends AbstractInputJax)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -46,12 +44,12 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
         FindAsciiMath: null
     };
 
-    /*
+    /**
      * The FindMath object used to search for AsciiMath in the document
      */
     protected findAsciiMath: FindAsciiMath<N, T, D>;
 
-    /*
+    /**
      * @override
      */
     constructor(options: OptionList) {
@@ -60,7 +58,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
         this.findAsciiMath = this.options['FindAsciiMath'] || new FindAsciiMath(find);
     }
 
-    /*
+    /**
      * Use legacy AsciiMath input jax for now
      *
      * @override
@@ -69,7 +67,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
         return LegacyAsciiMath.Compile(math.math, math.display);
     }
 
-    /*
+    /**
      * @override
      */
     public findMath(strings: string[]) {

--- a/mathjax3-ts/input/asciimath/FindAsciiMath.ts
+++ b/mathjax3-ts/input/asciimath/FindAsciiMath.ts
@@ -87,9 +87,9 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Add the needed patterns for a pair of delimiters
      *
-     * @param{string[]} starts  Array of starting delimiter strings
-     * @param{Delims} delims    Array of delimiter strings, as [start, end]
-     * @param{boolean} display  True if the delimiters are for display mode
+     * @param {string[]} starts  Array of starting delimiter strings
+     * @param {Delims} delims    Array of delimiter strings, as [start, end]
+     * @param {boolean} display  True if the delimiters are for display mode
      */
     protected addPattern(starts: string[], delims: Delims, display: boolean) {
         let [open, close] = delims;
@@ -100,11 +100,11 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Search for the end delimiter given the start delimiter.
      *
-     * @param{string} text            The string being searched for the end delimiter
-     * @param{number} n               The index of the string being searched
-     * @param{RegExpExecArray} start  The result array from the start-delimiter search
-     * @param{EndItem} end            The end-delimiter data corresponding to the start delimiter
-     * @return{ProtoItem}             The proto math item for the math, if found
+     * @param {string} text            The string being searched for the end delimiter
+     * @param {number} n               The index of the string being searched
+     * @param {RegExpExecArray} start  The result array from the start-delimiter search
+     * @param {EndItem} end            The end-delimiter data corresponding to the start delimiter
+     * @return {ProtoItem}             The proto math item for the math, if found
      */
     protected findEnd(text: string, n: number, start: RegExpExecArray, end: EndItem) {
         let [close, display, pattern] = end;
@@ -117,9 +117,9 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Search a string for math delimited by one of the delimiter pairs.
      *
-     * @param{ProtoItem[]} math  The array of proto math items located so far
-     * @param{number} n          The index of the string being searched
-     * @param{string} text       The string being searched
+     * @param {ProtoItem[]} math  The array of proto math items located so far
+     * @param {number} n          The index of the string being searched
+     * @param {string} text       The string being searched
      */
     protected findMathInString(math: ProtoItem<N, T>[], n: number, text: string) {
         let start, match;

--- a/mathjax3-ts/input/asciimath/FindAsciiMath.ts
+++ b/mathjax3-ts/input/asciimath/FindAsciiMath.ts
@@ -26,20 +26,18 @@ import {OptionList} from '../../util/Options.js';
 import {sortLength, quotePattern} from '../../util/string.js';
 import {MathItem, ProtoItem, protoItem, Location} from '../../core/MathItem.js';
 
-/*
+/**
  * Shorthand types for data about end delimiters and delimiter pairs
  */
 export type EndItem = [string, boolean, RegExp];
 export type Delims = [string, string];
 
 /*****************************************************************/
-/*
+/**
  *  Implements the FindAsciiMath class (extends AbstractFindMath)
  *
  *  Locates AsciiMath expressions within strings
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -50,22 +48,22 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
         delimiters: [['`', '`']],   // The start/end delimiter pairs for asciimath code
     };
 
-    /*
+    /**
      * The regular expression for any starting delimiter
      */
     protected start: RegExp;
 
-    /*
+    /**
      * The end-delimiter data keyed to the opening delimiter string
      */
     protected end: {[name: string]: EndItem};
 
-    /*
+    /**
      * False if the configuration has no delimiters (so search can be skipped), true otherwise
      */
     protected hasPatterns: boolean;
 
-    /*
+    /**
      * @override
      */
     constructor(options: OptionList) {
@@ -73,7 +71,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
         this.getPatterns();
     }
 
-    /*
+    /**
      * Create the patterns needed for searching the strings for AsciiMath
      *   based on the configuration options
      */
@@ -86,7 +84,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
         this.hasPatterns = (starts.length > 0);
     }
 
-    /*
+    /**
      * Add the needed patterns for a pair of delimiters
      *
      * @param{string[]} starts  Array of starting delimiter strings
@@ -99,7 +97,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
         this.end[open] = [close, display, new RegExp(quotePattern(close), 'g')];
     }
 
-    /*
+    /**
      * Search for the end delimiter given the start delimiter.
      *
      * @param{string} text            The string being searched for the end delimiter
@@ -116,7 +114,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
                                                 n, start.index, match.index + match[0].length, display));
     }
 
-    /*
+    /**
      * Search a string for math delimited by one of the delimiter pairs.
      *
      * @param{ProtoItem[]} math  The array of proto math items located so far
@@ -135,7 +133,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Search for math in an array of strings and return an array of matches.
      *
      * @override

--- a/mathjax3-ts/input/mathml.ts
+++ b/mathjax3-ts/input/mathml.ts
@@ -84,7 +84,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
     /**
      * Set the adaptor in any of the objects that need it
      *
-     * @param{DOMAdaptor} adaptor  The adaptor to save
+     * @param {DOMAdaptor} adaptor  The adaptor to save
      */
     public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
         super.setAdaptor(adaptor);
@@ -139,8 +139,8 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
     /**
      * Check a parsed MathML string for errors.
      *
-     * @param{Document} doc  The document returns from the DOMParser
-     * @return{Document}     The document
+     * @param {Document} doc  The document returns from the DOMParser
+     * @return {Document}     The document
      */
     protected checkForErrors(doc: D) {
         let err = this.adaptor.tags(this.adaptor.body(doc), 'parsererror')[0];
@@ -156,7 +156,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
     /**
      * Throw an error
      *
-     * @param{string} message  The error message to produce
+     * @param {string} message  The error message to produce
      */
     protected error(message: string) {
         throw new Error(message);

--- a/mathjax3-ts/input/mathml.ts
+++ b/mathjax3-ts/input/mathml.ts
@@ -31,11 +31,9 @@ import {FindMathML} from './mathml/FindMathML.js';
 import {MathMLCompile} from './mathml/MathMLCompile.js';
 
 /*****************************************************************/
-/*
+/**
  *  Implements the MathML class (extends AbstractInputJax)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -57,22 +55,22 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         }
     }, AbstractInputJax.OPTIONS);
 
-    /*
+    /**
      * The FindMathML instance used to locate MathML in the document
      */
     protected findMathML: FindMathML<N, T, D>;
 
-    /*
+    /**
      * The MathMLCompile instance used to convert the MathML tree to internal format
      */
     protected mathml: MathMLCompile<N, T, D>;
 
-    /*
+    /**
      * A list of functions to call on the parsed MathML DOM before conversion to internal structure
      */
     protected mmlFilters: FunctionList;
 
-    /*
+    /**
      * @override
      */
     constructor(options: OptionList = {}) {
@@ -83,13 +81,18 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         this.mmlFilters = new FunctionList();
     }
 
+    /**
+     * Set the adaptor in any of the objects that need it
+     *
+     * @param{DOMAdaptor} adaptor  The adaptor to save
+     */
     public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
         super.setAdaptor(adaptor);
         this.findMathML.adaptor = adaptor;
         this.mathml.adaptor = adaptor;
     }
 
-    /*
+    /**
      * Don't process strings (process nodes)
      *
      * @override
@@ -98,7 +101,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         return false;
     }
 
-    /*
+    /**
      * Convert a MathItem to internal format:
      *   If there is no existing MathML node, or we are asked to reparse everything
      *     Execute the preFilters on the math
@@ -133,7 +136,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         return this.executeFilters(this.postFilters, math, this.mathml.compile(mml as N));
     }
 
-    /*
+    /**
      * Check a parsed MathML string for errors.
      *
      * @param{Document} doc  The document returns from the DOMParser
@@ -150,7 +153,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         return doc;
     }
 
-    /*
+    /**
      * Throw an error
      *
      * @param{string} message  The error message to produce
@@ -159,7 +162,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         throw new Error(message);
     }
 
-    /*
+    /**
      * @override
      */
     public findMath(node: N) {

--- a/mathjax3-ts/input/mathml/FindMathML.ts
+++ b/mathjax3-ts/input/mathml/FindMathML.ts
@@ -26,18 +26,16 @@ import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 import {OptionList} from '../../util/Options.js';
 import {ProtoItem} from '../../core/MathItem.js';
 
-/*
+/**
  * The MathML namespace
  */
 const NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 
 
 /*****************************************************************/
-/*
+/**
  *  Implements the FindMathML object (extends AbstractFindMath)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -48,7 +46,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
 
     public adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      * Locates math nodes, possibly with namespace prefixes.
      *  Store them in a set so that if found more than once, they will only
      *  appear in the list once.
@@ -66,7 +64,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
         return this.processMath(set);
     }
 
-    /*
+    /**
      * Find plain <math> tags
      *
      * @param{N} node       The container to seaerch for math
@@ -78,7 +76,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Find <m:math> tags (or whatever prefixes there are)
      *
      * @param{N} node  The container to seaerch for math
@@ -96,7 +94,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Find namespaced math in XHTML documents (is this really needed?)
      *
      * @param{N} node  The container to seaerch for math
@@ -108,7 +106,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
         }
     }
 
-    /*
+    /**
      *  Produce the array of proto math items from the node set
      */
     protected processMath(set: Set<N>) {

--- a/mathjax3-ts/input/mathml/FindMathML.ts
+++ b/mathjax3-ts/input/mathml/FindMathML.ts
@@ -67,8 +67,8 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Find plain <math> tags
      *
-     * @param{N} node       The container to seaerch for math
-     * @param{Set<N>} set   The set in which to store the math nodes
+     * @param {N} node       The container to seaerch for math
+     * @param {Set<N>} set   The set in which to store the math nodes
      */
     protected findMathNodes(node: N, set: Set<N>) {
         for (const math of this.adaptor.tags(node, 'math')) {
@@ -79,8 +79,8 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Find <m:math> tags (or whatever prefixes there are)
      *
-     * @param{N} node  The container to seaerch for math
-     * @param{NodeSet} set   The set in which to store the math nodes
+     * @param {N} node  The container to seaerch for math
+     * @param {NodeSet} set   The set in which to store the math nodes
      */
     protected findMathPrefixed(node: N, set: Set<N>) {
         let html = this.adaptor.root(this.adaptor.document);
@@ -97,8 +97,8 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
     /**
      * Find namespaced math in XHTML documents (is this really needed?)
      *
-     * @param{N} node  The container to seaerch for math
-     * @param{NodeSet} set   The set in which to store the math nodes
+     * @param {N} node  The container to seaerch for math
+     * @param {NodeSet} set   The set in which to store the math nodes
      */
     protected findMathNS(node: N, set: Set<N>) {
         for (const math of this.adaptor.tags(node, 'math', NAMESPACE)) {

--- a/mathjax3-ts/input/mathml/MathMLCompile.ts
+++ b/mathjax3-ts/input/mathml/MathMLCompile.ts
@@ -130,8 +130,8 @@ export class MathMLCompile<N, T, D> {
     /**
      * Copy the attributes from a MathML node to an MmlNode.
      *
-     * @param{MmlNode} mml       The MmlNode to which attributes will be added
-     * @param{N} node  The MathML node whose attributes to copy
+     * @param {MmlNode} mml       The MmlNode to which attributes will be added
+     * @param {N} node  The MathML node whose attributes to copy
      */
     protected addAttributes(mml: MmlNode, node: N) {
         for (const attr of this.adaptor.allAttributes(node)) {
@@ -154,8 +154,8 @@ export class MathMLCompile<N, T, D> {
      * Provide a hook for the Safe extension to filter
      * attribute values.
      *
-     * @param{string} name   The name of an attribute to filter
-     * @param{string} value  The value to filter
+     * @param {string} name   The name of an attribute to filter
+     * @param {string} value  The value to filter
      */
     protected filterAttribute(name: string, value: string) {
         return value;
@@ -164,8 +164,8 @@ export class MathMLCompile<N, T, D> {
     /**
      * Convert the children of the MathML node and add them to the MmlNode
      *
-     * @param{MmlNode} mml       The MmlNode to which children will be added
-     * @param{N} node  The MathML node whose children are to be copied
+     * @param {MmlNode} mml       The MmlNode to which children will be added
+     * @param {N} node  The MathML node whose children are to be copied
      */
     protected addChildren(mml: MmlNode, node: N) {
         if (mml.arity === 0) {
@@ -197,8 +197,8 @@ export class MathMLCompile<N, T, D> {
     /**
      * Add text to a token node
      *
-     * @param{MmlNode} mml  The MmlNode to which text will be added
-     * @param{N} child      The text node whose contents is to be copied
+     * @param {MmlNode} mml  The MmlNode to which text will be added
+     * @param {N} child      The text node whose contents is to be copied
      */
     protected addText(mml: MmlNode, child: N) {
         let text = this.adaptor.value(child);
@@ -216,8 +216,8 @@ export class MathMLCompile<N, T, D> {
     /**
      * Check for special MJX values in the class and process them
      *
-     * @param{MmlNode} mml       The MmlNode to be modified according to the class markers
-     * @param{N} node  The MathML node whose class is to be processed
+     * @param {MmlNode} mml       The MmlNode to be modified according to the class markers
+     * @param {N} node  The MathML node whose class is to be processed
      */
     protected checkClass(mml: MmlNode, node: N) {
         let classList = [];

--- a/mathjax3-ts/input/mathml/MathMLCompile.ts
+++ b/mathjax3-ts/input/mathml/MathMLCompile.ts
@@ -29,19 +29,17 @@ import * as Entities from '../../util/Entities.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 
 /********************************************************************/
-/*
+/**
  *  The class for performing the MathML DOM node to
  *  internal MmlNode conversion.
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export class MathMLCompile<N, T, D> {
 
-    /*
+    /**
      *  The default options for this object
      */
     public static OPTIONS: OptionList = {
@@ -53,7 +51,7 @@ export class MathMLCompile<N, T, D> {
         translateEntities: true             // True means translate entities in text nodes
     };
 
-    /*
+    /**
      *  The default values for the verify option
      */
     public static VERIFY: OptionList = {
@@ -62,14 +60,14 @@ export class MathMLCompile<N, T, D> {
 
     public adaptor: DOMAdaptor<N, T, D>;
 
-    /*
+    /**
      *  The instance of the MmlFactory object and
      *  the options (the defaults with the user options merged in)
      */
     protected factory: MmlFactory;
     protected options: OptionList;
 
-    /*
+    /**
      *  Merge the user options into the defaults, and save them
      *  Create the MmlFactory object
      *
@@ -84,7 +82,7 @@ export class MathMLCompile<N, T, D> {
         this.factory = this.options['MmlFactory'] || new MmlFactory();
     }
 
-    /*
+    /**
      * Convert a MathML DOM tree to internal MmlNodes
      *
      * @param {N} node  The <math> node to convert to MmlNodes
@@ -98,7 +96,7 @@ export class MathMLCompile<N, T, D> {
         return mml;
     }
 
-    /*
+    /**
      * Recursively convert nodes and their children, taking MathJax classes
      * into account.
      *
@@ -129,7 +127,7 @@ export class MathMLCompile<N, T, D> {
         return mml;
     }
 
-    /*
+    /**
      * Copy the attributes from a MathML node to an MmlNode.
      *
      * @param{MmlNode} mml       The MmlNode to which attributes will be added
@@ -152,7 +150,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Provide a hook for the Safe extension to filter
      * attribute values.
      *
@@ -163,7 +161,7 @@ export class MathMLCompile<N, T, D> {
         return value;
     }
 
-    /*
+    /**
      * Convert the children of the MathML node and add them to the MmlNode
      *
      * @param{MmlNode} mml       The MmlNode to which children will be added
@@ -196,7 +194,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add text to a token node
      *
      * @param{MmlNode} mml  The MmlNode to which text will be added
@@ -215,7 +213,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Check for special MJX values in the class and process them
      *
      * @param{MmlNode} mml       The MmlNode to be modified according to the class markers
@@ -239,7 +237,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Handle the properties of a TeXAtom
      *
      * @param {MmlNode} mml      The node to be updated
@@ -254,7 +252,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Check to see if an mrow has delimiters at both ends (so looks like an mfenced structure).
      *
      * @param {MmlNode} mml  The node to check for mfenced structure
@@ -275,7 +273,7 @@ export class MathMLCompile<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param {string} text  The text to have leading/trailing spaced removed
      * @return {string}      The trimmed text
      */
@@ -285,7 +283,7 @@ export class MathMLCompile<N, T, D> {
                    .replace(/  +/g, ' ');        // internal multiple whitespace
     }
 
-    /*
+    /**
      * @param {string} message  The error message to produce
      */
     protected error(message: string) {

--- a/mathjax3-ts/input/tex/FindTeX.ts
+++ b/mathjax3-ts/input/tex/FindTeX.ts
@@ -136,9 +136,9 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
     /*
      * Add the needed patterns for a pair of delimiters
      *
-     * @param{string[]} starts  Array of starting delimiter strings
-     * @param{Delims} delims    Array of delimiter strings, as [start, end]
-     * @param{boolean} display  True if the delimiters are for display mode
+     * @param {string[]} starts  Array of starting delimiter strings
+     * @param {Delims} delims    Array of delimiter strings, as [start, end]
+     * @param {boolean} display  True if the delimiters are for display mode
      */
     protected addPattern(starts: string[], delims: Delims, display: boolean) {
         let [open, close] = delims;
@@ -149,8 +149,8 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
     /*
      * Create the pattern for a close delimiter
      *
-     * @param{string} end  The end delimiter text
-     * @return{RegExp}     The regular expression for the end delimiter
+     * @param {string} end  The end delimiter text
+     * @return {RegExp}     The regular expression for the end delimiter
      */
     protected endPattern(end: string) {
         return new RegExp(quotePattern(end) + '|\\\\(?:[a-zA-Z]|.)|[{}]', 'g');
@@ -161,11 +161,11 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
      *   skipping braced groups, and control sequences that aren't
      *   the close delimiter.
      *
-     * @param{string} text            The string being searched for the end delimiter
-     * @param{number} n               The index of the string being searched
-     * @param{RegExpExecArray} start  The result array from the start-delimiter search
-     * @param{EndItem} end            The end-delimiter data corresponding to the start delimiter
-     * @return{ProtoItem}             The proto math item for the math, if found
+     * @param {string} text            The string being searched for the end delimiter
+     * @param {number} n               The index of the string being searched
+     * @param {RegExpExecArray} start  The result array from the start-delimiter search
+     * @param {EndItem} end            The end-delimiter data corresponding to the start delimiter
+     * @return {ProtoItem}             The proto math item for the math, if found
      */
     protected findEnd(text: string, n: number, start: RegExpExecArray, end: EndItem) {
         let [close, display, pattern] = end;
@@ -188,9 +188,9 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
      * Search a string for math delimited by one of the delimiter pairs,
      *   or by \begin{env}...\end{env}, or \eqref{...}, \ref{...}, \\, or \$.
      *
-     * @param{ProtoItem[]} math  The array of proto math items located so far
-     * @param{number} n          The index of the string being searched
-     * @param{string} text       The string being searched
+     * @param {ProtoItem[]} math  The array of proto math items located so far
+     * @param {number} n          The index of the string being searched
+     * @param {string} text       The string being searched
      */
     protected findMathInString(math: ProtoItem<N, T>[], n: number, text: string) {
         let start, match;

--- a/mathjax3-ts/mathjax.ts
+++ b/mathjax3-ts/mathjax.ts
@@ -43,9 +43,9 @@ export const MathJax = {
     /**
      * Creates a MathDocument using a registered handler that knows how to handl it
      *
-     * @param{any} document        The document to handle
-     * @param{OptionLis} options   The options to use for the document (e.g., input and output jax)
-     * @return{MathDocument}       The MathDocument to handle the document
+     * @param {any} document        The document to handle
+     * @param {OptionLis} options   The options to use for the document (e.g., input and output jax)
+     * @return {MathDocument}       The MathDocument to handle the document
      */
     document: function (document: any, options: OptionList) {
         return this.handlers.document(document, options);

--- a/mathjax3-ts/mathjax.ts
+++ b/mathjax3-ts/mathjax.ts
@@ -1,15 +1,59 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The main MathJax global object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
 import {HandlerList} from './core/HandlerList.js';
 import {handleRetriesFor, retryAfter} from './util/Retries.js';
 import {OptionList} from './util/Options.js';
 
+/*****************************************************************/
+/**
+ * The main MathJax global object
+ */
 export const MathJax = {
+    /**
+     *  The MathJax version number
+     */
     version: '3.0.0',
+
+    /**
+     *  The list of registers document handlers
+     */
     handlers: new HandlerList(),
 
+    /**
+     * Creates a MathDocument using a registered handler that knows how to handl it
+     *
+     * @param{any} document        The document to handle
+     * @param{OptionLis} options   The options to use for the document (e.g., input and output jax)
+     * @return{MathDocument}       The MathDocument to handle the document
+     */
     document: function (document: any, options: OptionList) {
         return this.handlers.document(document, options);
     },
 
+    /**
+     * The functions for handling retries if a file must be loaded dynamically
+     */
     handleRetriesFor: handleRetriesFor,
     retryAfter: retryAfter
 };

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -38,7 +38,7 @@ import {BBox} from './chtml/BBox.js';
 
 /*****************************************************************/
 
-/*
+/**
  * Maps linking a node to the test node it contains,
  *  and a map linking a node to the metrics within that node.
  */
@@ -46,11 +46,9 @@ export type MetricMap<N> = Map<N, Metrics>;
 type MetricDomMap<N> = Map<N, N>;
 
 /*****************************************************************/
-/*
+/**
  *  Implements the CHTML class (extends AbstractOutputJax)
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -69,7 +67,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         cssStyles: null                // The CssStyles object to use
     };
 
-    /*
+    /**
      *  Used to store the CHTMLWrapper factory,
      *  the FontData object, and the CssStyles object.
      */
@@ -77,14 +75,14 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     public font: FontData;
     public cssStyles: CssStyles;
 
-    /*
+    /**
      * The MathDocument for the math we find
      * and the MathItem currently being processed
      */
     public document: MathDocument<N, T, D>;
     public math: MathItem<N, T, D>;
 
-    /*
+    /**
      * A map from the nodes in the expression currently being processed to the
      * wrapper nodes for them (used by functions like core() to locate the wrappers
      * from the core nodes)
@@ -93,7 +91,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
 
     public testNodes: N;
 
-    /*
+    /**
      * Get the WrapperFactory and connect it to this output jax
      * Get the cssStyle and font objects
      *
@@ -109,7 +107,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         this.font = this.options.font || new TeXFont(fontOptions);
     }
 
-    /*
+    /**
      * Save the math document and the math item
      * Set the document where HTML nodes will be created via the adaptor
      * Recursively set the TeX classes for the nodes
@@ -134,7 +132,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return this.executeFilters(this.postFilters, math, node);
     }
 
-    /*
+    /**
      * @param{MathItem} math      The MathItem to get the bounding box for
      * @param{MathDocument} html  The MathDocument for the math
      */
@@ -149,7 +147,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return bbox;
     }
 
-    /*
+    /**
      * @override
      */
     public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
@@ -157,7 +155,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return this.html('span', {}, [this.text(math.math)]);
     }
 
-    /*
+    /**
      * @override
      */
     public getMetrics(html: MathDocument<N, T, D>) {
@@ -171,7 +169,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Get a MetricMap for the math list
      *
      * @param{MathDocument} html  The math document whose math list is to be processed.
@@ -205,7 +203,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return map;
     }
 
-    /*
+    /**
      * @param{N} node    The container to add the test elements to
      * @return{N}        The test elements that were added
      */
@@ -235,7 +233,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return adaptor.append(node, adaptor.clone(this.testNodes)) as N;
     }
 
-    /*
+    /**
      * @param{N} node    The test node to measure
      * @return{Metrics}  The metric data for the given node
      */
@@ -249,7 +247,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return {em, ex, containerWidth, lineWidth, scale} as Metrics;
     }
 
-    /*
+    /**
      * @override
      */
     public styleSheet(html: MathDocument<N, T, D>) {
@@ -281,7 +279,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return sheet as N;
     }
 
-    /*
+    /**
      * @param{MmlNode} node  The MML node whose HTML is to be produced
      * @param{HTMLElement} parent  The HTML node to contain the HTML
      */
@@ -289,7 +287,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return this.factory.wrap(node).toCHTML(parent);
     }
 
-    /*
+    /**
      * @param{string} type  The type of HTML node to create
      * @param{OptionList} def  The properties to set on the HTML node
      * @param{HTMLElement[]} content  Array of child nodes to set for the HTML node
@@ -300,7 +298,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
         return this.adaptor.node(type, def, content);
     }
 
-    /*
+    /**
      * @param{string} text  The text string for which to make a text node
      *
      * @return{HTMLElement}  A text node with the given text

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -95,7 +95,7 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
      * Get the WrapperFactory and connect it to this output jax
      * Get the cssStyle and font objects
      *
-     * @param{OptionList} options  The configuration options
+     * @param {OptionList} options  The configuration options
      * @constructor
      */
     constructor(options: OptionList = null) {
@@ -133,8 +133,8 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     }
 
     /**
-     * @param{MathItem} math      The MathItem to get the bounding box for
-     * @param{MathDocument} html  The MathDocument for the math
+     * @param {MathItem} math      The MathItem to get the bounding box for
+     * @param {MathDocument} html  The MathDocument for the math
      */
     public getBBox(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
         this.document = html;
@@ -172,8 +172,8 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     /**
      * Get a MetricMap for the math list
      *
-     * @param{MathDocument} html  The math document whose math list is to be processed.
-     * @return{MetricMap}         The node-to-metrics map for all the containers that have math
+     * @param {MathDocument} html  The math document whose math list is to be processed.
+     * @return {MetricMap}         The node-to-metrics map for all the containers that have math
      */
     protected getMetricMap(html: MathDocument<N, T, D>) {
         const adaptor = this.adaptor;
@@ -204,8 +204,8 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     }
 
     /**
-     * @param{N} node    The container to add the test elements to
-     * @return{N}        The test elements that were added
+     * @param {N} node    The container to add the test elements to
+     * @return {N}        The test elements that were added
      */
     protected getTestElement(node: N) {
         const adaptor = this.adaptor;
@@ -234,8 +234,8 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     }
 
     /**
-     * @param{N} node    The test node to measure
-     * @return{Metrics}  The metric data for the given node
+     * @param {N} node    The test node to measure
+     * @return {Metrics}  The metric data for the given node
      */
     protected measureMetrics(node: N) {
         const adaptor = this.adaptor;
@@ -280,28 +280,28 @@ export class CHTML<N, T, D> extends AbstractOutputJax<N, T, D> {
     }
 
     /**
-     * @param{MmlNode} node  The MML node whose HTML is to be produced
-     * @param{HTMLElement} parent  The HTML node to contain the HTML
+     * @param {MmlNode} node  The MML node whose HTML is to be produced
+     * @param {HTMLElement} parent  The HTML node to contain the HTML
      */
     public toCHTML(node: MmlNode, parent: N) {
         return this.factory.wrap(node).toCHTML(parent);
     }
 
     /**
-     * @param{string} type  The type of HTML node to create
-     * @param{OptionList} def  The properties to set on the HTML node
-     * @param{HTMLElement[]} content  Array of child nodes to set for the HTML node
+     * @param {string} type  The type of HTML node to create
+     * @param {OptionList} def  The properties to set on the HTML node
+     * @param {HTMLElement[]} content  Array of child nodes to set for the HTML node
      *
-     * @return{HTMLElement} The newly created HTML tree
+     * @return {HTMLElement} The newly created HTML tree
      */
     public html(type: string, def: OptionList = {}, content: (N | T)[] = []) {
         return this.adaptor.node(type, def, content);
     }
 
     /**
-     * @param{string} text  The text string for which to make a text node
+     * @param {string} text  The text string for which to make a text node
      *
-     * @return{HTMLElement}  A text node with the given text
+     * @return {HTMLElement}  A text node with the given text
      */
     public text(text: string) {
         return this.adaptor.text(text);

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -74,23 +74,23 @@ export class BBox {
     public sk: number;     // skew
 
     /**
-     * @return{BBox}  A BBox initialized to zeros
+     * @return {BBox}  A BBox initialized to zeros
      */
     public static zero() {
         return new BBox({h: 0, d: 0, w: 0});
     }
 
     /**
-     * @return{BBox}  A BBox with height and depth not set
+     * @return {BBox}  A BBox with height and depth not set
      */
     public static empty() {
         return new BBox();
     }
 
     /**
-     * @param{BBoxData} def  The data with which to initialize the BBox
+     * @param {BBoxData} def  The data with which to initialize the BBox
      *
-     * @return{BBox}  The newly created BBox
+     * @return {BBox}  The newly created BBox
      *
      * @constructor
      */
@@ -105,7 +105,7 @@ export class BBox {
 
     /**
      * Set up a bbox for append() and combine() operations
-     * @return{BBOX}  the boox itself (for chaining calls)
+     * @return {BBOX}  the boox itself (for chaining calls)
      */
     public empty() {
         this.w = 0;
@@ -123,7 +123,7 @@ export class BBox {
     }
 
     /**
-     * @param{number} scale  The scale to use to modify the bounding box size
+     * @param {number} scale  The scale to use to modify the bounding box size
      */
     public rescale(scale: number) {
         this.w *= scale;
@@ -132,9 +132,9 @@ export class BBox {
     }
 
     /**
-     * @param{BBox} cbox  A bounding to combine with this one
-     * @param{number} x   An x-offest for the child bounding box
-     * @param{number} y   A y-offset for the child bounding box
+     * @param {BBox} cbox  A bounding to combine with this one
+     * @param {number} x   An x-offest for the child bounding box
+     * @param {number} y   A y-offset for the child bounding box
      */
     public combine(cbox: BBox, x: number = 0, y: number = 0) {
         cbox.x = x;
@@ -149,7 +149,7 @@ export class BBox {
     }
 
     /**
-     * @param{BBox} cbox  A bounding box to be added to the right of this one
+     * @param {BBox} cbox  A bounding box to be added to the right of this one
      */
     public append(cbox: BBox) {
         let scale = cbox.rscale;
@@ -163,7 +163,7 @@ export class BBox {
     }
 
     /**
-     * @param{BBox} cbox  The bounding box to use to overwrite this one
+     * @param {BBox} cbox  The bounding box to use to overwrite this one
      */
     public updateFrom(cbox: BBox) {
         this.h = cbox.h;

--- a/mathjax3-ts/output/chtml/BBox.ts
+++ b/mathjax3-ts/output/chtml/BBox.ts
@@ -23,7 +23,7 @@
 
 import {BIGDIMEN, length2em} from '../../util/lengths.js';
 
-/*
+/**
  *  CSS styles that affect BBoxes
  */
 export const BBoxstyleAdjust = [
@@ -37,7 +37,7 @@ export const BBoxstyleAdjust = [
     ['paddingLeft', 'w', 0]
 ];
 
-/*
+/**
  *  The data used to initialie a BBox
  */
 export type BBoxData = {
@@ -47,17 +47,17 @@ export type BBoxData = {
 };
 
 /*****************************************************************/
-/*
+/**
  *  The BBox class
  */
 
 export class BBox {
-    /*
+    /**
      * Constant for pwidth of full width box
      */
     public static fullWidth = '100%';
 
-    /*
+    /**
      *  These are the data stored for a bounding box
      */
     public w: number;
@@ -73,21 +73,21 @@ export class BBox {
     public ic: number;     // italic correction
     public sk: number;     // skew
 
-    /*
+    /**
      * @return{BBox}  A BBox initialized to zeros
      */
     public static zero() {
         return new BBox({h: 0, d: 0, w: 0});
     }
 
-    /*
+    /**
      * @return{BBox}  A BBox with height and depth not set
      */
     public static empty() {
         return new BBox();
     }
 
-    /*
+    /**
      * @param{BBoxData} def  The data with which to initialize the BBox
      *
      * @return{BBox}  The newly created BBox
@@ -103,7 +103,7 @@ export class BBox {
         this.pwidth = '';
     }
 
-    /*
+    /**
      * Set up a bbox for append() and combine() operations
      * @return{BBOX}  the boox itself (for chaining calls)
      */
@@ -113,7 +113,7 @@ export class BBox {
         return this;
     }
 
-    /*
+    /**
      * Convert any unspecified values into zeros
      */
     public clean () {
@@ -122,7 +122,7 @@ export class BBox {
         if (this.d === -BIGDIMEN) this.d = 0;
     }
 
-    /*
+    /**
      * @param{number} scale  The scale to use to modify the bounding box size
      */
     public rescale(scale: number) {
@@ -131,7 +131,7 @@ export class BBox {
         this.d *= scale;
     }
 
-    /*
+    /**
      * @param{BBox} cbox  A bounding to combine with this one
      * @param{number} x   An x-offest for the child bounding box
      * @param{number} y   A y-offset for the child bounding box
@@ -148,7 +148,7 @@ export class BBox {
         if (d > this.d) this.d = d;
     }
 
-    /*
+    /**
      * @param{BBox} cbox  A bounding box to be added to the right of this one
      */
     public append(cbox: BBox) {
@@ -162,7 +162,7 @@ export class BBox {
         }
     }
 
-    /*
+    /**
      * @param{BBox} cbox  The bounding box to use to overwrite this one
      */
     public updateFrom(cbox: BBox) {

--- a/mathjax3-ts/output/chtml/CssStyles.ts
+++ b/mathjax3-ts/output/chtml/CssStyles.ts
@@ -47,14 +47,14 @@ export class CssStyles {
     protected styles: StyleList = {};
 
     /**
-     * @return{string}  The styles as a CSS string
+     * @return {string}  The styles as a CSS string
      */
     get cssText() {
         return this.getStyleString();
     }
 
     /**
-     * @param{StyleList} styles  The initial styles to use, if any
+     * @param {StyleList} styles  The initial styles to use, if any
      * @constructor
      */
     constructor(styles: StyleList = null) {
@@ -62,7 +62,7 @@ export class CssStyles {
     }
 
     /**
-     * @param{StyleList} styles  The styles to combine with the existing ones
+     * @param {StyleList} styles  The styles to combine with the existing ones
      */
     public addStyles(styles: StyleList) {
         if (!styles) return;
@@ -75,7 +75,7 @@ export class CssStyles {
     }
 
     /**
-     * @param{string[]} selectors  The selectors for the styles to remove
+     * @param {string[]} selectors  The selectors for the styles to remove
      */
     public removeStyles(...selectors: string[]) {
         for (const selector of selectors) {
@@ -84,7 +84,7 @@ export class CssStyles {
     }
 
     /**
-     * @return{string} The CSS string for the style list
+     * @return {string} The CSS string for the style list
      */
     public getStyleString() {
         const selectors = Object.keys(this.styles);
@@ -97,8 +97,8 @@ export class CssStyles {
     }
 
     /**
-     * @param{StyleData} styles  The style data to be stringified
-     * @return{string}           The CSS string for the given data
+     * @param {StyleData} styles  The style data to be stringified
+     * @return {string}           The CSS string for the given data
      */
     public getStyleDefString(styles: StyleData) {
         const properties = Object.keys(styles);

--- a/mathjax3-ts/output/chtml/CssStyles.ts
+++ b/mathjax3-ts/output/chtml/CssStyles.ts
@@ -21,14 +21,14 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-/*
+/**
  * The data for a selector
  */
 export type StyleData = {
     [property: string]: string | number;
 };
 
-/*
+/**
  * A list of selectors and their data (basically a stylesheet)
  */
 export type StyleList = {
@@ -36,24 +36,24 @@ export type StyleList = {
 };
 
 /******************************************************************************/
-/*
+/**
  * The CssStyles class (for managing a collection of CSS style definitions)
  */
 
 export class CssStyles {
-    /*
+    /**
      * The styles as they currently stand
      */
     protected styles: StyleList = {};
 
-    /*
+    /**
      * @return{string}  The styles as a CSS string
      */
     get cssText() {
         return this.getStyleString();
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The initial styles to use, if any
      * @constructor
      */
@@ -61,7 +61,7 @@ export class CssStyles {
         this.addStyles(styles);
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The styles to combine with the existing ones
      */
     public addStyles(styles: StyleList) {
@@ -74,7 +74,7 @@ export class CssStyles {
         }
     }
 
-    /*
+    /**
      * @param{string[]} selectors  The selectors for the styles to remove
      */
     public removeStyles(...selectors: string[]) {
@@ -83,7 +83,7 @@ export class CssStyles {
         }
     }
 
-    /*
+    /**
      * @return{string} The CSS string for the style list
      */
     public getStyleString() {
@@ -96,7 +96,7 @@ export class CssStyles {
         return defs.join('\n\n');
     }
 
-    /*
+    /**
      * @param{StyleData} styles  The style data to be stringified
      * @return{string}           The CSS string for the given data
      */

--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -347,9 +347,9 @@ export class FontData {
      *   bold-italic looks for bold-italic, then bold, then italic,
      *   then normal glyphs in order to find the given character.
      *
-     * @param{string} name     The new variant to create
-     * @param{string} inherit  The variant to use if a character is not in this one
-     * @param{string} link     A variant to search before the inherit one (but only
+     * @param {string} name     The new variant to create
+     * @param {string} inherit  The variant to use if a character is not in this one
+     * @param {string} link     A variant to search before the inherit one (but only
      *                           its top-level object).
      */
     public createVariant(name: string, inherit: string = null, link: string = null) {
@@ -368,7 +368,7 @@ export class FontData {
     /**
      * Create a collection of variants
      *
-     * @param{string[][]} variants  Array of [name, inherit?, link?] values for
+     * @param {string[][]} variants  Array of [name, inherit?, link?] values for
      *                              the variants to define
      */
     public createVariants(variants: string[][]) {
@@ -383,8 +383,8 @@ export class FontData {
      *  the character maps are objeccts with prototypes, and we don't
      *  want to loose those by doing {...chars} or something similar.)
      *
-     * @param{string} name    The variant for these characters
-     * @param{CharMap} chars  The characters to define
+     * @param {string} name    The variant for these characters
+     * @param {CharMap} chars  The characters to define
      */
     public defineChars(name: string, chars: CharMap) {
         let variant = this.variant[name];
@@ -397,7 +397,7 @@ export class FontData {
     /**
      * Defines stretchy delimiters
      *
-     * @param{DelimiterMap} delims  The delimiters to define
+     * @param {DelimiterMap} delims  The delimiters to define
      */
     public defineDelimiters(delims: DelimiterMap) {
         Object.assign(this.delimiters, delims);
@@ -406,8 +406,8 @@ export class FontData {
     /**
      * Defines a character remapping map
      *
-     * @param{string} name     The name of the map to define or augment
-     * @param{RemapMap} remap  The characters to remap
+     * @param {string} name     The name of the map to define or augment
+     * @param {RemapMap} remap  The characters to remap
      */
     public defineRemap(name: string, remap: RemapMap) {
         if (!this.remapChars.hasOwnProperty(name)) {
@@ -417,17 +417,17 @@ export class FontData {
     }
 
     /**
-     * @param{number} n  The delimiter character number whose data is desired
-     * @return{DelimiterData}  The data for that delimiter (or undefined)
+     * @param {number} n  The delimiter character number whose data is desired
+     * @return {DelimiterData}  The data for that delimiter (or undefined)
      */
     public getDelimiter(n: number) {
         return this.delimiters[n];
     }
 
     /**
-     * @param{number} n  The delimiter character number whose variant is needed
-     * @param{number} i  The index in the size array of the size whose variant is needed
-     * @return{string}   The variant of the i-th size for delimiter n
+     * @param {number} n  The delimiter character number whose variant is needed
+     * @param {number} i  The index in the size array of the size whose variant is needed
+     * @return {string}   The variant of the i-th size for delimiter n
      */
     public getSizeVariant(n: number, i: number) {
         if (this.delimiters[n].variants) {
@@ -437,26 +437,26 @@ export class FontData {
     }
 
     /**
-     * @param{string} name  The variant whose character data is being querried
-     * @param{number} n     The unicode number for the character to be found
-     * @return{CharData}    The data for the given character (or undefined)
+     * @param {string} name  The variant whose character data is being querried
+     * @param {number} n     The unicode number for the character to be found
+     * @return {CharData}    The data for the given character (or undefined)
      */
     public getChar(name: string, n: number) {
         return this.variant[name].chars[n];
     }
 
     /**
-     * @param{string} name   The name of the variant whose data is to be obtained
-     * @return{VariantData}  The data for the requested variant (or undefined)
+     * @param {string} name   The name of the variant whose data is to be obtained
+     * @return {VariantData}  The data for the requested variant (or undefined)
      */
     public getVariant(name: string) {
         return this.variant[name];
     }
 
     /**
-     * @param{string} name   The name of the map to query
-     * @param{number} c      The character to remap
-     * @return{number}       The remapped character (or the original)
+     * @param {string} name   The name of the map to query
+     * @param {number} c      The character to remap
+     * @return {number}       The remapped character (or the original)
      */
     public getRemappedChar(name: string, c: number) {
         const map = this.remapChars[name] || {} as RemapMap;
@@ -464,10 +464,10 @@ export class FontData {
     }
 
     /**
-     * @param{number} n  A unicode code point to be converted to a character reference for use with the
+     * @param {number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).
-     * @return{string}  The character as a properly encoded string.
+     * @return {string}  The character as a properly encoded string.
      */
     public char(n: number, escape: boolean = false) {
         return (n >= 0x20 && n <= 0x7E && n !== 0x22 && n !== 0x27 && n !== 0x5C ?

--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -24,7 +24,7 @@
 
 import {StringMap} from './Wrapper.js';
 
-/*
+/**
  * The extra options allowed in a CharData array
  */
 export type CharOptions = {
@@ -35,7 +35,7 @@ export type CharOptions = {
     sk?: number;                  // skew value
 };
 
-/*
+/**
  * The bit values for CharOptions.css
  */
 export const enum CSS {
@@ -45,7 +45,7 @@ export const enum CSS {
 }
 
 
-/*
+/**
  * Data about a character
  *   [height, depth, width, {italic-correction, skew, options}]
  */
@@ -61,20 +61,20 @@ export type CharMapMap = {
     [name: string]: CharMap;
 };
 
-/*
+/**
  * Data for a variant
  */
 export type VariantData = {
-    /*
+    /**
      * A list of CharMaps that must be updated when characters are
      * added to this variant
      */
     linked: CharMap[];
-    /*
+    /**
      * The character data for this variant
      */
     chars: CharMap;
-    /*
+    /**
      * The classes to use for this variant
      */
     classes?: string;
@@ -84,7 +84,7 @@ export type VariantMap = {
     [name: string]: VariantData;
 };
 
-/*
+/**
  * Stretchy delimiter data
  */
 export const enum DIRECTION {None, Vertical, Horizontal}
@@ -109,7 +109,7 @@ export type DelimiterMap = {
 
 export const NOSTRETCH: DelimiterData = {dir: DIRECTION.None};
 
-/*
+/**
  * Data for remapping characters
  */
 export type RemapData = string;
@@ -120,7 +120,7 @@ export type RemapMapMap = {
     [key: string]: RemapMap;
 }
 
-/*
+/**
  * Font parameters (for TeX typesetting rules)
  */
 export type FontParameters = {
@@ -159,13 +159,13 @@ export type FontParameters = {
 };
 
 /****************************************************************************/
-/*
+/**
  *  The FontData class (for storing character bounding box data by variant,
  *                      and the stretchy delimiter data).
  */
 export class FontData {
 
-    /*
+    /**
      *  The standard variants to define
      */
     protected static defaultVariants = [
@@ -185,7 +185,7 @@ export class FontData {
         ['monospace', 'normal']
     ];
 
-    /*
+    /**
      *  The default remappings
      */
     protected static defaultAccentMap = {
@@ -228,7 +228,7 @@ export class FontData {
         0x002D: '\u2212' // hyphen
     }
 
-    /*
+    /**
      *  The default font parameters for the font
      */
     public static defaultParams: FontParameters = {
@@ -266,40 +266,40 @@ export class FontData {
         min_rule_thickness:  1.25     // in pixels
     };
 
-    /*
+    /**
      * The default delimiter and character data
      */
     protected static defaultDelimiters: DelimiterMap = {};
     protected static defaultChars: CharMapMap = {};
 
-    /*
+    /**
      * The default variants for the fixed size stretchy delimiters
      */
     protected static defaultSizeVariants: string[] = [];
 
-    /*
+    /**
      * The default class names to use for each variant
      */
     protected static defaultVariantClasses: StringMap = {};
 
-    /*
+    /**
      * The actual variant, delimiter, and size information for this font
      */
     protected variant: VariantMap = {};
     protected delimiters: DelimiterMap = {};
     protected sizeVariants: string[];
 
-    /*
+    /**
      * The character maps
      */
     protected remapChars: RemapMapMap = {};
 
-    /*
+    /**
      * The actual font parameters for this font
      */
     public params: FontParameters;
 
-    /*
+    /**
      * Copies the data from the defaults to the instance
      *
      * @constructor
@@ -321,7 +321,7 @@ export class FontData {
         this.defineRemap('mn', CLASS.defaultMnMap);
     }
 
-    /*
+    /**
      * Creates the data structure for a variant -- an object with
      *   prototype chain that includes a copy of the linked variant,
      *   and then the inherited variant chain.
@@ -365,7 +365,7 @@ export class FontData {
         this.variant[name] = variant;
     }
 
-    /*
+    /**
      * Create a collection of variants
      *
      * @param{string[][]} variants  Array of [name, inherit?, link?] values for
@@ -377,7 +377,7 @@ export class FontData {
         }
     }
 
-    /*
+    /**
      * Defines new character data in a given variant
      *  (We use Object.assign() here rather than the spread operator since
      *  the character maps are objeccts with prototypes, and we don't
@@ -394,7 +394,7 @@ export class FontData {
         }
     }
 
-    /*
+    /**
      * Defines stretchy delimiters
      *
      * @param{DelimiterMap} delims  The delimiters to define
@@ -403,7 +403,7 @@ export class FontData {
         Object.assign(this.delimiters, delims);
     }
 
-    /*
+    /**
      * Defines a character remapping map
      *
      * @param{string} name     The name of the map to define or augment
@@ -416,7 +416,7 @@ export class FontData {
         Object.assign(this.remapChars[name], remap);
     }
 
-    /*
+    /**
      * @param{number} n  The delimiter character number whose data is desired
      * @return{DelimiterData}  The data for that delimiter (or undefined)
      */
@@ -424,7 +424,7 @@ export class FontData {
         return this.delimiters[n];
     }
 
-    /*
+    /**
      * @param{number} n  The delimiter character number whose variant is needed
      * @param{number} i  The index in the size array of the size whose variant is needed
      * @return{string}   The variant of the i-th size for delimiter n
@@ -436,7 +436,7 @@ export class FontData {
         return this.sizeVariants[i];
     }
 
-    /*
+    /**
      * @param{string} name  The variant whose character data is being querried
      * @param{number} n     The unicode number for the character to be found
      * @return{CharData}    The data for the given character (or undefined)
@@ -445,7 +445,7 @@ export class FontData {
         return this.variant[name].chars[n];
     }
 
-    /*
+    /**
      * @param{string} name   The name of the variant whose data is to be obtained
      * @return{VariantData}  The data for the requested variant (or undefined)
      */
@@ -453,7 +453,7 @@ export class FontData {
         return this.variant[name];
     }
 
-    /*
+    /**
      * @param{string} name   The name of the map to query
      * @param{number} c      The character to remap
      * @return{number}       The remapped character (or the original)
@@ -463,7 +463,7 @@ export class FontData {
         return map[c];
     }
 
-    /*
+    /**
      * @param{number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).

--- a/mathjax3-ts/output/chtml/Notation.ts
+++ b/mathjax3-ts/output/chtml/Notation.ts
@@ -35,7 +35,7 @@ export const SOLID = THICKNESS + 'em solid';  // a solid border
 
 /*****************************************************************/
 
-/*
+/**
  * The functions used for notation definitions
  */
 export type Renderer<N, T, D> = (node: CHTMLmenclose<N, T, D>, child: N) => void;
@@ -43,7 +43,7 @@ export type BBoxExtender<N, T, D> = (node: CHTMLmenclose<N, T, D>) => number[];
 export type BBoxBorder<N, T, D> = (node: CHTMLmenclose<N, T, D>) => number[];
 export type Initializer<N, T, D> = (node: CHTMLmenclose<N, T, D>) => void;
 
-/*
+/**
  * The definition of a notation
  */
 export type NotationDef<N, T, D> = {
@@ -55,13 +55,13 @@ export type NotationDef<N, T, D> = {
     remove?: string;                    // list of notations that are suppressed by this one
 };
 
-/*
+/**
  * For defining notation maps
  */
 export type DefPair = [string, NotationDef<any, any, any>];
 export type DefList = Map<string, NotationDef<any, any, any>>;
 
-/*
+/**
  * The list of notations for an menclose element
  */
 export type List<N, T, D> = {[notation: string]: NotationDef<N, T, D>};
@@ -69,28 +69,28 @@ export type List<N, T, D> = {[notation: string]: NotationDef<N, T, D>};
 
 /*****************************************************************/
 
-/*
+/**
  * The names and indices of sides for borders, padding, etc.
  */
 export const sideIndex = {top: 0, right: 1, bottom: 2, left: 3};
 export type Side = keyof typeof sideIndex;
 export const sideNames = Object.keys(sideIndex) as Side[];
 
-/*
+/**
  * the spacing to leave for an arrowhead
  */
 export const arrowHead = (node: CHTMLmenclose<any, any, any>) => {
     return Math.max(node.padding, node.thickness * (node.arrowhead.x + node.arrowhead.dx + 1));
 };
 
-/*
+/**
  * Common BBox and Border functions
  */
 export const fullBBox = ((node) => new Array(4).fill(node.thickness + node.padding)) as BBoxExtender<any, any, any>;
 export const fullPadding = ((node) => new Array(4).fill(node.padding)) as BBoxExtender<any, any, any>;
 export const fullBorder = ((node) => new Array(4).fill(node.thickness)) as BBoxBorder<any, any, any>;
 
-/*
+/**
  * The data for horizontal and vertical arrow notations
  *   [angle, neg, double, origin, offset, isVertical, remove]
  */
@@ -103,7 +103,7 @@ export const arrowDef = {
     leftright: [0,           -1, true, 'top left',  'Y', false, 'horizontalstrike leftarrow rightarrow']
 } as {[name: string]: [number, number, boolean, string, string, boolean, string]};
 
-/*
+/**
  * The data for diagonal arrow notations
  *   [neg, c, pi, double, origin, remove]
  */
@@ -119,7 +119,7 @@ export const diagonalArrowDef = {
                           'downdiagonalstrike northwestarrow southeastarrow']
 } as {[name: string]: [number, number, number, boolean, string, string]};
 
-/*
+/**
  * The BBox functions for horizontal and vertical arrows
  */
 export const arrowBBox = {
@@ -131,7 +131,7 @@ export const arrowBBox = {
     leftright: (node) => [0, arrowHead(node), 0, arrowHead(node)]
 } as {[name: string]: BBoxExtender<any, any, any>};
 
-/*
+/**
  * Create a named element (handled by CSS), and adjust it if thickness is non-standard
  *
  * @param{string} name    The name of the element to create
@@ -149,7 +149,7 @@ export const  RenderElement = (name: string, offset: string = '') => {
     }) as Renderer<any, any, any>;
 };
 
-/*
+/**
  * @param{string} side   The side on which a border should appear
  * @return{DefPair}      The notation definition for the notation having a line on the given side
  */
@@ -181,7 +181,7 @@ export const Border = (side: Side) => {
     }] as DefPair;
 };
 
-/*
+/**
  * @param{string} name    The name of the notation to define
  * @param{string} side1   The first side to get a border
  * @param{string} side2   The second side to get a border
@@ -223,7 +223,7 @@ export const Border2 = (name: string, side1: Side, side2: Side) => {
     }] as DefPair;
 };
 
-/*
+/**
  * @param{string} name  The name of the diagonal strike to define
  * @param{number} neg   1 or -1 to use with the angle
  * @return{DefPair}     The notation definition for the diagonal strike
@@ -252,7 +252,7 @@ export const DiagonalStrike = (name: string, neg: number) => {
     }] as DefPair;
 };
 
-/*
+/**
  * @param{string} name   The name of the diagonal arrow to define
  * @return{DefPair}      The notation definition for the diagonal arrow
  */
@@ -283,7 +283,7 @@ export const DiagonalArrow = (name: string) => {
     }] as DefPair;
 };
 
-/*
+/**
  * @param{string} name   The name of the horizontal or vertical arrow to define
  * @return{DefPair}      The notation definition for the arrow
  */

--- a/mathjax3-ts/output/chtml/Notation.ts
+++ b/mathjax3-ts/output/chtml/Notation.ts
@@ -134,9 +134,9 @@ export const arrowBBox = {
 /**
  * Create a named element (handled by CSS), and adjust it if thickness is non-standard
  *
- * @param{string} name    The name of the element to create
- * @param{string} offset  The offset direction to adjust if thickness is non-standard
- * @return{Renderer}      The renderer function for the given element name
+ * @param {string} name    The name of the element to create
+ * @param {string} offset  The offset direction to adjust if thickness is non-standard
+ * @return {Renderer}      The renderer function for the given element name
  */
 export const  RenderElement = (name: string, offset: string = '') => {
     return ((node, child) => {
@@ -150,8 +150,8 @@ export const  RenderElement = (name: string, offset: string = '') => {
 };
 
 /**
- * @param{string} side   The side on which a border should appear
- * @return{DefPair}      The notation definition for the notation having a line on the given side
+ * @param {string} side   The side on which a border should appear
+ * @return {DefPair}      The notation definition for the notation having a line on the given side
  */
 export const Border = (side: Side) => {
     const i = sideIndex[side];
@@ -182,10 +182,10 @@ export const Border = (side: Side) => {
 };
 
 /**
- * @param{string} name    The name of the notation to define
- * @param{string} side1   The first side to get a border
- * @param{string} side2   The second side to get a border
- * @return{DefPair}       The notation definition for the notation having lines on two sides
+ * @param {string} name    The name of the notation to define
+ * @param {string} side1   The first side to get a border
+ * @param {string} side2   The second side to get a border
+ * @return {DefPair}       The notation definition for the notation having lines on two sides
  */
 export const Border2 = (name: string, side1: Side, side2: Side) => {
     const i1 = sideIndex[side1];
@@ -224,9 +224,9 @@ export const Border2 = (name: string, side1: Side, side2: Side) => {
 };
 
 /**
- * @param{string} name  The name of the diagonal strike to define
- * @param{number} neg   1 or -1 to use with the angle
- * @return{DefPair}     The notation definition for the diagonal strike
+ * @param {string} name  The name of the diagonal strike to define
+ * @param {number} neg   1 or -1 to use with the angle
+ * @return {DefPair}     The notation definition for the diagonal strike
  */
 export const DiagonalStrike = (name: string, neg: number) => {
     const cname = 'mjx-' + name.charAt(0) + 'strike';
@@ -253,8 +253,8 @@ export const DiagonalStrike = (name: string, neg: number) => {
 };
 
 /**
- * @param{string} name   The name of the diagonal arrow to define
- * @return{DefPair}      The notation definition for the diagonal arrow
+ * @param {string} name   The name of the diagonal arrow to define
+ * @return {DefPair}      The notation definition for the diagonal arrow
  */
 export const DiagonalArrow = (name: string) => {
     const [neg, c, pi, double, origin, remove] = diagonalArrowDef[name];
@@ -284,8 +284,8 @@ export const DiagonalArrow = (name: string) => {
 };
 
 /**
- * @param{string} name   The name of the horizontal or vertical arrow to define
- * @return{DefPair}      The notation definition for the arrow
+ * @param {string} name   The name of the horizontal or vertical arrow to define
+ * @return {DefPair}      The notation definition for the arrow
  */
 export const Arrow = (name: string) => {
     const [angle, neg, double, origin, offset, isVertical, remove] = arrowDef[name];

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -298,9 +298,9 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{MmlNode} node  The node to the wrapped
-     * @param{CHTMLWrapper} parent  The wrapped parent node
-     * @return{CHTMLWrapper}  The newly wrapped node
+     * @param {MmlNode} node  The node to the wrapped
+     * @param {CHTMLWrapper} parent  The wrapped parent node
+     * @return {CHTMLWrapper}  The newly wrapped node
      */
     public wrap(node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
         const wrapped = this.factory.wrap(node, parent || this);
@@ -315,7 +315,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Create the HTML for the wrapped node.
      *
-     * @param{N} parent  The HTML node where the output is added
+     * @param {N} parent  The HTML node where the output is added
      */
     public toCHTML(parent: N) {
         const chtml = this.standardCHTMLnode(parent);
@@ -329,8 +329,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      * Return the wrapped node's bounding box, either the cached one, if it exists,
      *   or computed directly if not.
      *
-     * @param{boolean} save  Whether to cache the bbox or not (used for stretchy elements)
-     * @return{BBox}  The computed bounding box
+     * @param {boolean} save  Whether to cache the bbox or not (used for stretchy elements)
+     * @return {BBox}  The computed bounding box
      */
     public getBBox(save: boolean = true) {
         if (this.bboxComputed) {
@@ -343,7 +343,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{BBox} bbox  The bounding box to modify (either this.bbox, or an empty one)
+     * @param {BBox} bbox  The bounding box to modify (either this.bbox, or an empty one)
      */
     protected computeBBox(bbox: BBox) {
         bbox.empty();
@@ -368,7 +368,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Copy child skew and italic correction
      *
-     * @param{BBox} bbox  The bounding box to modify
+     * @param {BBox} bbox  The bounding box to modify
      */
     protected copySkewIC(bbox: BBox) {
         const first = this.childNodes[0];
@@ -437,9 +437,9 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Set the CSS for a token element having an explicit font (rather than regular mathvariant).
      *
-     * @param{string} fontFamily  The font family to use
-     * @param{string} fontWeight  The font weight to use
-     * @param{string} fontStyle   The font style to use
+     * @param {string} fontFamily  The font family to use
+     * @param {string} fontWeight  The font weight to use
+     * @param {string} fontStyle   The font style to use
      */
     protected explicitVariant(fontFamily: string, fontWeight: string, fontStyle: string) {
         let style = this.styles;
@@ -453,7 +453,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Determine the scaling factor to use for this wrapped node, and set the styles for it.
      *
-     * @return{number}   The scaling factor for this node
+     * @return {number}   The scaling factor for this node
      */
     protected getScale() {
         let scale = 1, parent = this.parent;
@@ -534,8 +534,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Get the spacing using the TeX rules
      *
-     * @parm{boolean} isTop       True when this is a top-level embellished operator
-     * @parm{boolean} hasSpacing  True when there is an explicit or inherited 'form' attribute
+     * @parm {boolean} isTop       True when this is a top-level embellished operator
+     * @parm {boolean} hasSpacing  True when there is an explicit or inherited 'form' attribute
      */
     protected getTeXSpacing(isTop: boolean, hasSpacing: boolean) {
         if (!hasSpacing) {
@@ -565,8 +565,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /**
      * Create the standard CHTML element for the given wrapped node.
      *
-     * @param{N} parent  The HTML element in which the node is to be created
-     * @returns{N}  The root of the HTML tree for the wrapped node's output
+     * @param {N} parent  The HTML element in which the node is to be created
+     * @returns {N}  The root of the HTML tree for the wrapped node's output
      */
     protected standardCHTMLnode(parent: N) {
         const chtml = this.createCHTMLnode(parent);
@@ -581,8 +581,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{N} parent  The HTML element in which the node is to be created
-     * @returns{N}  The root of the HTML tree for the wrapped node's output
+     * @param {N} parent  The HTML element in which the node is to be created
+     * @returns {N}  The root of the HTML tree for the wrapped node's output
      */
     protected createCHTMLnode(parent: N) {
         const href = this.node.attributes.get('href');
@@ -622,9 +622,9 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{N} chtml  The HTML node to scale
-     * @param{number} rscale      The relatie scale to apply
-     * @return{N}       The HTML node (for chaining)
+     * @param {N} chtml  The HTML node to scale
+     * @param {number} rscale      The relatie scale to apply
+     * @return {N}       The HTML node (for chaining)
      */
     protected setScale(chtml: N, rscale: number) {
         const scale = (Math.abs(rscale - 1) < .001 ? 1 : rscale);
@@ -714,21 +714,21 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     /*******************************************************************/
 
     /**
-     * @return{CHTMLWrapper}  The wrapper for this node's core node
+     * @return {CHTMLWrapper}  The wrapper for this node's core node
      */
     public core() {
         return this.CHTML.nodeMap.get(this.node.core());
     }
 
     /**
-     * @return{CHTMLWrapper}  The wrapper for this node's core <mo> node
+     * @return {CHTMLWrapper}  The wrapper for this node's core <mo> node
      */
     public coreMO(): CHTMLmo<N, T, D> {
         return this.CHTML.nodeMap.get(this.node.coreMO()) as CHTMLmo<N, T, D>;
     }
 
     /**
-     * @return{string}  For a token node, the combined text content of the node's children
+     * @return {string}  For a token node, the combined text content of the node's children
      */
     public getText() {
         let text = '';
@@ -743,8 +743,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{DIRECTION} direction  The direction to stretch this node
-     * @return{boolean}             Whether the node can stretch in that direction
+     * @param {DIRECTION} direction  The direction to stretch this node
+     * @return {boolean}             Whether the node can stretch in that direction
      */
     public canStretch(direction: DIRECTION): boolean {
         this.stretch = NOSTRETCH;
@@ -760,7 +760,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @return{[string, number]}  The alignment and indentation shift for the expression
+     * @return {[string, number]}  The alignment and indentation shift for the expression
      */
     protected getAlignShift() {
         let {indentalign, indentshift, indentalignfirst, indentshiftfirst} =
@@ -782,9 +782,9 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{N} chtml       The HTML node whose indentation is to be adjusted
-     * @param{string} align  The alignment for the node
-     * @param{number} shift  The indent (positive or negative) for the node
+     * @param {N} chtml       The HTML node whose indentation is to be adjusted
+     * @param {string} align  The alignment for the node
+     * @param {number} shift  The indent (positive or negative) for the node
      */
     protected setIndent(chtml: N, align: string, shift: number) {
         if (align === 'center' || align === 'left') {
@@ -837,35 +837,35 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      */
 
     /**
-     * @param{number} m  A number to be shown as a percent
-     * @return{string}  The number m as a percent
+     * @param {number} m  A number to be shown as a percent
+     * @return {string}  The number m as a percent
      */
     protected percent(m: number) {
         return LENGTHS.percent(m);
     }
 
     /**
-     * @param{number} m  A number to be shown in ems
-     * @return{string}  The number with units of ems
+     * @param {number} m  A number to be shown in ems
+     * @return {string}  The number with units of ems
      */
     protected em(m: number) {
         return LENGTHS.em(m);
     }
 
     /**
-     * @param{number} m   A number of em's to be shown as pixels
-     * @param{number} M   The minimum number of pixels to allow
-     * @return{string}  The number with units of px
+     * @param {number} m   A number of em's to be shown as pixels
+     * @param {number} M   The minimum number of pixels to allow
+     * @return {string}  The number with units of px
      */
     protected px(m: number, M: number = -LENGTHS.BIGDIMEN) {
         return LENGTHS.px(m, M, this.metrics.em);
     }
 
     /**
-     * @param{Property} length  A dimension (giving number and units) or number to be converted to ems
-     * @param{number} size  The default size of the dimension (for percentage values)
-     * @param{number} scale  The current scaling factor (to handle absolute units)
-     * @return{number}  The dimension converted to ems
+     * @param {Property} length  A dimension (giving number and units) or number to be converted to ems
+     * @param {number} size  The default size of the dimension (for percentage values)
+     * @param {number} scale  The current scaling factor (to handle absolute units)
+     * @return {number}  The dimension converted to ems
      */
     protected length2em(length: Property, size: number = 1, scale: number = null) {
         if (scale === null) {
@@ -875,62 +875,62 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /**
-     * @param{string} text  The text to turn into unicode locations
-     * @return{number[]}  Array of numbers represeting the string's unicode character positions
+     * @param {string} text  The text to turn into unicode locations
+     * @return {number[]}  Array of numbers represeting the string's unicode character positions
      */
     protected unicodeChars(text: string) {
         return unicodeChars(text);
     }
 
     /**
-     * @param{number} n  A unicode code point to be converted to a character reference for use with the
+     * @param {number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).
-     * @return{string}  The character as a properly encoded string.
+     * @return {string}  The character as a properly encoded string.
      */
     protected char(n: number, escape: boolean = false) {
         return this.font.char(n, escape);
     }
 
     /**
-     * @param{number[]} chars    The array of unicode character numbers to remap
-     * @return{number[]}         The converted array
+     * @param {number[]} chars    The array of unicode character numbers to remap
+     * @return {number[]}         The converted array
      */
     public remapChars(chars: number[]) {
         return chars;
     }
 
     /**
-     * @param{string} type  The tag name of the HTML node to be created
-     * @param{OptionList} def  The properties to set for the created node
-     * @param{N[]} content  The child nodes for the created HTML node
-     * @return{N}   The generated HTML tree
+     * @param {string} type  The tag name of the HTML node to be created
+     * @param {OptionList} def  The properties to set for the created node
+     * @param {N[]} content  The child nodes for the created HTML node
+     * @return {N}   The generated HTML tree
      */
     public html(type: string, def: OptionList = {}, content: N[] = []) {
         return this.factory.chtml.html(type, def, content);
     }
 
     /**
-     * @param{string} text  The text from which to create an HTML text node
-     * @return{T}  The generated text node with the given text
+     * @param {string} text  The text from which to create an HTML text node
+     * @return {T}  The generated text node with the given text
      */
     public text(text: string) {
         return this.factory.chtml.text(text);
     }
 
     /**
-     * @param{string} text  The text from which to create a TextNode object
-     * @return{CHTMLTextNode}  The TextNode with the given text
+     * @param {string} text  The text from which to create a TextNode object
+     * @return {CHTMLTextNode}  The TextNode with the given text
      */
     public mmlText(text: string) {
         return ((this.node as AbstractMmlNode).factory.create('text') as TextNode).setText(text);
     }
 
     /**
-     * @param{string} kind  The kind of MmlNode to create
+     * @param {string} kind  The kind of MmlNode to create
      * @paramProperyList} properties  The properties to set initially
-     * @param{MmlNode[]} children  The child nodes to add to the created node
-     * @return{MmlNode}  The newly created MmlNode
+     * @param {MmlNode[]} children  The child nodes to add to the created node
+     * @return {MmlNode}  The newly created MmlNode
      */
     public mmlNode(kind: string, properties: PropertyList = {}, children: MmlNode[] = []) {
         return (this.node as AbstractMmlNode).factory.create(kind, properties, children);
@@ -940,8 +940,8 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      * Create an mo wrapper with the given text,
      *   link it in, and give it the right defaults.
      *
-     * @param{string} text  The text for the wrapped element
-     * @return{CHTMLWrapper}  The wrapped MmlMo node
+     * @param {string} text  The text for the wrapped element
+     * @return {CHTMLWrapper}  The wrapped MmlMo node
      */
     protected createMo(text: string): CHTMLmo<N, T, D> {
         const mmlFactory = (this.node as AbstractMmlNode).factory;

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -40,12 +40,12 @@ import {StyleList} from './CssStyles.js';
 
 /*****************************************************************/
 
-/*
+/**
  * Shorthand for a dictionary object (an object of key:value pairs)
  */
 export type StringMap = {[key: string]: string};
 
-/*
+/**
  * Some standard sizes to use in predefind CSS properties
  */
 export const FONTSIZE: StringMap = {
@@ -69,14 +69,14 @@ export const SPACE: StringMap = {
     [LENGTHS.em(6/18)]: '5'
 };
 
-/*
+/**
  * Needed to access node.style[id] using variable id
  */
 interface CSSStyle extends CSSStyleDeclaration {
     [id: string]: string | Function | number | CSSRule;
 }
 
-/*
+/**
  * MathML spacing rules
  */
 const SMALLSIZE = 2/18;
@@ -85,11 +85,9 @@ function MathMLSpace(script: boolean, size: number) {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The base CHTMLWrapper class
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -98,13 +96,13 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     public static kind: string = 'unknown';
 
-    /*
+    /**
      * If true, this causes a style for the node type to be generated automatically
      * that sets display:inline-block (as needed for the output for MmlNodes).
      */
     public static autoStyle = true;
 
-    /*
+    /**
      *  The default styles for CommonHTML
      */
     public static styles: StyleList = {
@@ -150,7 +148,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     };
 
-    /*
+    /**
      * Styles that should not be passed on from style attribute
      */
     public static removeStyles: [string] = [
@@ -158,7 +156,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         'fontStyle', 'fontVariant', 'font'
     ];
 
-    /*
+    /**
      * Non-MathML attributes on MathML elements NOT to be copied to the
      * corresponding CHTML elements.  If set to false, then the attribute
      * WILL be copied.  Most of these (like the font attributes) are handled
@@ -171,7 +169,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         xmlns: true
     };
 
-    /*
+    /**
      * The translation of mathvariant to bold or italic styles, or to remove
      * bold or italic from a mathvariant.
      */
@@ -208,68 +206,68 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     };
 
-    /*
+    /**
      * The factory used to create more CHTMLWrappers
      */
     protected factory: CHTMLWrapperFactory<N, T, D>;
 
-    /*
+    /**
      * The parent and children of this node
      */
     public parent: CHTMLWrapper<N, T, D> = null;
     public childNodes: CHTMLWrapper<N, T, D>[];
 
-    /*
+    /**
      * The HTML element generated for this wrapped node
      */
     public chtml: N = null;
 
-    /*
+    /**
      * Styles that must be handled directly by CHTML (mostly having to do with fonts)
      */
     protected removedStyles: StringMap = null;
 
-    /*
+    /**
      * The explicit styles set by the node
      */
     protected styles: Styles = null;
 
-    /*
+    /**
      * The mathvariant for this node
      */
     public variant: string = '';
 
-    /*
+    /**
      * The bounding box for this node, and whether it has been computed yet
      */
     public bbox: BBox;
     protected bboxComputed: boolean = false;
 
-    /*
+    /**
      * Delimiter data for stretching this node (NOSTRETCH means not yet determined)
      */
     public stretch: DelimiterData = NOSTRETCH;
 
-    /*
+    /**
      * Easy access to the font parameters
      */
     public font: FontData = null;
 
-    /*
+    /**
      * Easy access to the CHTML output jax for this node
      */
     get CHTML() {
         return this.factory.chtml;
     }
 
-    /*
+    /**
      * Easy access to the DOMAdaptor object
      */
     get adaptor() {
         return this.factory.chtml.adaptor;
     }
 
-    /*
+    /**
      * Easy access to the metric data for this node
      */
     get metrics() {
@@ -278,7 +276,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     /*******************************************************************/
 
-    /*
+    /**
      * @override
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
@@ -299,7 +297,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         });
     }
 
-    /*
+    /**
      * @param{MmlNode} node  The node to the wrapped
      * @param{CHTMLWrapper} parent  The wrapped parent node
      * @return{CHTMLWrapper}  The newly wrapped node
@@ -314,7 +312,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /*******************************************************************/
-    /*
+    /**
      * Create the HTML for the wrapped node.
      *
      * @param{N} parent  The HTML node where the output is added
@@ -327,7 +325,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /*******************************************************************/
-    /*
+    /**
      * Return the wrapped node's bounding box, either the cached one, if it exists,
      *   or computed directly if not.
      *
@@ -344,7 +342,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return bbox;
     }
 
-    /*
+    /**
      * @param{BBox} bbox  The bounding box to modify (either this.bbox, or an empty one)
      */
     protected computeBBox(bbox: BBox) {
@@ -355,7 +353,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         bbox.clean();
     }
 
-    /*
+    /**
      * Mark BBox to be computed again (e.g., when an mo has stretched)
      */
     public invalidateBBox() {
@@ -367,7 +365,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Copy child skew and italic correction
      *
      * @param{BBox} bbox  The bounding box to modify
@@ -386,7 +384,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     /*******************************************************************/
 
-    /*
+    /**
      * Add the style attribute, but remove any font-related styles
      *   (since these are handled separately by the variant)
      */
@@ -404,7 +402,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Get the mathvariant (or construct one, if needed).
      */
     protected getVariant() {
@@ -436,7 +434,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         this.variant = variant;
     }
 
-    /*
+    /**
      * Set the CSS for a token element having an explicit font (rather than regular mathvariant).
      *
      * @param{string} fontFamily  The font family to use
@@ -452,7 +450,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return '-explicitFont';
     }
 
-    /*
+    /**
      * Determine the scaling factor to use for this wrapped node, and set the styles for it.
      *
      * @return{number}   The scaling factor for this node
@@ -504,7 +502,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         this.bbox.rscale = scale / pscale;
     }
 
-    /*
+    /**
      * Sets the spacing based on TeX or MathML algorithm
      */
     protected getSpace() {
@@ -517,7 +515,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Get the spacing using MathML rules based on the core MO
      */
     protected getMathMLSpacing() {
@@ -533,7 +531,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
                        MathMLSpace(isScript, node.rspace));
     }
 
-    /*
+    /**
      * Get the spacing using the TeX rules
      *
      * @parm{boolean} isTop       True when this is a top-level embellished operator
@@ -564,7 +562,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     /*******************************************************************/
 
-    /*
+    /**
      * Create the standard CHTML element for the given wrapped node.
      *
      * @param{N} parent  The HTML element in which the node is to be created
@@ -582,7 +580,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return chtml;
     }
 
-    /*
+    /**
      * @param{N} parent  The HTML element in which the node is to be created
      * @returns{N}  The root of the HTML tree for the wrapped node's output
      */
@@ -595,7 +593,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return this.chtml;
     }
 
-    /*
+    /**
      * Set the CSS styles for the chtml element
      */
     protected handleStyles() {
@@ -606,7 +604,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Set the CSS for the math variant
      */
     protected handleVariant() {
@@ -616,14 +614,14 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Set the (relative) scaling factor for the node
      */
     protected handleScale() {
         this.setScale(this.chtml, this.bbox.rscale);
     }
 
-    /*
+    /**
      * @param{N} chtml  The HTML node to scale
      * @param{number} rscale      The relatie scale to apply
      * @return{N}       The HTML node (for chaining)
@@ -641,7 +639,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return chtml;
     }
 
-    /*
+    /**
      * Add the proper spacing
      */
     protected handleSpace() {
@@ -659,7 +657,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Add the foreground and background colors
      * (Only look at explicit attributes, since inherited ones will
      *  be applied to a parent element, and we will inherit from that)
@@ -678,7 +676,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Copy RDFa, aria, and other tags from the MathML to the CHTML output nodes.
      * Don't copy those in the skipAttributes list, or anything that already exists
      * as a property of the node (e.g., no "onlick", etc.).  If a name in the
@@ -700,7 +698,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         }
     }
 
-    /*
+    /**
      * Handle the attributes needed for percentage widths
      */
     protected handlePWidth() {
@@ -715,21 +713,21 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
     /*******************************************************************/
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The wrapper for this node's core node
      */
     public core() {
         return this.CHTML.nodeMap.get(this.node.core());
     }
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The wrapper for this node's core <mo> node
      */
     public coreMO(): CHTMLmo<N, T, D> {
         return this.CHTML.nodeMap.get(this.node.coreMO()) as CHTMLmo<N, T, D>;
     }
 
-    /*
+    /**
      * @return{string}  For a token node, the combined text content of the node's children
      */
     public getText() {
@@ -744,7 +742,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return text;
     }
 
-    /*
+    /**
      * @param{DIRECTION} direction  The direction to stretch this node
      * @return{boolean}             Whether the node can stretch in that direction
      */
@@ -761,7 +759,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return this.stretch.dir !== DIRECTION.None;
     }
 
-    /*
+    /**
      * @return{[string, number]}  The alignment and indentation shift for the expression
      */
     protected getAlignShift() {
@@ -783,7 +781,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return [indentalign, shift] as [string, number];
     }
 
-    /*
+    /**
      * @param{N} chtml       The HTML node whose indentation is to be adjusted
      * @param{string} align  The alignment for the node
      * @param{number} shift  The indent (positive or negative) for the node
@@ -798,7 +796,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
     }
 
     /*******************************************************************/
-    /*
+    /**
      * For debugging
      */
 
@@ -838,7 +836,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
      * Easy access to some utility routines
      */
 
-    /*
+    /**
      * @param{number} m  A number to be shown as a percent
      * @return{string}  The number m as a percent
      */
@@ -846,7 +844,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return LENGTHS.percent(m);
     }
 
-    /*
+    /**
      * @param{number} m  A number to be shown in ems
      * @return{string}  The number with units of ems
      */
@@ -854,7 +852,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return LENGTHS.em(m);
     }
 
-    /*
+    /**
      * @param{number} m   A number of em's to be shown as pixels
      * @param{number} M   The minimum number of pixels to allow
      * @return{string}  The number with units of px
@@ -863,7 +861,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return LENGTHS.px(m, M, this.metrics.em);
     }
 
-    /*
+    /**
      * @param{Property} length  A dimension (giving number and units) or number to be converted to ems
      * @param{number} size  The default size of the dimension (for percentage values)
      * @param{number} scale  The current scaling factor (to handle absolute units)
@@ -876,7 +874,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return LENGTHS.length2em(length as string, size, scale, this.metrics.em);
     }
 
-    /*
+    /**
      * @param{string} text  The text to turn into unicode locations
      * @return{number[]}  Array of numbers represeting the string's unicode character positions
      */
@@ -884,7 +882,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return unicodeChars(text);
     }
 
-    /*
+    /**
      * @param{number} n  A unicode code point to be converted to a character reference for use with the
      *                   CSS rules for fonts (either a literal character for most ASCII values, or \nnnn
      *                   for higher values, or for the double quote and backslash characters).
@@ -894,7 +892,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return this.font.char(n, escape);
     }
 
-    /*
+    /**
      * @param{number[]} chars    The array of unicode character numbers to remap
      * @return{number[]}         The converted array
      */
@@ -902,7 +900,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return chars;
     }
 
-    /*
+    /**
      * @param{string} type  The tag name of the HTML node to be created
      * @param{OptionList} def  The properties to set for the created node
      * @param{N[]} content  The child nodes for the created HTML node
@@ -912,7 +910,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return this.factory.chtml.html(type, def, content);
     }
 
-    /*
+    /**
      * @param{string} text  The text from which to create an HTML text node
      * @return{T}  The generated text node with the given text
      */
@@ -920,7 +918,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return this.factory.chtml.text(text);
     }
 
-    /*
+    /**
      * @param{string} text  The text from which to create a TextNode object
      * @return{CHTMLTextNode}  The TextNode with the given text
      */
@@ -928,7 +926,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return ((this.node as AbstractMmlNode).factory.create('text') as TextNode).setText(text);
     }
 
-    /*
+    /**
      * @param{string} kind  The kind of MmlNode to create
      * @paramProperyList} properties  The properties to set initially
      * @param{MmlNode[]} children  The child nodes to add to the created node
@@ -938,7 +936,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
         return (this.node as AbstractMmlNode).factory.create(kind, properties, children);
     }
 
-    /*
+    /**
      * Create an mo wrapper with the given text,
      *   link it in, and give it the right defaults.
      *
@@ -963,7 +961,7 @@ export class CHTMLWrapper<N, T, D> extends AbstractWrapper<MmlNode, CHTMLWrapper
 
 }
 
-/*
+/**
  *  The type of the CHTMLWrapper class (used when creating the wrapper factory for this class)
  */
 export type CHTMLWrapperClass = typeof CHTMLWrapper;

--- a/mathjax3-ts/output/chtml/WrapperFactory.ts
+++ b/mathjax3-ts/output/chtml/WrapperFactory.ts
@@ -28,28 +28,26 @@ import {CHTMLWrappers} from './Wrappers.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  *  The CHTMLWrapperFactory class for creating CHTMLWrapper nodes
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
 export class CHTMLWrapperFactory<N, T, D> extends AbstractWrapperFactory<MmlNode, CHTMLWrapper<N, T, D>, CHTMLWrapperClass> {
 
-    /*
+    /**
      * The default list of wrapper nodes this factory can create
      */
     public static defaultNodes = CHTMLWrappers;
 
-    /*
+    /**
      * The CHTML output jax associated with this factory
      */
     public chtml: CHTML<N, T, D> = null;
 
-    /*
+    /**
      * @return {object}  The list of node-creation functions
      */
     get Wrappers() {

--- a/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
@@ -27,7 +27,7 @@ import {TeXAtom} from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
 import {MmlNode, TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLTeXAtom wrapper for the TeXAtom object
  *
  * @template N  The HTMLElement node class
@@ -37,7 +37,7 @@ import {MmlNode, TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 export class CHTMLTeXAtom<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = TeXAtom.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -54,7 +54,7 @@ export class CHTMLTeXAtom<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -89,9 +89,9 @@ export class CHTMLTextNode<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{string} variant   The variant in which to look for the character
-     * @param{number} n         The number of the character to look up
-     * @return{CharData}        The full CharData object, with CharOptions guaranteed to be defined
+     * @param {string} variant   The variant in which to look for the character
+     * @param {number} n         The number of the character to look up
+     * @return {CharData}        The full CharData object, with CharOptions guaranteed to be defined
      */
     protected getChar(variant: string, n: number) {
         const char = this.font.getChar(variant, n) || [0, 0, 0, null];

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -27,11 +27,9 @@ import {TextNode} from '../../../core/MmlTree/MmlNode.js';
 import {CharOptions} from '../FontData.js';
 
 /*****************************************************************/
-/*
+/**
  *  The CHTMLTextNode wrapper for the TextNode object
- */
-
-/*
+ *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
@@ -46,7 +44,7 @@ export class CHTMLTextNode<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -62,7 +60,7 @@ export class CHTMLTextNode<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -90,7 +88,7 @@ export class CHTMLTextNode<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{string} variant   The variant in which to look for the character
      * @param{number} n         The number of the character to look up
      * @return{CharData}        The full CharData object, with CharOptions guaranteed to be defined
@@ -106,22 +104,22 @@ export class CHTMLTextNode<N, T, D> extends CHTMLWrapper<N, T, D> {
      *   are inherited from the parent nodes
      */
 
-    /*
+    /**
      * @override
      */
     public getStyles() {}
 
-    /*
+    /**
      * @override
      */
     public getVariant() {}
 
-    /*
+    /**
      * @override
      */
     public getScale() {}
 
-    /*
+    /**
      * @override
      */
     public getSpace() {}

--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -44,7 +44,7 @@ export type ActionPair = [string, [ActionHandler<any, any, any>, ActionData]];
 export type EventHandler = (event: Event) => void;
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmaction wrapper for the MmlMaction object
  *
  * @template N  The HTMLElement node class
@@ -90,7 +90,7 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * The valid action types and their handlers
      */
     public static Actions = new Map([
@@ -208,7 +208,7 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /*************************************************************/
 
-    /*
+    /**
      *  Delays before posting or clearing a math tooltip
      */
     public static postDelay = 600;
@@ -216,13 +216,13 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /*************************************************************/
 
-    /*
+    /**
      * The handler for the specified actiontype
      */
     protected action: ActionHandler<N, T, D> = null;
     protected data: ActionData = null;
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The selected child wrapper
      */
     public get selected(): CHTMLWrapper<N, T, D> {
@@ -233,7 +233,7 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /*************************************************************/
 
-    /*
+    /**
      * @override
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
@@ -245,7 +245,7 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.data = data;
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -255,14 +255,14 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.action(this, this.data);
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
         bbox.updateFrom(this.selected.getBBox());
     }
 
-    /*
+    /**
      * Add an event handler to the output for this maction
      */
     public setEventHandler(type: string, handler: EventHandler) {

--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -223,7 +223,7 @@ export class CHTMLmaction<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected data: ActionData = null;
 
     /**
-     * @return{CHTMLWrapper}  The selected child wrapper
+     * @return {CHTMLWrapper}  The selected child wrapper
      */
     public get selected(): CHTMLWrapper<N, T, D> {
         const selection = this.node.attributes.get('selection') as number;

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -28,7 +28,7 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmath wrapper for the MmlMath object
  *
  * @template N  The HTMLElement node class
@@ -70,7 +70,7 @@ export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -408,7 +408,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{number[]}  Array of the maximum extra space from the notations along each side
+     * @return {number[]}  Array of the maximum extra space from the notations along each side
      */
     protected getBBoxExtenders() {
         let TRBL = [0, 0, 0, 0];
@@ -419,7 +419,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{number[]}  Array of padding (i.e., BBox minus border) along each side
+     * @return {number[]}  Array of padding (i.e., BBox minus border) along each side
      */
     protected getPadding() {
         let TRBL = [0, 0, 0, 0];
@@ -437,8 +437,8 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Each entry in X gets replaced by the corresponding one in Y if it is larger
      *
-     * @param{number[]} X   An array of numbers
-     * @param{number[]} Y   An array of numbers that replace smaller ones in X
+     * @param {number[]} X   An array of numbers
+     * @param {number[]} Y   An array of numbers that replace smaller ones in X
      */
     protected maximizeEntries(X: number[], Y: number[]) {
         for (let i = 0; i < X.length; i++) {
@@ -459,8 +459,8 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number} m  A number to trim to 4 decimal places
-     * @return{string}   The number trimmed to 4 places, with trailing 0's removed
+     * @param {number} m  A number to trim to 4 decimal places
+     * @return {string}   The number trimmed to 4 places, with trailing 0's removed
      */
     public units(m: number) {
         if (Math.abs(m) < .001) return '0';
@@ -468,9 +468,9 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number} w   The width of the box whose diagonal is needed
-     * @param{number} h   The height of the box whose diagonal is needed
-     * @param{number[]}   The angle and width of the diagonal of the box
+     * @param {number} w   The width of the box whose diagonal is needed
+     * @param {number} h   The height of the box whose diagonal is needed
+     * @param {number[]}   The angle and width of the diagonal of the box
      */
     public getArgMod(w: number, h: number) {
         return [Math.atan2(h, w), Math.sqrt(w * w + h * h)];
@@ -479,11 +479,11 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create an svg element
      *
-     * @param{string} type       The class for the new svg element
-     * @param{number[]} box      The viewBox values for the svg element
-     * @param{N[]} nodes         The children for the svg element
-     * @param{StyleData} styles  Styles to set on the svg element, if any
-     * @return{N}                The newly created svg element
+     * @param {string} type       The class for the new svg element
+     * @param {number[]} box      The viewBox values for the svg element
+     * @param {N[]} nodes         The children for the svg element
+     * @param {StyleData} styles  Styles to set on the svg element, if any
+     * @return {N}                The newly created svg element
      */
     public svg(type: string, box: number[], nodes: N[], styles: StyleData = null) {
         const properties: OptionList = {
@@ -499,9 +499,9 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create an ellipse element
      *
-     * @param{number} w  The width of the ellipse
-     * @param{number} h  The height of the ellipse
-     * @return{N}        The newly created ellipse node
+     * @param {number} w  The width of the ellipse
+     * @param {number} h  The height of the ellipse
+     * @return {N}        The newly created ellipse node
      */
     public ellipse(w: number, h: number) {
         const t = this.thickness;
@@ -514,11 +514,11 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create a line element
      *
-     * @param{number} x1   The x-coordinate of the starting point
-     * @param{number} y1   The y-coordinate of the starting point
-     * @param{number} x2   The x-coordinate of the ending point
-     * @param{number} y2   The y-coordinate of the ending point
-     * @return{N}          The newly created line element
+     * @param {number} x1   The x-coordinate of the starting point
+     * @param {number} y1   The y-coordinate of the starting point
+     * @param {number} x2   The x-coordinate of the ending point
+     * @param {number} y2   The y-coordinate of the ending point
+     * @return {N}          The newly created line element
      */
     public line(x1: number, y1: number, x2: number, y2: number) {
         return this.adjustThickness(this.html('line', {
@@ -530,8 +530,8 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create a path element from the commands the specify it
      *
-     * @param{(string|number)[]} P   The list of commands and coordinates for the path
-     * @return{N}                    The newly created path
+     * @param {(string|number)[]} P   The list of commands and coordinates for the path
+     * @return {N}                    The newly created path
      */
     public path(...P: (string | number)[]) {
         return this.adjustThickness(this.html('path', {
@@ -543,8 +543,8 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Create a filled path element from the commands the specify it
      *   (same as path above, but no thickness adjustments)
      *
-     * @param{(string|number)[]} P   The list of commands and coordinates for the path
-     * @return{N}                    The newly created path
+     * @param {(string|number)[]} P   The list of commands and coordinates for the path
+     * @return {N}                    The newly created path
      */
     public fill(...P: (string | number)[]) {
         return this.html('path', {
@@ -555,13 +555,13 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create a arrow using an svg element
      *
-     * @param{number} w        The length of the arrow
-     * @param{number} a        The angle for the arrow
-     * @param{number} neg      The direction to shift the arrow's Y coordinate before rotating it (1 or -1)
-     * @param{string} origin   The transform-origin for the rotation
-     * @param{string} offset   The axis alogn which to offset the rotated arrow
-     * @param{number} d        The distance to offset by
-     * @param{boolean} double  True if this is a double-headed arrow
+     * @param {number} w        The length of the arrow
+     * @param {number} a        The angle for the arrow
+     * @param {number} neg      The direction to shift the arrow's Y coordinate before rotating it (1 or -1)
+     * @param {string} origin   The transform-origin for the rotation
+     * @param {string} offset   The axis alogn which to offset the rotated arrow
+     * @param {number} d        The distance to offset by
+     * @param {boolean} double  True if this is a double-headed arrow
      */
     public arrow(w: number, a: number, neg: number, origin: string, offset: string = '', d: number = 0, double: boolean = false) {
         const t = this.thickness;
@@ -599,9 +599,9 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{N} shape   The svg element whose stroke-thickness must be
+     * @param {N} shape   The svg element whose stroke-thickness must be
      *                   adjusted if the thickness isn't the default
-     * @return{N}        The adjusted element
+     * @return {N}        The adjusted element
      */
     public adjustThickness(shape: N) {
         if (this.thickness !== Notation.THICKNESS) {
@@ -611,9 +611,9 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{N} node   The HTML element whose border width must be
+     * @param {N} node   The HTML element whose border width must be
      *                  adjusted if the thickness isn't the default
-     * @return{N}       The adjusted element
+     * @return {N}       The adjusted element
      */
     public adjustBorder(node: N) {
         if (this.thickness !== Notation.THICKNESS) {
@@ -630,8 +630,8 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
      *   but without changing the parent pointer, so as not to detach it from
      *   the menclose (which would desrtoy the original MathML tree).
      *
-     * @param{CHTMLWrapper} child   The inferred mrow that is the child of this menclose
-     * @return{CHTMLmsqrt}          The newly created (but detached) msqrt wrapper
+     * @param {CHTMLWrapper} child   The inferred mrow that is the child of this menclose
+     * @return {CHTMLmsqrt}          The newly created (but detached) msqrt wrapper
      */
     public createMsqrt(child: CHTMLWrapper<N, T, D>) {
         const mmlFactory = (this.node as AbstractMmlNode).factory;
@@ -650,9 +650,9 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{number[]}  The differences between the msqrt bounding box
-     *                    and its child bounding box (i.e., the extra space
-     *                    created by the radical symbol).
+     * @return {number[]}  The differences between the msqrt bounding box
+     *                     and its child bounding box (i.e., the extra space
+     *                     created by the radical symbol).
      */
     public sqrtTRBL() {
         const bbox = this.msqrt.getBBox();

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -34,7 +34,7 @@ import {split} from '../../../util/string.js';
 
 /*****************************************************************/
 
-/*
+/**
  * The CHTMLmenclose wrapper for the MmlMenclose object
  *
  * @template N  The HTMLElement node class
@@ -44,7 +44,7 @@ import {split} from '../../../util/string.js';
 export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMenclose.prototype.kind;
 
-    /*
+    /**
      * Styles needed for the various notations
      */
     public static styles: StyleList = {
@@ -119,7 +119,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      *  The definitions of the various notations
      */
     public static Notations: Notation.DefList = new Map([
@@ -261,18 +261,18 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     ] as Notation.DefPair[]);
 
-    /*
+    /**
      *  The notations active on this menclose, and the one to use for the child, if any
      */
     protected notations: Notation.List<N, T, D> = {};
     protected renderChild: Notation.Renderer<N, T, D> = null;
 
-    /*
+    /**
      * fake msqrt for radial notation (if used)
      */
     protected msqrt: CHTMLmsqrt<N, T, D> = null;
 
-    /*
+    /**
      * The padding, thickness, and shape of the arrow head
      *   (may be overriden using data-padding, data-thickness, and data-arrowhead attibutes)
      */
@@ -280,7 +280,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
     public thickness: number = Notation.THICKNESS;
     public arrowhead = {x: Notation.ARROWX, y: Notation.ARROWY, dx: Notation.ARROWDX};
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -292,7 +292,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.initializeNotations();
     }
 
-    /*
+    /**
      * Look up the data-* attributes and override the default values
      */
     protected getParameters() {
@@ -316,7 +316,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      *  Get the notations given in the notation attribute
      *    and check if any are used to render the child nodes
      */
@@ -333,7 +333,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      *  Remove any redundant notations
      */
     protected removeRedundantNotations() {
@@ -347,7 +347,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      *  Run any initialization needed by notations in use
      */
     protected initializeNotations() {
@@ -359,7 +359,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /********************************************************/
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -392,7 +392,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -407,7 +407,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.w += R;
     }
 
-    /*
+    /**
      * @return{number[]}  Array of the maximum extra space from the notations along each side
      */
     protected getBBoxExtenders() {
@@ -418,7 +418,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return TRBL;
     }
 
-    /*
+    /**
      * @return{number[]}  Array of padding (i.e., BBox minus border) along each side
      */
     protected getPadding() {
@@ -434,7 +434,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [0, 1, 2, 3].map(i => TRBL[i] - BTRBL[i]);
     }
 
-    /*
+    /**
      * Each entry in X gets replaced by the corresponding one in Y if it is larger
      *
      * @param{number[]} X   An array of numbers
@@ -450,7 +450,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /********************************************************/
 
-    /*
+    /**
      * @override
      * (make it public so it can be called by the notation functions)
      */
@@ -458,7 +458,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return super.em(m);
     }
 
-    /*
+    /**
      * @param{number} m  A number to trim to 4 decimal places
      * @return{string}   The number trimmed to 4 places, with trailing 0's removed
      */
@@ -467,7 +467,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return m.toFixed(4).replace(/\.?0+$/, '');
     }
 
-    /*
+    /**
      * @param{number} w   The width of the box whose diagonal is needed
      * @param{number} h   The height of the box whose diagonal is needed
      * @param{number[]}   The angle and width of the diagonal of the box
@@ -476,7 +476,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [Math.atan2(h, w), Math.sqrt(w * w + h * h)];
     }
 
-    /*
+    /**
      * Create an svg element
      *
      * @param{string} type       The class for the new svg element
@@ -496,7 +496,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.html('svg', properties, nodes);
     }
 
-    /*
+    /**
      * Create an ellipse element
      *
      * @param{number} w  The width of the ellipse
@@ -511,7 +511,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }));
     }
 
-    /*
+    /**
      * Create a line element
      *
      * @param{number} x1   The x-coordinate of the starting point
@@ -527,7 +527,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }));
     }
 
-    /*
+    /**
      * Create a path element from the commands the specify it
      *
      * @param{(string|number)[]} P   The list of commands and coordinates for the path
@@ -539,7 +539,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         }));
     }
 
-    /*
+    /**
      * Create a filled path element from the commands the specify it
      *   (same as path above, but no thickness adjustments)
      *
@@ -552,7 +552,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         });
     }
 
-    /*
+    /**
      * Create a arrow using an svg element
      *
      * @param{number} w        The length of the arrow
@@ -598,7 +598,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return svg;
     }
 
-    /*
+    /**
      * @param{N} shape   The svg element whose stroke-thickness must be
      *                   adjusted if the thickness isn't the default
      * @return{N}        The adjusted element
@@ -610,7 +610,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return shape;
     }
 
-    /*
+    /**
      * @param{N} node   The HTML element whose border width must be
      *                  adjusted if the thickness isn't the default
      * @return{N}       The adjusted element
@@ -624,7 +624,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /********************************************************/
 
-    /*
+    /**
      * Create an unattached msqrt wrapper to render the 'radical' notation.
      *   We replace the inferred mrow of the msqrt with the one from the menclose
      *   but without changing the parent pointer, so as not to detach it from
@@ -649,7 +649,7 @@ export class CHTMLmenclose<N, T, D> extends CHTMLWrapper<N, T, D> {
         return node;
     }
 
-    /*
+    /**
      * @return{number[]}  The differences between the msqrt bounding box
      *                    and its child bounding box (i.e., the extra space
      *                    created by the radical symbol).

--- a/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
@@ -96,7 +96,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Wrap an mo element and push it onto the mrow
      *
-     * @param{MmlNode} node  The mo element to push on the mrow
+     * @param {MmlNode} node  The mo element to push on the mrow
      */
     protected addMo(node: MmlNode) {
         if (!node) return;

--- a/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
@@ -30,7 +30,7 @@ import {MmlNode, AbstractMmlNode, AttributeList} from '../../../core/MmlTree/Mml
 import {BBox} from '../BBox.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmfenced wrapper for the MmlMfenced object
  *
  * @template N  The HTMLElement node class
@@ -45,7 +45,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
     //
     protected mrow: CHTMLinferredMrow<N, T, D> = null;
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -55,7 +55,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.addMrowChildren();
     }
 
-    /*
+    /**
      * Creates the mrow wrapper to use for the layout
      */
     protected createMrow() {
@@ -72,7 +72,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.mrow.parent = this;
     }
 
-    /*
+    /**
      * Populate the mrow with wrapped mo elements interleaved
      *   with the mfenced children (the mo's are already created
      *   in the mfenced object)
@@ -93,7 +93,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
         mrow.stretchChildren();
     }
 
-    /*
+    /**
      * Wrap an mo element and push it onto the mrow
      *
      * @param{MmlNode} node  The mo element to push on the mrow
@@ -105,7 +105,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
         mo.parent = this.mrow;
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -114,7 +114,7 @@ export class CHTMLmfenced<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.drawBBox();
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -187,8 +187,8 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     /************************************************/
 
     /**
-     * @param{boolean} display  True when fraction is in display mode
-     * @param{number} t         The rule line thickness
+     * @param {boolean} display  True when fraction is in display mode
+     * @param {number} t         The rule line thickness
      */
     protected makeFraction(display: boolean, t: number) {
         const {numalign, denomalign} = this.node.attributes.getList('numalign', 'denomalign');
@@ -236,9 +236,9 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{BBox} bbox        The buonding box to modify
-     * @param{boolean} display  True for display-mode fractions
-     * @param{number} t         The thickness of the line
+     * @param {BBox} bbox        The buonding box to modify
+     * @param {boolean} display  True for display-mode fractions
+     * @param {number} t         The thickness of the line
      */
     protected getFractionBBox(bbox: BBox, display: boolean, t: number) {
         const nbox = this.childNodes[0].getBBox();
@@ -253,9 +253,9 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{boolean} display  True for display-mode fractions
-     * @param{number} t         The thickness of the line
-     * @return{Object}          The expanded rule thickness (T), and baeline offsets
+     * @param {boolean} display  True for display-mode fractions
+     * @param {number} t         The thickness of the line
+     * @return {Object}          The expanded rule thickness (T), and baeline offsets
      *                             for numerator and denomunator (u and v)
      */
     protected getTUV(display: boolean, t: number) {
@@ -270,7 +270,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     /************************************************/
 
     /**
-     * @param{boolean} display  True when fraction is in display mode
+     * @param {boolean} display  True when fraction is in display mode
      */
     protected makeAtop(display: boolean) {
         const {numalign, denomalign} = this.node.attributes.getList('numalign', 'denomalign');
@@ -301,8 +301,8 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{BBox} bbox        The bounding box to modify
-     * @param{boolean} display  True for display-mode fractions
+     * @param {BBox} bbox        The bounding box to modify
+     * @param {boolean} display  True for display-mode fractions
      */
     protected getAtopBBox(bbox: BBox, display: boolean) {
         const tex = this.font.params;
@@ -314,8 +314,8 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{boolean} display  True for diplay-mode fractions
-     * @return{Object}
+     * @param {boolean} display  True for diplay-mode fractions
+     * @return {Object}
      *    The vertical offsets of the numerator (u), the denominator (v),
      *    the separation between the two, and the bboxes themselves.
      */
@@ -345,7 +345,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     /************************************************/
 
     /**
-     * @param{boolean} display  True when fraction is in display mode
+     * @param {boolean} display  True when fraction is in display mode
      */
     protected makeBevelled(display: boolean) {
         const adaptor = this.adaptor;
@@ -373,8 +373,8 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{BBox} bbox        The boundng box to modify
-     * @param{boolean} display  True for display-mode fractions
+     * @param {BBox} bbox        The boundng box to modify
+     * @param {boolean} display  True for display-mode fractions
      */
     protected getBevelledBBox(bbox: BBox, display: boolean) {
         const {u, v, delta, nbox, dbox} = this.getBevelData(display);
@@ -385,8 +385,8 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{boolean} display  True for display-style fractions
-     * @return{Object}          The height (H) of the bevel, horizontal offest (delta)
+     * @param {boolean} display  True for display-style fractions
+     * @return {Object}          The height (H) of the bevel, horizontal offest (delta)
      *                             vertical offsets (u and v) of the parts, and
      *                             bounding boxes of the parts.
      */
@@ -412,7 +412,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{boolean}   True if in display mode, false otherwise
+     * @return {boolean}   True if in display mode, false otherwise
      */
     protected isDisplay() {
         const {displaystyle, scriptlevel} = this.node.attributes.getList('displaystyle', 'scriptlevel');

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -32,7 +32,7 @@ import {OptionList} from '../../../util/Options.js';
 import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmfrac wrapper for the MmlMfrac object
  *
  * @template N  The HTMLElement node class
@@ -128,7 +128,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /************************************************/
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -145,7 +145,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -164,7 +164,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -186,7 +186,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /************************************************/
 
-    /*
+    /**
      * @param{boolean} display  True when fraction is in display mode
      * @param{number} t         The rule line thickness
      */
@@ -235,7 +235,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.childNodes[1].toCHTML(den);
     }
 
-    /*
+    /**
      * @param{BBox} bbox        The buonding box to modify
      * @param{boolean} display  True for display-mode fractions
      * @param{number} t         The thickness of the line
@@ -252,7 +252,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.w += 2 * pad + .2;
     }
 
-    /*
+    /**
      * @param{boolean} display  True for display-mode fractions
      * @param{number} t         The thickness of the line
      * @return{Object}          The expanded rule thickness (T), and baeline offsets
@@ -269,7 +269,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /************************************************/
 
-    /*
+    /**
      * @param{boolean} display  True when fraction is in display mode
      */
     protected makeAtop(display: boolean) {
@@ -300,7 +300,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.childNodes[1].toCHTML(den);
     }
 
-    /*
+    /**
      * @param{BBox} bbox        The bounding box to modify
      * @param{boolean} display  True for display-mode fractions
      */
@@ -313,7 +313,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.w += 2 * pad;
     }
 
-    /*
+    /**
      * @param{boolean} display  True for diplay-mode fractions
      * @return{Object}
      *    The vertical offsets of the numerator (u), the denominator (v),
@@ -344,7 +344,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /************************************************/
 
-    /*
+    /**
      * @param{boolean} display  True when fraction is in display mode
      */
     protected makeBevelled(display: boolean) {
@@ -372,7 +372,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         adaptor.setStyle(this.bevel.chtml, 'marginRight', dx);
     }
 
-    /*
+    /**
      * @param{BBox} bbox        The boundng box to modify
      * @param{boolean} display  True for display-mode fractions
      */
@@ -384,7 +384,7 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.combine(dbox, bbox.w - delta / 2, v);
     }
 
-    /*
+    /**
      * @param{boolean} display  True for display-style fractions
      * @return{Object}          The height (H) of the bevel, horizontal offest (delta)
      *                             vertical offsets (u and v) of the parts, and
@@ -404,14 +404,14 @@ export class CHTMLmfrac<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /************************************************/
 
-    /*
+    /**
      * @override
      */
     public canStretch(direction: DIRECTION) {
         return false;
     }
 
-    /*
+    /**
      * @return{boolean}   True if in display mode, false otherwise
      */
     protected isDisplay() {

--- a/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
@@ -30,7 +30,7 @@ import {Property} from '../../../core/Tree/Node.js';
 import {StyleList, StyleData} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmglyph wrapper for the MmlMglyph object
  *
  * @template N  The HTMLElement node class
@@ -48,14 +48,14 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * The image's width, height, and voffset values converted to em's
      */
     public width: number;
     public height: number;
     public voffset: number;
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -64,7 +64,7 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.getParameters();
     }
 
-    /*
+    /**
      * Obtain the width, height, and voffset.
      * Note:  Currently, the width and height must be specified explicitly, or they default to 1em
      *   Since loading the image may be asynchronous, it would require a restart.
@@ -78,7 +78,7 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.voffset = this.length2em(voffset || '0');
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -95,7 +95,7 @@ export class CHTMLmglyph<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.adaptor.append(chtml, img);
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/mi.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mi.ts
@@ -26,7 +26,7 @@ import {MmlMi} from '../../../core/MmlTree/MmlNodes/mi.js';
 import {BBox} from '../BBox.js';
 
 /*****************************************************************/
-/*
+/**
  *  The CHTMLmi wrapper for the MmlMi object
  *
  * @template N  The HTMLElement node class
@@ -36,12 +36,12 @@ import {BBox} from '../BBox.js';
 export class CHTMLmi<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMi.prototype.kind;
 
-    /*
+    /**
      * True if no italic correction should be used
      */
     public noIC: boolean = false;
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -51,7 +51,7 @@ export class CHTMLmi<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -28,7 +28,7 @@ import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
 
-/*
+/**
  * The data about the scripts and base
  */
 export type ScriptData = {
@@ -42,7 +42,7 @@ export type ScriptData = {
 }
 export type ScriptDataName = keyof ScriptData;
 
-/*
+/**
  * The lists of all the individual script bboxes
  */
 export type ScriptLists = {
@@ -54,7 +54,7 @@ export type ScriptLists = {
 };
 export type ScriptListName = keyof ScriptLists;
 
-/*
+/**
  * The type of script that follows the given type
  */
 export const NextScript: {[key: string]: ScriptListName} = {
@@ -65,13 +65,13 @@ export const NextScript: {[key: string]: ScriptListName} = {
     psupList: 'psubList',
 };
 
-/*
+/**
  * The names of the scripts (for looping)
  */
 export const ScriptNames = ['sup', 'sup', 'psup', 'psub'] as ScriptDataName[];
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmmultiscripts wrapper for the MmlMmultiscripts object
  *
  * @template N  The HTMLElement node class
@@ -95,19 +95,19 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         }
     };
 
-    /*
+    /**
      *  The cached data for the various bounding boxes
      */
     protected scriptData: ScriptData = null;
 
-    /*
+    /**
      *  The index of the child following the <mprescripts/> tag
      */
     protected firstPrescript = 0;
 
     /*************************************************************/
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -132,7 +132,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{BBox} pre   The prescript bounding box
      * @param{BBox} post  The postcript bounding box
      * @return{BBox}      The combined bounding box
@@ -143,7 +143,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         return bbox;
     }
 
-    /*
+    /**
      * Create a table with the super and subscripts properly separated and aligned.
      *
      * @param{number} u       The baseline offset for the superscripts
@@ -174,7 +174,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
 
     /*************************************************************/
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -205,7 +205,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         bbox.clean();
     }
 
-    /*
+    /**
      * @return{ScriptData}   The bounding box information about all the scripts
      */
     protected getScriptData() {
@@ -237,7 +237,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         return this.scriptData;
     }
 
-    /*
+    /**
      * @return{ScriptLists}  The bounding boxes for all the scripts divided into lists by position
      */
     protected getScriptBBoxLists() {
@@ -269,7 +269,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         return lists;
     }
 
-    /*
+    /**
      * Pad the second list, if it is one short
      *
      * @param{BBox[]} list1   The first list
@@ -281,7 +281,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{BBox} bbox1    The bbox for the combined subscripts
      * @param{BBox} bbox2    The bbox for the combined superscripts
      * @param{BBox[]} list1  The list of subscripts to combine
@@ -301,7 +301,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{BBox} bbox  The bounding box from which to get the (scaled) width, height, and depth
      */
     protected getScaledWHD(bbox: BBox) {
@@ -311,7 +311,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
 
     /*************************************************************/
 
-    /*
+    /**
      * @override
      */
     protected getUVQ(basebox: BBox, subbox: BBox, supbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -133,9 +133,9 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     }
 
     /**
-     * @param{BBox} pre   The prescript bounding box
-     * @param{BBox} post  The postcript bounding box
-     * @return{BBox}      The combined bounding box
+     * @param {BBox} pre   The prescript bounding box
+     * @param {BBox} post  The postcript bounding box
+     * @return {BBox}      The combined bounding box
      */
     protected combinePrePost(pre: BBox, post: BBox) {
         const bbox = new BBox(pre);
@@ -146,13 +146,13 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     /**
      * Create a table with the super and subscripts properly separated and aligned.
      *
-     * @param{number} u       The baseline offset for the superscripts
-     * @param{number} v       The baseline offset for the subscripts
-     * @param{boolean} isPre  True for prescripts, false for scripts
-     * @param{BBox} sub       The subscript bounding box
-     * @param{BBox} sup       The superscript bounding box
-     * @param{number} i       The starting index for the scripts
-     * @param{number} n       The number of sub/super-scripts
+     * @param {number} u       The baseline offset for the superscripts
+     * @param {number} v       The baseline offset for the subscripts
+     * @param {boolean} isPre  True for prescripts, false for scripts
+     * @param {BBox} sub       The subscript bounding box
+     * @param {BBox} sup       The superscript bounding box
+     * @param {number} i       The starting index for the scripts
+     * @param {number} n       The number of sub/super-scripts
      */
     protected addScripts(u: number, v: number, isPre: boolean, sub: BBox, sup: BBox, i: number, n: number) {
         const adaptor = this.adaptor;
@@ -206,7 +206,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     }
 
     /**
-     * @return{ScriptData}   The bounding box information about all the scripts
+     * @return {ScriptData}   The bounding box information about all the scripts
      */
     protected getScriptData() {
         //
@@ -238,7 +238,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     }
 
     /**
-     * @return{ScriptLists}  The bounding boxes for all the scripts divided into lists by position
+     * @return {ScriptLists}  The bounding boxes for all the scripts divided into lists by position
      */
     protected getScriptBBoxLists() {
         const lists: ScriptLists = {
@@ -272,8 +272,8 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     /**
      * Pad the second list, if it is one short
      *
-     * @param{BBox[]} list1   The first list
-     * @param{BBox[]} list2   The second list
+     * @param {BBox[]} list1   The first list
+     * @param {BBox[]} list2   The second list
      */
     protected padLists(list1: BBox[], list2: BBox[]) {
         if (list1.length > list2.length) {
@@ -282,10 +282,10 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     }
 
     /**
-     * @param{BBox} bbox1    The bbox for the combined subscripts
-     * @param{BBox} bbox2    The bbox for the combined superscripts
-     * @param{BBox[]} list1  The list of subscripts to combine
-     * @param{BBox[]} list2  The list of superscripts to combine
+     * @param {BBox} bbox1    The bbox for the combined subscripts
+     * @param {BBox} bbox2    The bbox for the combined superscripts
+     * @param {BBox[]} list1  The list of subscripts to combine
+     * @param {BBox[]} list2  The list of superscripts to combine
      */
     protected combineBBoxLists(bbox1: BBox, bbox2: BBox, list1: BBox[], list2: BBox[]) {
         for (let i = 0; i < list1.length; i++) {
@@ -302,7 +302,7 @@ export class CHTMLmmultiscripts<N, T, D> extends CHTMLmsubsup<N, T, D> {
     }
 
     /**
-     * @param{BBox} bbox  The bounding box from which to get the (scaled) width, height, and depth
+     * @param {BBox} bbox  The bounding box from which to get the (scaled) width, height, and depth
      */
     protected getScaledWHD(bbox: BBox) {
         const {w, h, d, rscale} = bbox;

--- a/mathjax3-ts/output/chtml/Wrappers/mn.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mn.ts
@@ -27,7 +27,7 @@ import {MmlMn} from '../../../core/MmlTree/MmlNodes/mn.js';
 import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmn wrapper for the MmlMn object
  *
  * @template N  The HTMLElement node class
@@ -37,7 +37,7 @@ import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.
 export class CHTMLmn<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMn.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     public remapChars(chars: number[]) {

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -30,7 +30,7 @@ import {DelimiterData} from '../FontData.js';
 import {StyleList} from '../CssStyles.js';
 import {DIRECTION, NOSTRETCH} from '../FontData.js';
 
-/*
+/**
  * Convert direction to letter
  */
 const DirectionVH: {[n: number]: string} = {
@@ -39,7 +39,7 @@ const DirectionVH: {[n: number]: string} = {
 };
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmo wrapper for the MmlMo object
  *
  * @template N  The HTMLElement node class
@@ -111,23 +111,23 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     };
 
-    /*
+    /**
      * True if no italic correction should be used
      */
     public noIC: boolean = false;
 
-    /*
+    /**
      * The font size that a stretched operator uses.
      * If -1, then stretch arbitrarily, and bbox gives the actual height, depth, width
      */
     public size: number = null;
 
-    /*
+    /**
      * True if used as an accent in an munderover construct
      */
     public isAccent: boolean;
 
-    /*
+    /**
      * @override
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
@@ -135,7 +135,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.isAccent = (this.node as MmlMo).isAccent;
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -166,7 +166,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Create the HTML for a multi-character stretchy delimiter
      *
      * @param{N} chtml  The parent element in which to put the delimiter
@@ -221,7 +221,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.adaptor.append(chtml, html);
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -240,7 +240,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     protected getVariant() {
@@ -251,7 +251,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public canStretch(direction: DIRECTION) {
@@ -267,7 +267,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.stretch.dir !== DIRECTION.None;
     }
 
-    /*
+    /**
      * Determint variant for vertically/horizontally stretched character
      *
      * @param{number[]} WH  size to stretch to, either [W] or [H, D]
@@ -316,7 +316,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{string} name   The name of the attribute to get
      * @param{number} value  The default value to use
      * @return{number}       The size in em's of the attribute (or the default value)
@@ -329,7 +329,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         return value;
     }
 
-    /*
+    /**
      * @param{number[]} WH  Either [W] for width, [H, D] for height and depth, or [] for min/max size
      * @return{number}      Either the width or the total height of the character
      */
@@ -341,7 +341,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         return (this.node.attributes.get('symmetric') ? 2 * Math.max(H - a, D + a) : H + D);
     }
 
-    /*
+    /**
      * @param{number[]} WHD     The [W] or [H, D] being requested from the parent mrow
      * @param{number} D         The full dimension (including symmetry, etc)
      * @param{DelimiterData} C  The delimiter data for the stretchy character
@@ -358,7 +358,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.bbox.w = w;
     }
 
-    /*
+    /**
      * @param{number[]} WHD     The [H, D] being requested from the parent mrow
      * @param{number} HD        The full height (including symmetry, etc)
      * @param{DelimiterData} C  The delimiter data for the stretchy character
@@ -394,7 +394,7 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [h - d, d];
     }
 
-    /*
+    /**
      * @override
      */
     public remapChars(chars: number[]) {

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -169,8 +169,8 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create the HTML for a multi-character stretchy delimiter
      *
-     * @param{N} chtml  The parent element in which to put the delimiter
-     * @param{boolean} symmetric  Whether delimiter should be symmetric about the math axis
+     * @param {N} chtml  The parent element in which to put the delimiter
+     * @param {boolean} symmetric  Whether delimiter should be symmetric about the math axis
      */
     protected stretchHTML(chtml: N, symmetric: boolean) {
         const c = this.getText().charCodeAt(0);
@@ -270,8 +270,8 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Determint variant for vertically/horizontally stretched character
      *
-     * @param{number[]} WH  size to stretch to, either [W] or [H, D]
-     * @param{boolean} exact  True if not allowed to use delimiter factor and shortfall
+     * @param {number[]} WH  size to stretch to, either [W] or [H, D]
+     * @param {boolean} exact  True if not allowed to use delimiter factor and shortfall
      */
     public getStretchedVariant(WH: number[], exact: boolean = false) {
         if (this.stretch.dir !== DIRECTION.None) {
@@ -317,9 +317,9 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{string} name   The name of the attribute to get
-     * @param{number} value  The default value to use
-     * @return{number}       The size in em's of the attribute (or the default value)
+     * @param {string} name   The name of the attribute to get
+     * @param {number} value  The default value to use
+     * @return {number}       The size in em's of the attribute (or the default value)
      */
     protected getSize(name: string, value: number) {
         let attributes = this.node.attributes;
@@ -330,8 +330,8 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number[]} WH  Either [W] for width, [H, D] for height and depth, or [] for min/max size
-     * @return{number}      Either the width or the total height of the character
+     * @param {number[]} WH  Either [W] for width, [H, D] for height and depth, or [] for min/max size
+     * @return {number}      Either the width or the total height of the character
      */
     protected getWH(WH: number[]) {
         if (WH.length === 0) return 0;
@@ -342,9 +342,9 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number[]} WHD     The [W] or [H, D] being requested from the parent mrow
-     * @param{number} D         The full dimension (including symmetry, etc)
-     * @param{DelimiterData} C  The delimiter data for the stretchy character
+     * @param {number[]} WHD     The [W] or [H, D] being requested from the parent mrow
+     * @param {number} D         The full dimension (including symmetry, etc)
+     * @param {DelimiterData} C  The delimiter data for the stretchy character
      */
     protected getStretchBBox(WHD: number[], D: number, C: DelimiterData) {
         let [h, d, w] = C.HDW;
@@ -359,10 +359,10 @@ export class CHTMLmo<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number[]} WHD     The [H, D] being requested from the parent mrow
-     * @param{number} HD        The full height (including symmetry, etc)
-     * @param{DelimiterData} C  The delimiter data for the stretchy character
-     * @return{number[]}        The height and depth for the vertically stretched delimiter
+     * @param {number[]} WHD     The [H, D] being requested from the parent mrow
+     * @param {number} HD        The full height (including symmetry, etc)
+     * @param {DelimiterData} C  The delimiter data for the stretchy character
+     * @return {number[]}        The height and depth for the vertically stretched delimiter
      */
     protected getBaseline(WHD: number[], HD: number, C: DelimiterData) {
         const hasWHD = (WHD.length === 2 && WHD[0] + WHD[1] === HD);

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -29,7 +29,7 @@ import {Property} from '../../../core/Tree/Node.js';
 import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmpadded wrapper for the MmlMpadded object
  *
  * @template N  The HTMLElement node class
@@ -49,7 +49,7 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -86,7 +86,7 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Get the content bounding box, and the change in size and offsets
      *   as specified by the parameters
      *
@@ -106,7 +106,7 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [H, D, W, h - H, d - D, w - W, x, y];
     }
 
-    /*
+    /**
      * Get a particular dimension, which can be relative to any of the BBox dimensions,
      *   and can be an offset from the default size of the given dimension.
      *
@@ -130,7 +130,7 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
         return dimen;
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -90,7 +90,7 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Get the content bounding box, and the change in size and offsets
      *   as specified by the parameters
      *
-     * @return{number[]}  The original height, depth, width, the changes in height, depth,
+     * @return {number[]}  The original height, depth, width, the changes in height, depth,
      *                    and width, and the horizontal and vertical offsets of the content
      */
     protected getDimens() {
@@ -110,11 +110,11 @@ export class CHTMLmpadded<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Get a particular dimension, which can be relative to any of the BBox dimensions,
      *   and can be an offset from the default size of the given dimension.
      *
-     * @param{Property} length   The value to be converted to a length in ems
-     * @param{BBox} bbox         The bbox of the mpadded content
-     * @param{string} d          The default dimension to use for relative sizes ('w', 'h', or 'd')
-     * @param{number} m          The minimum value allowed for the dimension
-     * @return{number}           The final dimension in ems
+     * @param {Property} length   The value to be converted to a length in ems
+     * @param {BBox} bbox         The bbox of the mpadded content
+     * @param {string} d          The default dimension to use for relative sizes ('w', 'h', or 'd')
+     * @param {number} m          The minimum value allowed for the dimension
+     * @return {number}           The final dimension in ems
      */
     protected dimen(length: Property, bbox: BBox, d: string = '', m: number = null) {
         length = String(length);

--- a/mathjax3-ts/output/chtml/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mroot.ts
@@ -92,10 +92,10 @@ export class CHTMLmroot<N, T, D> extends CHTMLmsqrt<N, T, D> {
     }
 
     /**
-     * @param{BBox} rbox      The bbox of the root
-     * @param{BBox} sbox      The bbox of the surd
-     * @param{number} size    The size of the surd
-     * @return{number}        The height of the root within the surd
+     * @param {BBox} rbox      The bbox of the root
+     * @param {BBox} sbox      The bbox of the surd
+     * @param {number} size    The size of the surd
+     * @return {number}        The height of the root within the surd
      */
     protected rootHeight(rbox: BBox, sbox: BBox, size: number) {
         const H = sbox.h + sbox.d;

--- a/mathjax3-ts/output/chtml/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mroot.ts
@@ -29,7 +29,7 @@ import {MmlMroot} from '../../../core/MmlTree/MmlNodes/mroot.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmroot wrapper for the MmlMroot object (extends CHTMLmsqrt)
  *
  * @template N  The HTMLElement node class
@@ -39,21 +39,21 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 export class CHTMLmroot<N, T, D> extends CHTMLmsqrt<N, T, D> {
     public static kind = MmlMroot.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     get surd() {
         return 2;
     }
 
-    /*
+    /**
      * @override
      */
     get root(): number {
         return 1;
     }
 
-    /*
+    /**
      * @override
      */
     protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox) {
@@ -67,7 +67,7 @@ export class CHTMLmroot<N, T, D> extends CHTMLmsqrt<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     protected combineRootBBox(BBOX: BBox, sbox: BBox) {
@@ -76,7 +76,7 @@ export class CHTMLmroot<N, T, D> extends CHTMLmsqrt<N, T, D> {
         BBOX.combine(bbox, 0, h);
     }
 
-    /*
+    /**
      * @override
      */
     protected getRootDimens(sbox: BBox) {
@@ -91,7 +91,7 @@ export class CHTMLmroot<N, T, D> extends CHTMLmsqrt<N, T, D> {
         return [x, h, dx];
     }
 
-    /*
+    /**
      * @param{BBox} rbox      The bbox of the root
      * @param{BBox} sbox      The bbox of the surd
      * @param{number} size    The size of the surd

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -29,7 +29,7 @@ import {BBox} from '../BBox.js';
 import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmrow wrapper for the MmlMrow object
  *
  * @template N  The HTMLElement node class
@@ -39,7 +39,7 @@ import {DIRECTION} from '../FontData.js';
 export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMrow.prototype.kind;
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -54,7 +54,7 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -78,7 +78,7 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Handle vertical stretching of children to match height of
      *  other nodes in the row.
      */
@@ -122,14 +122,14 @@ export class CHTMLmrow<N, T, D> extends CHTMLWrapper<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  *  The CHTMLinferredMrow wrapper for the MmlInferredMrow object
  */
 
 export class CHTMLinferredMrow<N, T, D> extends CHTMLmrow<N, T, D> {
     public static kind = MmlInferredMrow.prototype.kind;
 
-    /*
+    /**
      * Since inferred rows don't produce a container span, we can't
      * set a font-size for it, so we inherit the parent scale
      *

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -27,7 +27,7 @@ import {MmlMs} from '../../../core/MmlTree/MmlNodes/ms.js';
 import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLms wrapper for the MmlMs object
  *
  * @template N  The HTMLElement node class
@@ -37,7 +37,7 @@ import {MmlNode, AbstractMmlNode, TextNode} from '../../../core/MmlTree/MmlNode.
 export class CHTMLms<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMs.prototype.kind;
 
-    /*
+    /**
      * Add the quote characters to the wrapper children so they will be output
      *
      * @override
@@ -54,7 +54,7 @@ export class CHTMLms<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.childNodes.push(this.createText(quotes.rquote as string));
     }
 
-    /*
+    /**
      * Create a text wrapper with the given text;
      *
      * @param{string} text  The text for the wrapped element

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -57,8 +57,8 @@ export class CHTMLms<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Create a text wrapper with the given text;
      *
-     * @param{string} text  The text for the wrapped element
-     * @return{CHTMLWrapper}   The wrapped text node
+     * @param {string} text  The text for the wrapped element
+     * @return {CHTMLWrapper}   The wrapped text node
      */
     protected createText(text: string) {
         const node = this.wrap(this.mmlText(text));

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -27,7 +27,7 @@ import {MmlMspace} from '../../../core/MmlTree/MmlNodes/mspace.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmspace wrapper for the MmlMspace object
  *
  * @template N  The HTMLElement node class
@@ -37,7 +37,7 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 export class CHTMLmspace<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlMspace.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -59,7 +59,7 @@ export class CHTMLmspace<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -69,7 +69,7 @@ export class CHTMLmspace<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.d = this.length2em(attributes.get('depth'), 0);
     }
 
-    /*
+    /**
      * No contents, so no need for variant class
      *
      * @override

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -64,21 +64,21 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     };
 
     /**
-     * @return{number}  The index of the base of the root in childNodes
+     * @return {number}  The index of the base of the root in childNodes
      */
     get base() {
         return 0;
     }
 
     /**
-     * @return{number}  The index of the surd in childNodes
+     * @return {number}  The index of the surd in childNodes
      */
     get surd() {
         return 1;
     }
 
     /**
-     * @return{number}  The index of the root in childNodes (or null if none)
+     * @return {number}  The index of the root in childNodes (or null if none)
      */
     get root(): number {
         return null;
@@ -158,9 +158,9 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Add root HTML (overridden in mroot)
      *
-     * @param{N} ROOT   The container for the root
-     * @param{CHTMLWrapper} root  The wrapped MML root content
-     * @param{BBox} sbox          The bounding box of the surd
+     * @param {N} ROOT   The container for the root
+     * @param {CHTMLWrapper} root  The wrapped MML root content
+     * @param {BBox} sbox          The bounding box of the surd
      */
     protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox) {
     }
@@ -185,15 +185,15 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Combine the bounding box of the root (overridden in mroot)
      *
-     * @param{BBox} bbox  The bounding box so far
-     * @param{BBox} sbox  The bounding box of the surd
+     * @param {BBox} bbox  The bounding box so far
+     * @param {BBox} sbox  The bounding box of the surd
      */
     protected combineRootBBox(bbox: BBox, sbox: BBox) {
     }
 
     /**
-     * @param{BBox} sbox  The bounding box for the surd character
-     * @return{number[]}  The p, q, and x values for the TeX layout computations
+     * @param {BBox} sbox  The bounding box for the surd character
+     * @return {number[]}  The p, q, and x values for the TeX layout computations
      */
     protected getPQ(sbox: BBox) {
         const t = this.font.params.rule_thickness;
@@ -203,8 +203,8 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{BBox} sbox  The bounding box of the surd
-     * @return{number[]}  The x offset of the surd, and the height, x offset, and scale of the root
+     * @param {BBox} sbox  The bounding box of the surd
+     * @return {number[]}  The x offset of the surd, and the height, x offset, and scale of the root
      */
     protected getRootDimens(sbox: BBox) {
         return [0, 0, 0, 0];

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -31,7 +31,7 @@ import {StyleList} from '../CssStyles.js';
 import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmsqrt wrapper for the MmlMsqrt object
  *
  * @template N  The HTMLElement node class
@@ -63,33 +63,33 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @return{number}  The index of the base of the root in childNodes
      */
     get base() {
         return 0;
     }
 
-    /*
+    /**
      * @return{number}  The index of the surd in childNodes
      */
     get surd() {
         return 1;
     }
 
-    /*
+    /**
      * @return{number}  The index of the root in childNodes (or null if none)
      */
     get root(): number {
         return null;
     }
 
-    /*
+    /**
      * The requested height of the stretched surd character
      */
     protected surdH: number;
 
-    /*
+    /**
      * Add the surd character so we can display it later
      *
      * @override
@@ -105,7 +105,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         surd.getStretchedVariant([this.surdH - d, d], true);
     }
 
-    /*
+    /**
      * @override
      */
     protected createMo(text: string) {
@@ -114,7 +114,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         return node;
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -155,7 +155,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add root HTML (overridden in mroot)
      *
      * @param{N} ROOT   The container for the root
@@ -165,7 +165,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox) {
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -182,7 +182,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.clean();
     }
 
-    /*
+    /**
      * Combine the bounding box of the root (overridden in mroot)
      *
      * @param{BBox} bbox  The bounding box so far
@@ -191,7 +191,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected combineRootBBox(bbox: BBox, sbox: BBox) {
     }
 
-    /*
+    /**
      * @param{BBox} sbox  The bounding box for the surd character
      * @return{number[]}  The p, q, and x values for the TeX layout computations
      */
@@ -202,7 +202,7 @@ export class CHTMLmsqrt<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [p, q];
     }
 
-    /*
+    /**
      * @param{BBox} sbox  The bounding box of the surd
      * @return{number[]}  The x offset of the surd, and the height, x offset, and scale of the root
      */

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -30,7 +30,7 @@ import {BBox} from '../BBox.js';
 import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmsub wrapper for the MmlMsub object
  *
  * @template N  The HTMLElement node class
@@ -40,14 +40,14 @@ import {StyleList} from '../CssStyles.js';
 export class CHTMLmsub<N, T, D> extends CHTMLscriptbase<N, T, D> {
     public static kind = MmlMsub.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     public get script() {
         return this.childNodes[(this.node as MmlMsub).sub];
     }
 
-    /*
+    /**
      * Get the shift for the subscript
      *
      * @override
@@ -59,7 +59,7 @@ export class CHTMLmsub<N, T, D> extends CHTMLscriptbase<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmsup wrapper for the MmlMsup object
  *
  * @template N  The HTMLElement node class
@@ -71,14 +71,14 @@ export class CHTMLmsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
 
     public static useIC: boolean = true;
 
-    /*
+    /**
      * @override
      */
     public get script() {
         return this.childNodes[(this.node as MmlMsup).sup];
     }
 
-    /*
+    /**
      * Get the shift for the superscript
      *
      * @override
@@ -91,7 +91,7 @@ export class CHTMLmsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmsubsup wrapper for the MmlMsubsup object
  *
  * @template N  The HTMLElement node class
@@ -113,27 +113,27 @@ export class CHTMLmsubsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
 
     public static noIC: boolean = true;
 
-    /*
+    /**
      *  Cached values for the script offsets and separation (so if they are
      *  computed in computeBBox(), they don't have to be recomputed for toCHTML())
      */
     protected UVQ: number[] = null;
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The wrapper for the subscript
      */
     public get subChild() {
         return this.childNodes[(this.node as MmlMsubsup).sub];
     }
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The wrapper for the superscript
      */
     public get supChild() {
         return this.childNodes[(this.node as MmlMsubsup).sup];
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -152,7 +152,7 @@ export class CHTMLmsubsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -169,7 +169,7 @@ export class CHTMLmsubsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
         bbox.clean();
     }
 
-    /*
+    /**
      * Get the shift for the scripts and their separation (TeXBook Appendix G 18adef)
      *
      * @param{BBox} basebox    The bounding box of the base

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -120,14 +120,14 @@ export class CHTMLmsubsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
     protected UVQ: number[] = null;
 
     /**
-     * @return{CHTMLWrapper}  The wrapper for the subscript
+     * @return {CHTMLWrapper}  The wrapper for the subscript
      */
     public get subChild() {
         return this.childNodes[(this.node as MmlMsubsup).sub];
     }
 
     /**
-     * @return{CHTMLWrapper}  The wrapper for the superscript
+     * @return {CHTMLWrapper}  The wrapper for the superscript
      */
     public get supChild() {
         return this.childNodes[(this.node as MmlMsubsup).sup];
@@ -172,10 +172,10 @@ export class CHTMLmsubsup<N, T, D> extends CHTMLscriptbase<N, T, D> {
     /**
      * Get the shift for the scripts and their separation (TeXBook Appendix G 18adef)
      *
-     * @param{BBox} basebox    The bounding box of the base
-     * @param{BBox} subbox     The bounding box of the superscript
-     * @param{BBox} supbox     The bounding box of the subscript
-     * @return{number[]}       The vertical offsets for super and subscripts, and the space between them
+     * @param {BBox} basebox    The bounding box of the base
+     * @param {BBox} subbox     The bounding box of the superscript
+     * @param {BBox} supbox     The bounding box of the subscript
+     * @return {number[]}       The vertical offsets for super and subscripts, and the space between them
      */
     protected getUVQ(basebox: BBox, subbox: BBox, supbox: BBox) {
         if (this.UVQ) return this.UVQ;

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -32,7 +32,7 @@ import {DIRECTION} from '../FontData.js';
 import {split, isPercent} from '../../../util/string.js';
 import {sum, max} from '../../../util/numeric.js';
 
-/*
+/**
  * The heights, depths, and widths of the rows and columns
  * Plus the natural height and depth (i.e., without the labels)
  * Plus the label column width
@@ -47,7 +47,7 @@ export type TableData = {
 };
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmtable wrapper for the MmlMtable object
  *
  * @template N  The HTMLElement node class
@@ -107,18 +107,18 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * The column for labels
      */
     public labels: N;
 
-    /*
+    /**
      * The number of columns and rows in the table
      */
     protected numCols: number = 0;
     protected numRows: number = 0;
 
-    /*
+    /**
      * The spacing and line data
      */
     protected frame: boolean;
@@ -129,13 +129,13 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected rLines: number[];
     protected cWidths: (number | string)[];
 
-    /*
+    /**
      * The bounding box information for the table rows and columns
      */
     protected data: TableData = null;
 
 
-    /*
+    /**
      * @return{CHTMLmtr[]}  The rows of the table
      */
     get tableRows() {
@@ -144,7 +144,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -175,7 +175,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.stretchColumns();
     }
 
-    /*
+    /**
      * If the table has a precentage width or has labels, set the pwidth of the bounding box
      */
     protected getPercentageWidth() {
@@ -191,7 +191,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Stretch the rows to the equal height or natural height
      */
     protected stretchRows() {
@@ -205,7 +205,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Stretch the columns to their proper widths
      */
     protected stretchColumns() {
@@ -215,7 +215,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Handle horizontal stretching within the ith column
      *
      * @param{number} i   The column number
@@ -271,7 +271,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -303,7 +303,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.shiftColor();
     }
 
-    /*
+    /**
      * Move background color (if any) to inner itable node so that labeled tables are
      * only colored on the main part of the table.
      */
@@ -317,7 +317,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * Determine the row heights and depths, the column widths,
      * and the natural width and height of the table.
      */
@@ -349,7 +349,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.data;
     }
 
-    /*
+    /**
      * @param{CHTMLWrapper} cell    The cell whose height, depth, and width are to be added into the H, D, W arrays
      * @param{number} i             The column number for the cell
      * @param{number} j             The row number for the cell
@@ -366,7 +366,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         if (W && w > W[i]) W[i] = w;
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -412,7 +412,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.w = width;
     }
 
-    /*
+    /**
      * @param{number} height   The total height of the table
      * @return{number[]}       The [height, depth] for the aligned table
      */
@@ -437,7 +437,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * Pad any short rows with extra cells
      */
     protected padRows() {
@@ -448,7 +448,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Set the inter-column spacing for all columns
      *  (Use frame spacing on the outsides, if needed, and use half the column spacing on each
      *   neighboring column, so that if column lines are needed, they fall in the middle
@@ -486,7 +486,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add borders to the left of cells to make the column lines
      */
     protected handleColumnLines() {
@@ -503,7 +503,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add widths to the cells for the column widths
      */
     protected handleColumnWidths() {
@@ -521,7 +521,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Set the inter-row spacing for all rows
      *  (Use frame spacing on the outsides, if needed, and use half the row spacing on each
      *   neighboring row, so that if row lines are needed, they fall in the middle
@@ -558,7 +558,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add borders to the tops of cells to make the row lines
      */
     protected handleRowLines() {
@@ -575,7 +575,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Set the heights of all rows to be the same, and properly center
      * baseline or axis rows within the newly sized
      */
@@ -596,7 +596,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Set the height of the row, and make sure that the baseline is in the right position for cells
      *   that are row aligned to baseline ot axis
      *
@@ -617,7 +617,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Make sure the baseline is in the correct place for cells aligned on baseline or axis
      *
      * @param{CHTMLWrapper} cell  The cell to modify
@@ -642,7 +642,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return false;
     }
 
-    /*
+    /**
      * Add a frame to the mtable, if needed
      */
     protected handleFrame() {
@@ -652,7 +652,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Handle percentage widths and fixed widths
      */
     protected handleWidth() {
@@ -666,7 +666,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.adaptor.setStyle(table, 'minWidth', w);
     }
 
-    /*
+    /**
      * Handle alignment of table to surrounding baseline
      */
     protected handleAlign() {
@@ -682,7 +682,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Mark the alignment of the table
      */
     protected handleJustify() {
@@ -694,7 +694,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * Handle addition of labels to the table
      */
     protected handleLabels() {
@@ -740,7 +740,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         adaptor.append(this.chtml, labels);
     }
 
-    /*
+    /**
      * Update any rows that are not naturally tall enough for the labels,
      *   and set the baseline for labels that are baseline aligned.
      */
@@ -758,7 +758,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Add spacing elements between the label rows so align them with the rest of the table
      */
     protected addLabelSpacing() {
@@ -788,7 +788,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * Get the maximum height of a row
      */
     protected getEqualRowHeight() {
@@ -797,7 +797,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return Math.max.apply(Math, HD);
     }
 
-    /*
+    /**
      * Determine the column widths that can be computed (and need to be set).
      * The resulting arrays will have numbers for fixed-size arrays,
      *   strings for percentage sizes that can't be determined now,
@@ -822,7 +822,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.getColumnWidthsFixed(swidths, this.length2em(width));
     }
 
-    /*
+    /**
      * For tables with equal columns, get the proper amount per row.
      *
      * @return{(string|number|null)[]}  The array of widths
@@ -842,7 +842,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return Array(this.numCols).fill(cwidth);
     }
 
-    /*
+    /**
      * For tables with width="auto", auto and fit columns
      * will end up being natural width, so don't need to
      * set those explicitly.
@@ -857,7 +857,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         });
     }
 
-    /*
+    /**
      * For tables with percentage widths, let 'fit' columns (or 'auto'
      * columns if there are not 'fit' ones) will stretch automatically,
      * but for 'auto' columns (when there are 'fit' ones), set the size
@@ -877,7 +877,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         });
     }
 
-    /*
+    /**
      * For fixed-width tables, compute the column widths of all columns.
      *
      * @return{(string|number|null)[]}  The array of widths
@@ -918,7 +918,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         });
     }
 
-    /*
+    /**
      * @param{number} i      The row number (starting at 0)
      * @param{string} align  The alignment on that row
      * @return{number}       The offest of the alignment position from the top of the table
@@ -959,7 +959,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     /******************************************************************/
 
-    /*
+    /**
      * @param{number} fspace   The frame spacing to use
      * @param{number[]} space  The array of spacing values to convert to strings
      * @return{string[]}       The half-spacing as stings with units of "em"
@@ -976,7 +976,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return spaceEm;
     }
 
-    /*
+    /**
      * @return{number[]}   The half-spacing for rows with frame spacing at the ends
      */
     protected getRowHalfSpacing() {
@@ -986,7 +986,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return space;
     }
 
-    /*
+    /**
      * @return{[string,number|null]}  The alignment and row number (based at 0) or null
      */
     protected getAlignmentRow(): [string, number] {
@@ -997,7 +997,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [align, i < 1 || i > this.numRows ? null : i - 1];
     }
 
-    /*
+    /**
      * @param{string} name           The name of the attribute to get as an array
      * @param{number} i              Return this many fewer than numCols entries
      * @return{string[]}             The array of values in the given attribute, split at spaces,
@@ -1016,7 +1016,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return columns;
     }
 
-    /*
+    /**
      * @param{string} name           The name of the attribute to get as an array
      * @param{number} i              Return this many fewer than numRows entries
      * @return{string[]}             The array of values in the given attribute, split at spaces,
@@ -1035,7 +1035,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return rows;
     }
 
-    /*
+    /**
      * @param{string} name           The name of the attribute to get as an array
      * @return{string[]}             The array of values in the given attribute, split at spaces
      *                                 (after leading and trailing spaces are removed, and multiple
@@ -1047,7 +1047,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return split(value);
     }
 
-    /*
+    /**
      * Adds "em" to a list of dimensions, after dividing by n (defaults to 1).
      *
      * @param{string[]} list   The array of dimensions (in em's)
@@ -1059,7 +1059,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
         return list.map(x => this.em(x / n));
     }
 
-    /*
+    /**
      * Converts an array of dimensions (with arbitrary units) to an array of numbers
      *   representing the dimensions in units of em's.
      *

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -136,7 +136,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
 
 
     /**
-     * @return{CHTMLmtr[]}  The rows of the table
+     * @return {CHTMLmtr[]}  The rows of the table
      */
     get tableRows() {
         return this.childNodes as CHTMLmtr<N, T, D>[];
@@ -218,8 +218,8 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Handle horizontal stretching within the ith column
      *
-     * @param{number} i   The column number
-     * @param{number} W   The computed width of the column (or null of not computed)
+     * @param {number} i   The column number
+     * @param {number} W   The computed width of the column (or null of not computed)
      */
     protected stretchColumn(i: number, W: number) {
         let stretchy: CHTMLWrapper<N, T, D>[] = [];
@@ -350,12 +350,12 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{CHTMLWrapper} cell    The cell whose height, depth, and width are to be added into the H, D, W arrays
-     * @param{number} i             The column number for the cell
-     * @param{number} j             The row number for the cell
-     * @param{number[]} H           The maximum height for each of the rows
-     * @param{number[]} D           The maximum depth for each of the rows
-     * @param{number[]} W           The maximum width for each column
+     * @param {CHTMLWrapper} cell    The cell whose height, depth, and width are to be added into the H, D, W arrays
+     * @param {number} i             The column number for the cell
+     * @param {number} j             The row number for the cell
+     * @param {number[]} H           The maximum height for each of the rows
+     * @param {number[]} D           The maximum depth for each of the rows
+     * @param {number[]} W           The maximum width for each column
      */
     protected updateHDW(cell: CHTMLWrapper<N, T, D>, i: number, j: number, H: number[], D: number[], W: number[] = null) {
         let {h, d, w} = cell.getBBox();
@@ -413,8 +413,8 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number} height   The total height of the table
-     * @return{number[]}       The [height, depth] for the aligned table
+     * @param {number} height   The total height of the table
+     * @return {number[]}       The [height, depth] for the aligned table
      */
     protected getBBoxHD(height: number) {
         const [align, row] = this.getAlignmentRow();
@@ -600,10 +600,10 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Set the height of the row, and make sure that the baseline is in the right position for cells
      *   that are row aligned to baseline ot axis
      *
-     * @param{CHTMLWrapper} row   The row to be set
-     * @param{number} HD          The total height+depth for the row
-     * @param{number] D           The new depth for the row
-     * @param{number} space       The total spacing above and below the row
+     * @param {CHTMLWrapper} row   The row to be set
+     * @param {number} HD          The total height+depth for the row
+     * @param {number] D           The new depth for the row
+     * @param {number} space       The total spacing above and below the row
      */
     protected setRowHeight(row: CHTMLWrapper<N, T, D>, HD: number, D: number, space: number) {
         this.adaptor.setStyle(row.chtml, 'height', this.em(HD + space));
@@ -620,11 +620,11 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Make sure the baseline is in the correct place for cells aligned on baseline or axis
      *
-     * @param{CHTMLWrapper} cell  The cell to modify
-     * @param{string} ralign      The alignment of the row
-     * @param{number} HD          The total height+depth for the row
-     * @param{number] D           The new depth for the row
-     * @return{boolean}           True if no other cells in this row need to be processed
+     * @param {CHTMLWrapper} cell  The cell to modify
+     * @param {string} ralign      The alignment of the row
+     * @param {number} HD          The total height+depth for the row
+     * @param {number] D           The new depth for the row
+     * @return {boolean}           True if no other cells in this row need to be processed
      */
     protected setCellBaseline(cell: CHTMLWrapper<N, T, D>, ralign: string, HD: number, D: number) {
         const calign = cell.node.attributes.get('rowalign');
@@ -805,7 +805,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Depending on the width specified for the table, different column
      *  values can be determined.
      *
-     * @return{(string|number|null)[]}  The array of widths
+     * @return {(string|number|null)[]}  The array of widths
      */
     protected getColumnWidths() {
         const width = this.node.attributes.get('width') as string;
@@ -825,7 +825,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * For tables with equal columns, get the proper amount per row.
      *
-     * @return{(string|number|null)[]}  The array of widths
+     * @return {(string|number|null)[]}  The array of widths
      */
     protected getEqualColumns(width: string) {
         const n = Math.max(1, this.numCols);
@@ -847,7 +847,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      * will end up being natural width, so don't need to
      * set those explicitly.
      *
-     * @return{(string|number|null)[]}  The array of widths
+     * @return {(string|number|null)[]}  The array of widths
      */
     protected getColumnWidthsAuto(swidths: string[]) {
         return swidths.map(x => {
@@ -863,7 +863,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      * but for 'auto' columns (when there are 'fit' ones), set the size
      * to the natural size of the column.
      *
-     * @return{(string|number|null)[]}  The array of widths
+     * @return {(string|number|null)[]}  The array of widths
      */
     protected getColumnWidthsPercent(swidths: string[], width: string) {
         const hasFit = swidths.indexOf('fit') >= 0;
@@ -880,7 +880,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * For fixed-width tables, compute the column widths of all columns.
      *
-     * @return{(string|number|null)[]}  The array of widths
+     * @return {(string|number|null)[]}  The array of widths
      */
     protected getColumnWidthsFixed(swidths: string[], width: number) {
         //
@@ -919,9 +919,9 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{number} i      The row number (starting at 0)
-     * @param{string} align  The alignment on that row
-     * @return{number}       The offest of the alignment position from the top of the table
+     * @param {number} i      The row number (starting at 0)
+     * @param {string} align  The alignment on that row
+     * @return {number}       The offest of the alignment position from the top of the table
      */
     protected getVerticalPosition(i: number, align: string) {
         const equal = this.node.attributes.get('equalrows') as boolean;
@@ -960,9 +960,9 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /******************************************************************/
 
     /**
-     * @param{number} fspace   The frame spacing to use
-     * @param{number[]} space  The array of spacing values to convert to strings
-     * @return{string[]}       The half-spacing as stings with units of "em"
+     * @param {number} fspace   The frame spacing to use
+     * @param {number[]} space  The array of spacing values to convert to strings
+     * @return {string[]}       The half-spacing as stings with units of "em"
      *                           with frame spacing at the beginning and end
      */
     protected getEmHalfSpacing(fspace: number, space: number[]) {
@@ -977,7 +977,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{number[]}   The half-spacing for rows with frame spacing at the ends
+     * @return {number[]}   The half-spacing for rows with frame spacing at the ends
      */
     protected getRowHalfSpacing() {
         const space = this.rSpace.map(x => x / 2);
@@ -987,7 +987,7 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{[string,number|null]}  The alignment and row number (based at 0) or null
+     * @return {[string,number|null]}  The alignment and row number (based at 0) or null
      */
     protected getAlignmentRow(): [string, number] {
         const [align, row] = split(this.node.attributes.get('align') as string);
@@ -998,9 +998,9 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{string} name           The name of the attribute to get as an array
-     * @param{number} i              Return this many fewer than numCols entries
-     * @return{string[]}             The array of values in the given attribute, split at spaces,
+     * @param {string} name           The name of the attribute to get as an array
+     * @param {number} i              Return this many fewer than numCols entries
+     * @return {string[]}             The array of values in the given attribute, split at spaces,
      *                                 padded to the number of table columns (minus 1) by repeating the last entry
      */
     protected getColumnAttributes(name: string, i: number = 1) {
@@ -1017,9 +1017,9 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{string} name           The name of the attribute to get as an array
-     * @param{number} i              Return this many fewer than numRows entries
-     * @return{string[]}             The array of values in the given attribute, split at spaces,
+     * @param {string} name           The name of the attribute to get as an array
+     * @param {number} i              Return this many fewer than numRows entries
+     * @return {string[]}             The array of values in the given attribute, split at spaces,
      *                                 padded to the number of table rows (minus 1) by repeating the last entry
      */
     protected getRowAttributes(name: string, i: number = 1) {
@@ -1036,8 +1036,8 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{string} name           The name of the attribute to get as an array
-     * @return{string[]}             The array of values in the given attribute, split at spaces
+     * @param {string} name           The name of the attribute to get as an array
+     * @return {string[]}             The array of values in the given attribute, split at spaces
      *                                 (after leading and trailing spaces are removed, and multiple
      *                                  spaces have been collapsed to one).
      */
@@ -1050,9 +1050,9 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Adds "em" to a list of dimensions, after dividing by n (defaults to 1).
      *
-     * @param{string[]} list   The array of dimensions (in em's)
-     * @param{nunber} n        The number to divide each dimension by after converted
-     * @return{string[]}       The array of values with "em" added
+     * @param {string[]} list   The array of dimensions (in em's)
+     * @param {nunber} n        The number to divide each dimension by after converted
+     * @return {string[]}       The array of values with "em" added
      */
     protected addEm(list: number[], n: number = 1) {
         if (!list) return;
@@ -1063,8 +1063,8 @@ export class CHTMLmtable<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Converts an array of dimensions (with arbitrary units) to an array of numbers
      *   representing the dimensions in units of em's.
      *
-     * @param{string[]} list   The array of dimensions to be turned into em's
-     * @return{number[]}       The array of values converted to em's
+     * @param {string[]} list   The array of dimensions to be turned into em's
+     * @return {number[]}       The array of values converted to em's
      */
     protected convertLengths(list: string[]) {
         if (!list) return;

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -28,7 +28,7 @@ import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
 import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmtd wrapper for the MmlMtd object
  *
  * @template N  The HTMLElement node class
@@ -90,7 +90,7 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -65,36 +65,36 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
     };
 
     /**
-     * @return{number}   The number of mtd's in the mtr
+     * @return {number}   The number of mtd's in the mtr
      */
     get numCells() {
         return this.childNodes.length;
     }
 
     /**
-     * @return{boolean}   True if this is a labeled row
+     * @return {boolean}   True if this is a labeled row
      */
     get labeled() {
         return false;
     }
 
     /**
-     * @return{CHTMLmtd[]}  The child nodes that are part of the table (no label node)
+     * @return {CHTMLmtd[]}  The child nodes that are part of the table (no label node)
      */
     get tableCells() {
         return this.childNodes as CHTMLmtd<N, T, D>[];
     }
 
     /**
-     * @param{nunber} i   The index of the child to get (skipping labels)
-     * @return{Wrapper}   The ith child node wrapper
+     * @param {nunber} i   The index of the child to get (skipping labels)
+     * @return {Wrapper}   The ith child node wrapper
      */
     public getChild(i: number) {
         return this.childNodes[i] as CHTMLmtd<N, T, D>;
     }
 
     /**
-     * @return{BBox[]}  An array of the bounding boxes for the mtd's in the row
+     * @return {BBox[]}  An array of the bounding boxes for the mtd's in the row
      */
     public getChildBBoxes() {
         return this.childNodes.map(cell => cell.getBBox());
@@ -115,7 +115,7 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
      * Handle vertical stretching of cells to match height of
      *  other cells in the row.
      *
-     * @param{number[]} HD   The total height and depth for the row [H, D]
+     * @param {number[]} HD   The total height and depth for the row [H, D]
      *
      * If this isn't specified, the maximum height and depth is computed.
      */

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -33,7 +33,7 @@ import {StyleList} from '../CssStyles.js';
 import {DIRECTION} from '../FontData.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmtr wrapper for the MmlMtr object
  *
  * @template N  The HTMLElement node class
@@ -64,28 +64,28 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @return{number}   The number of mtd's in the mtr
      */
     get numCells() {
         return this.childNodes.length;
     }
 
-    /*
+    /**
      * @return{boolean}   True if this is a labeled row
      */
     get labeled() {
         return false;
     }
 
-    /*
+    /**
      * @return{CHTMLmtd[]}  The child nodes that are part of the table (no label node)
      */
     get tableCells() {
         return this.childNodes as CHTMLmtd<N, T, D>[];
     }
 
-    /*
+    /**
      * @param{nunber} i   The index of the child to get (skipping labels)
      * @return{Wrapper}   The ith child node wrapper
      */
@@ -93,14 +93,14 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.childNodes[i] as CHTMLmtd<N, T, D>;
     }
 
-    /*
+    /**
      * @return{BBox[]}  An array of the bounding boxes for the mtd's in the row
      */
     public getChildBBoxes() {
         return this.childNodes.map(cell => cell.getBBox());
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -111,7 +111,7 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * Handle vertical stretching of cells to match height of
      *  other cells in the row.
      *
@@ -169,7 +169,7 @@ export class CHTMLmtr<N, T, D> extends CHTMLWrapper<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLlabeledmtr wrapper for the MmlMlabeledtr object
  *
  * @template N  The HTMLElement node class
@@ -200,7 +200,7 @@ export class CHTMLmlabeledtr<N, T, D> extends CHTMLmtr<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -218,7 +218,7 @@ export class CHTMLmlabeledtr<N, T, D> extends CHTMLmtr<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     get numCells() {
@@ -228,28 +228,28 @@ export class CHTMLmlabeledtr<N, T, D> extends CHTMLmtr<N, T, D> {
         return Math.max(0, this.childNodes.length - 1);
     }
 
-    /*
+    /**
      * @override
      */
     get labeled() {
         return true;
     }
 
-    /*
+    /**
      * @override
      */
     get tableCells() {
         return this.childNodes.slice(1) as CHTMLmtd<N, T, D>[];
     }
 
-    /*
+    /**
      * @override
      */
     public getChild(i: number) {
         return this.childNodes[i + 1] as CHTMLmtd<N, T, D>;
     }
 
-    /*
+    /**
      * @override
      */
     public getChildBBoxes() {

--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -32,7 +32,7 @@ import {BBox} from '../BBox.js';
 import {StyleList} from '../CssStyles.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmunder wrapper for the MmlMunder object
  *
  * @template N  The HTMLElement node class
@@ -59,14 +59,14 @@ export class CHTMLmunder<N, T, D> extends CHTMLmsub<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public get script() {
         return this.childNodes[(this.node as MmlMunder).under];
     }
 
-    /*
+    /**
      * @override
      * @constructor
      */
@@ -75,7 +75,7 @@ export class CHTMLmunder<N, T, D> extends CHTMLmsub<N, T, D> {
         this.stretchChildren();
     }
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -104,7 +104,7 @@ export class CHTMLmunder<N, T, D> extends CHTMLmsub<N, T, D> {
         this.adjustUnderDepth(under, underbox);
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -128,7 +128,7 @@ export class CHTMLmunder<N, T, D> extends CHTMLmsub<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLmover wrapper for the MmlMover object
  *
  * @template N  The HTMLElement node class
@@ -150,14 +150,14 @@ export class CHTMLmover<N, T, D> extends CHTMLmsup<N, T, D> {
         }
     };
 
-    /*
+    /**
      * @override
      */
     public get script() {
         return this.childNodes[(this.node as MmlMover).over];
     }
 
-    /*
+    /**
      * @override
      * @constructor
      */

--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -235,14 +235,14 @@ export class CHTMLmunderover<N, T, D> extends CHTMLmsubsup<N, T, D> {
     };
 
     /*
-     * @return{CHTMLWrapper)   The wrapped under node
+     * @return {CHTMLWrapper)   The wrapped under node
      */
     public get underChild() {
         return this.childNodes[(this.node as MmlMunderover).under];
     }
 
     /*
-     * @return{CHTMLWrapper)   The wrapped overder node
+     * @return {CHTMLWrapper)   The wrapped overder node
      */
     public get overChild() {
         return this.childNodes[(this.node as MmlMunderover).over];

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -61,14 +61,14 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     protected baseCore: CHTMLWrapper<N, T, D>;
 
     /**
-     * @return{CHTMLWrapper}  The base element's wrapper
+     * @return {CHTMLWrapper}  The base element's wrapper
      */
     public get baseChild() {
         return this.childNodes[(this.node as MmlMsubsup).base];
     }
 
     /**
-     * @return{CHTMLWrapper}  The script element's wrapper (overridden in subclasses)
+     * @return {CHTMLWrapper}  The script element's wrapper (overridden in subclasses)
      */
     public get script() {
         return this.childNodes[1];
@@ -135,7 +135,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
+     * @return {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
      */
     protected isCharBase() {
         let base = this.baseChild;
@@ -155,9 +155,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Get the shift for the script (implemented in subclasses)
      *
-     * @param{BBox} bbox   The bounding box of the base element
-     * @param{BBox} sbox   The bounding box of the script element
-     * @return{number[]}   The horizontal and vertical offsets for the script
+     * @param {BBox} bbox   The bounding box of the base element
+     * @param {BBox} sbox   The bounding box of the script element
+     * @return {number[]}   The horizontal and vertical offsets for the script
      */
     protected getOffset(bbox: BBox, sbox: BBox) {
         return [0, 0];
@@ -166,9 +166,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Get the shift for a subscript (TeXBook Appendix G 18ab)
      *
-     * @param{BBox} bbox   The bounding box of the base element
-     * @param{BBox} sbox   The bounding box of the superscript element
-     * @return{number}     The vertical offset for the script
+     * @param {BBox} bbox   The bounding box of the base element
+     * @param {BBox} sbox   The bounding box of the superscript element
+     * @return {number}     The vertical offset for the script
      */
     protected getV(bbox: BBox, sbox: BBox) {
         const tex = this.font.params;
@@ -183,9 +183,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Get the shift for a superscript (TeXBook Appendix G 18acd)
      *
-     * @param{BBox} bbox   The bounding box of the base element
-     * @param{BBox} sbox   The bounding box of the superscript element
-     * @return{number}     The vertical offset for the script
+     * @param {BBox} bbox   The bounding box of the base element
+     * @param {BBox} sbox   The bounding box of the superscript element
+     * @return {number}     The vertical offset for the script
      */
     protected getU(bbox: BBox, sbox: BBox) {
         const tex = this.font.params;
@@ -205,7 +205,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
      */
 
     /**
-     * @return{boolean}  True if the base has movablelimits (needed by munderover)
+     * @return {boolean}  True if the base has movablelimits (needed by munderover)
      */
     protected hasMovableLimits() {
         const display = this.node.attributes.get('displaystyle');
@@ -217,9 +217,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Get the separation and offset for overscripts (TeXBoox Appendix G 13, 13a)
      *
-     * @param{BBox} basebox  The bounding box of the base
-     * @param{BBox} overbox  The bounding box of the overscript
-     * @return{numner[]}     The separation between their boxes, and the offset of the overscript
+     * @param {BBox} basebox  The bounding box of the base
+     * @param {BBox} overbox  The bounding box of the overscript
+     * @return {numner[]}     The separation between their boxes, and the offset of the overscript
      */
     protected getOverKU(basebox: BBox, overbox: BBox) {
         const accent = this.node.attributes.get('accent') as boolean;
@@ -234,9 +234,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     /**
      * Get the separation and offset for underscripts (TeXBoox Appendix G 13, 13a)
      *
-     * @param{BBox} basebox   The bounding box of the base
-     * @param{BBox} underbox  The bounding box of the underscript
-     * @return{numner[]}      The separation between their boxes, and the offset of the underscript
+     * @param {BBox} basebox   The bounding box of the base
+     * @param {BBox} underbox  The bounding box of the underscript
+     * @return {numner[]}      The separation between their boxes, and the offset of the underscript
      */
     protected getUnderKV(basebox: BBox, underbox: BBox) {
         const accent = this.node.attributes.get('accentunder') as boolean;
@@ -249,9 +249,9 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{BBox[]} boxes    The bounding boxes whose offsets are to be computed
-     * @param{number[]} delta  The initial x offsets of the boxes
-     * @return{number[]}       The actual offsets needed to center the boxes in the stack
+     * @param {BBox[]} boxes    The bounding boxes whose offsets are to be computed
+     * @param {number[]} delta  The initial x offsets of the boxes
+     * @return {number[]}       The actual offsets needed to center the boxes in the stack
      */
     protected getDeltaW(boxes: BBox[], delta: number[] = [0, 0, 0]) {
         const align = this.node.attributes.get('align');
@@ -275,8 +275,8 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{N[]} nodes    The HTML elements to be centered in a stack
-     * @param{number[]} dx  The x offsets needed to center the elements
+     * @param {N[]} nodes    The HTML elements to be centered in a stack
+     * @param {number[]} dx  The x offsets needed to center the elements
      */
     protected setDeltaW(nodes: N[], dx: number[]) {
         for (let i = 0; i < dx.length; i++) {
@@ -287,7 +287,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @return{number}   The offset for under and over
+     * @return {number}   The offset for under and over
      */
     protected getDelta(noskew: boolean = false) {
         const accent = this.node.attributes.get('accent');
@@ -335,8 +335,8 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{N} over        The HTML element for the overscript
-     * @param{BBox} overbox  The bbox for the overscript
+     * @param {N} over        The HTML element for the overscript
+     * @param {BBox} overbox  The bbox for the overscript
      */
     protected adjustOverDepth(over: N, overbox: BBox) {
         if (overbox.d >= 0) return;
@@ -344,8 +344,8 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     }
 
     /**
-     * @param{N} under        The HTML element for the underscript
-     * @param{BBox} underbox  The bbox for the underscript
+     * @param {N} under        The HTML element for the underscript
+     * @param {BBox} underbox  The bbox for the underscript
      */
     protected adjustUnderDepth(under: N, underbox: BBox) {
         if (underbox.d >= 0) return;

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -39,7 +39,7 @@ import {DIRECTION} from '../FontData.js';
 const DELTA = 1.5;
 
 /*****************************************************************/
-/*
+/**
  * A base class for msup/msub/msubsup and munder/mover/munderover
  * wrapper implementations
  *
@@ -50,31 +50,31 @@ const DELTA = 1.5;
 export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = 'scriptbase';
 
-    /*
+    /**
      * Set to true for munderover/munder/mover/msup (Appendix G 13)
      */
     public static useIC: boolean = false;
 
-    /*
+    /**
      * The core mi or mo of the base (or the base itself if there isn't one)
      */
     protected baseCore: CHTMLWrapper<N, T, D>;
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The base element's wrapper
      */
     public get baseChild() {
         return this.childNodes[(this.node as MmlMsubsup).base];
     }
 
-    /*
+    /**
      * @return{CHTMLWrapper}  The script element's wrapper (overridden in subclasses)
      */
     public get script() {
         return this.childNodes[1];
     }
 
-    /*
+    /**
      * @override
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
@@ -101,7 +101,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * This gives the common output for msub and msup.  It is overriden
      * for all the others (msubsup, munder, mover, munderover).
      *
@@ -118,7 +118,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.script.toCHTML(this.adaptor.append(this.chtml, this.html('mjx-script', {style})) as N);
     }
 
-    /*
+    /**
      * This gives the common bbox for msub and msup.  It is overriden
      * for all the others (msubsup, munder, mover, munderover).
      *
@@ -134,7 +134,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         bbox.clean();
     }
 
-    /*
+    /**
      * @return{boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
      */
     protected isCharBase() {
@@ -152,7 +152,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
      *  Methods for sub-sup nodes
      */
 
-    /*
+    /**
      * Get the shift for the script (implemented in subclasses)
      *
      * @param{BBox} bbox   The bounding box of the base element
@@ -163,7 +163,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [0, 0];
     }
 
-    /*
+    /**
      * Get the shift for a subscript (TeXBook Appendix G 18ab)
      *
      * @param{BBox} bbox   The bounding box of the base element
@@ -180,7 +180,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         );
     }
 
-    /*
+    /**
      * Get the shift for a superscript (TeXBook Appendix G 18acd)
      *
      * @param{BBox} bbox   The bounding box of the base element
@@ -204,7 +204,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
      *  Methods for under-over nodes
      */
 
-    /*
+    /**
      * @return{boolean}  True if the base has movablelimits (needed by munderover)
      */
     protected hasMovableLimits() {
@@ -214,7 +214,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
                              this.baseChild.coreMO().node.attributes.get('movablelimits')));
     }
 
-    /*
+    /**
      * Get the separation and offset for overscripts (TeXBoox Appendix G 13, 13a)
      *
      * @param{BBox} basebox  The bounding box of the base
@@ -231,7 +231,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [k, basebox.h + k + d];
     }
 
-    /*
+    /**
      * Get the separation and offset for underscripts (TeXBoox Appendix G 13, 13a)
      *
      * @param{BBox} basebox   The bounding box of the base
@@ -248,7 +248,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         return [k, -(basebox.d + k + h)];
     }
 
-    /*
+    /**
      * @param{BBox[]} boxes    The bounding boxes whose offsets are to be computed
      * @param{number[]} delta  The initial x offsets of the boxes
      * @return{number[]}       The actual offsets needed to center the boxes in the stack
@@ -274,7 +274,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         return dw;
     }
 
-    /*
+    /**
      * @param{N[]} nodes    The HTML elements to be centered in a stack
      * @param{number[]} dx  The x offsets needed to center the elements
      */
@@ -286,7 +286,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @return{number}   The offset for under and over
      */
     protected getDelta(noskew: boolean = false) {
@@ -295,7 +295,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         return DELTA * this.baseCore.bbox.ic / 2 + ddelta;
     }
 
-    /*
+    /**
      * Handle horizontal stretching of children to match greatest width
      *  of all children
      */
@@ -334,7 +334,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @param{N} over        The HTML element for the overscript
      * @param{BBox} overbox  The bbox for the overscript
      */
@@ -343,7 +343,7 @@ export class CHTMLscriptbase<N, T, D> extends CHTMLWrapper<N, T, D> {
         this.adaptor.setStyle(over, 'marginBottom', this.em(overbox.d * overbox.rscale));
     }
 
-    /*
+    /**
      * @param{N} under        The HTML element for the underscript
      * @param{BBox} underbox  The bbox for the underscript
      */

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -28,7 +28,7 @@ import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from '../../../core/MmlTr
 import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLsemantics wrapper for the MmlSemantics object
  *
  * @template N  The HTMLElement node class
@@ -38,7 +38,7 @@ import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
 export class CHTMLsemantics<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlSemantics.prototype.kind;
 
-    /*
+    /**
      * Only the first child of <semantics> is displayed
      *
      * @override
@@ -50,7 +50,7 @@ export class CHTMLsemantics<N, T, D> extends CHTMLWrapper<N, T, D> {
         }
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox(bbox: BBox) {
@@ -66,7 +66,7 @@ export class CHTMLsemantics<N, T, D> extends CHTMLWrapper<N, T, D> {
 
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLannotation wrapper for the MmlAnnotation object
  *
  * @template N  The HTMLElement node class
@@ -76,7 +76,7 @@ export class CHTMLsemantics<N, T, D> extends CHTMLWrapper<N, T, D> {
 export class CHTMLannotation<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlAnnotation.prototype.kind;
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
@@ -84,7 +84,7 @@ export class CHTMLannotation<N, T, D> extends CHTMLWrapper<N, T, D> {
         super.toCHTML(parent);
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox() {
@@ -95,7 +95,7 @@ export class CHTMLannotation<N, T, D> extends CHTMLWrapper<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLannotationXML wrapper for the MmlAnnotationXML object
  *
  * @template N  The HTMLElement node class
@@ -107,7 +107,7 @@ export class CHTMLannotationXML<N, T, D> extends CHTMLWrapper<N, T, D> {
 }
 
 /*****************************************************************/
-/*
+/**
  * The CHTMLxml wrapper for the XMLNode object
  *
  * @template N  The HTMLElement node class
@@ -119,14 +119,14 @@ export class CHTMLxml<N, T, D> extends CHTMLWrapper<N, T, D> {
 
     public static autoStyle = false;
 
-    /*
+    /**
      * @override
      */
     public toCHTML(parent: N) {
         this.adaptor.append(parent, this.adaptor.clone((this.node as XMLNode).getXML() as N));
     }
 
-    /*
+    /**
      * @override
      */
     public computeBBox() {
@@ -134,17 +134,17 @@ export class CHTMLxml<N, T, D> extends CHTMLWrapper<N, T, D> {
         return this.bbox;
     }
 
-    /*
+    /**
      * @override
      */
     protected getStyles() {}
 
-    /*
+    /**
      * @override
      */
     protected getScale() {}
 
-    /*
+    /**
      * @override
      */
     protected getVariant() {}

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -377,7 +377,7 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @return{StyleList}  The (computed) styles for this font
+     * @return {StyleList}  The (computed) styles for this font
      *                     (could be used to limit styles to those actually used, for example)
      */
     get styles() {
@@ -408,7 +408,7 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles  The style list to add characters to
+     * @param {StyleList} styles  The style list to add characters to
      */
     protected addVariantChars(styles: StyleList) {
         for (const name of Object.keys(this.variant)) {
@@ -424,9 +424,9 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles    The style object to add styles to
-     * @param{StyleList} fonts     The default font-face directives with %%URL%% where the url should go
-     * @param{string} url          The actual URL to insert into the src strings
+     * @param {StyleList} styles    The style object to add styles to
+     * @param {StyleList} fonts     The default font-face directives with %%URL%% where the url should go
+     * @param {string} url          The actual URL to insert into the src strings
      */
     protected addFontURLs(styles: StyleList, fonts: StyleList, url: string) {
         for (const name of Object.keys(fonts)) {
@@ -437,9 +437,9 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles    The style object to add styles to
-     * @param{number} n            The unicode character number of the delimiter
-     * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
+     * @param {StyleList} styles    The style object to add styles to
+     * @param {number} n            The unicode character number of the delimiter
+     * @param {DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterStyles(styles: StyleList, n: number, data: DelimiterData) {
         const c = this.char(n);
@@ -457,9 +457,9 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles    The style object to add styles to
-     * @param{string} c            The delimiter character string
-     * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
+     * @param {StyleList} styles    The style object to add styles to
+     * @param {string} c            The delimiter character string
+     * @param {DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterVStyles(styles: StyleList, c: string, data: DelimiterData) {
         const [beg, ext, end, mid] = data.stretch;
@@ -488,11 +488,11 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles  The style object to add styles to
-     * @param{string} c          The vertical character whose part is being added
-     * @param{string} part       The name of the part (beg, ext, end, mid) that is being added
-     * @param{number} n          The unicode character to use for the part
-     * @return{number}           The total height of the character
+     * @param {StyleList} styles  The style object to add styles to
+     * @param {string} c          The vertical character whose part is being added
+     * @param {string} part       The name of the part (beg, ext, end, mid) that is being added
+     * @param {number} n          The unicode character to use for the part
+     * @return {number}           The total height of the character
      */
     protected addDelimiterVPart(styles: StyleList, c: string, part: string, n: number) {
         if (!n) return 0;
@@ -506,9 +506,9 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles    The style object to add styles to
-     * @param{string} c            The delimiter character string
-     * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
+     * @param {StyleList} styles    The style object to add styles to
+     * @param {string} c            The delimiter character string
+     * @param {DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterHStyles(styles: StyleList, c: string, data: DelimiterData) {
         const [beg, ext, end, mid] = data.stretch;
@@ -522,10 +522,10 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles  The style object to add styles to
-     * @param{string} c          The vertical character whose part is being added
-     * @param{string} part       The name of the part (beg, ext, end, mid) that is being added
-     * @param{number} n          The unicode character to use for the part
+     * @param {StyleList} styles  The style object to add styles to
+     * @param {string} c          The vertical character whose part is being added
+     * @param {string} part       The name of the part (beg, ext, end, mid) that is being added
+     * @param {number} n          The unicode character to use for the part
      */
     protected addDelimiterHPart(styles: StyleList, c: string, part: string, n: number, force: boolean = false) {
         if (!n) {
@@ -542,10 +542,10 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{StyleList} styles  The style object to add styles to
-     * @param{string} vclass     The variant class string (e.g., .mjx-b) where this character is being defined
-     * @param{number} n          The unicode character being defined
-     * @param{CharData} data     The bounding box data and options for the character
+     * @param {StyleList} styles  The style object to add styles to
+     * @param {string} vclass     The variant class string (e.g., .mjx-b) where this character is being defined
+     * @param {number} n          The unicode character being defined
+     * @param {CharData} data     The bounding box data and options for the character
      */
     protected addCharStyles(styles: StyleList, vclass: string, n: number, data: CharData) {
         const [h, d, w, options] = data as [number, number, number, CharOptions];
@@ -574,16 +574,16 @@ export class TeXFont extends FontData {
     }
 
     /**
-     * @param{number} n  The number of ems
-     * @return{string}   The string representing the number with units of "em"
+     * @param {number} n  The number of ems
+     * @return {string}   The string representing the number with units of "em"
      */
     protected em(n: number) {
         return em(n);
     }
 
     /**
-     * @param{number} n  The number of ems (will be restricted to non-negative values)
-     * @return{string}   The string representing the number with units of "em"
+     * @param {number} n  The number of ems (will be restricted to non-negative values)
+     * @return {string}   The string representing the number with units of "em"
      */
     protected em0(n: number) {
         return em(Math.max(0, n));

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -56,19 +56,19 @@ import {texVariant} from './tex/tex-variant.js';
 import {delimiters} from './tex/delimiters.js';
 
 /***********************************************************************************/
-/*
+/**
  *  The TeXFont class
  */
 export class TeXFont extends FontData {
 
-    /*
+    /**
      * Default options
      */
     public static OPTIONS = {
         fontURL: 'mathjax2/css/'
     };
 
-    /*
+    /**
      *  Add the extra variants for the TeX fonts
      */
     protected static defaultVariants = FontData.defaultVariants.concat([
@@ -84,7 +84,7 @@ export class TeXFont extends FontData {
         ['-tex-variant', 'normal']
     ]);
 
-    /*
+    /**
      * The classes to use for each variant
      */
     protected static defaultVariantClasses: StringMap = {
@@ -114,17 +114,17 @@ export class TeXFont extends FontData {
         '-tex-variant': 'mjx-v'
     };
 
-    /*
+    /**
      *  The stretchy delimiter data (incomplete at the moment)
      */
     protected static defaultDelimiters: DelimiterMap = delimiters;
 
-    /*
+    /**
      *  The default variants for the standard stretchy sizes
      */
     protected static defaultSizeVariants = ['normal', '-smallop', '-largeop', '-size3', '-size4'];
 
-    /*
+    /**
      *  The character data by variant
      */
     protected static defaultChars: CharMapMap = {
@@ -154,7 +154,7 @@ export class TeXFont extends FontData {
         '-tex-variant': texVariant
     };
 
-    /*
+    /**
      * The CSS styles needed for this font.
      */
     protected static defaultStyles = {
@@ -367,7 +367,7 @@ export class TeXFont extends FontData {
 
     protected options: OptionList;
 
-    /*
+    /**
      * @override
      */
     constructor(options: OptionList = null) {
@@ -376,7 +376,7 @@ export class TeXFont extends FontData {
         this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     }
 
-    /*
+    /**
      * @return{StyleList}  The (computed) styles for this font
      *                     (could be used to limit styles to those actually used, for example)
      */
@@ -407,7 +407,7 @@ export class TeXFont extends FontData {
         return styles;
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The style list to add characters to
      */
     protected addVariantChars(styles: StyleList) {
@@ -423,7 +423,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{StyleList} styles    The style object to add styles to
      * @param{StyleList} fonts     The default font-face directives with %%URL%% where the url should go
      * @param{string} url          The actual URL to insert into the src strings
@@ -436,7 +436,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{StyleList} styles    The style object to add styles to
      * @param{number} n            The unicode character number of the delimiter
      * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
@@ -456,7 +456,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{StyleList} styles    The style object to add styles to
      * @param{string} c            The delimiter character string
      * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
@@ -487,7 +487,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The style object to add styles to
      * @param{string} c          The vertical character whose part is being added
      * @param{string} part       The name of the part (beg, ext, end, mid) that is being added
@@ -505,7 +505,7 @@ export class TeXFont extends FontData {
         return data[0] + data[1];
     }
 
-    /*
+    /**
      * @param{StyleList} styles    The style object to add styles to
      * @param{string} c            The delimiter character string
      * @param{DelimiterData} data  The data for the delimiter whose CSS is to be added
@@ -521,7 +521,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The style object to add styles to
      * @param{string} c          The vertical character whose part is being added
      * @param{string} part       The name of the part (beg, ext, end, mid) that is being added
@@ -541,7 +541,7 @@ export class TeXFont extends FontData {
         styles['.MJX-TEX mjx-stretchy-h[c="' + c + '"] mjx-' + part + ' mjx-c::before'] = css;
     }
 
-    /*
+    /**
      * @param{StyleList} styles  The style object to add styles to
      * @param{string} vclass     The variant class string (e.g., .mjx-b) where this character is being defined
      * @param{number} n          The unicode character being defined
@@ -573,7 +573,7 @@ export class TeXFont extends FontData {
         }
     }
 
-    /*
+    /**
      * @param{number} n  The number of ems
      * @return{string}   The string representing the number with units of "em"
      */
@@ -581,7 +581,7 @@ export class TeXFont extends FontData {
         return em(n);
     }
 
-    /*
+    /**
      * @param{number} n  The number of ems (will be restricted to non-negative values)
      * @return{string}   The string representing the number with units of "em"
      */

--- a/mathjax3-ts/util/AsyncLoad-disabled.ts
+++ b/mathjax3-ts/util/AsyncLoad-disabled.ts
@@ -22,8 +22,8 @@
  */
 
 /**
- * @param{string} name  The name of the file to load
- * @return{Promise}     The promise that always fails (indicating file not loaded)
+ * @param {string} name  The name of the file to load
+ * @return {Promise}     The promise that always fails (indicating file not loaded)
  */
 export function asyncLoad(name: string) {
     return new Promise((ok, fail) => fail());

--- a/mathjax3-ts/util/AsyncLoad-disabled.ts
+++ b/mathjax3-ts/util/AsyncLoad-disabled.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-/*
+/**
  * @param{string} name  The name of the file to load
  * @return{Promise}     The promise that always fails (indicating file not loaded)
  */

--- a/mathjax3-ts/util/AsyncLoad.ts
+++ b/mathjax3-ts/util/AsyncLoad.ts
@@ -25,7 +25,7 @@ declare var System: {import: Function};
 declare function require(name: string): Object;
 declare var __dirname: string;
 
-/*
+/**
  * Load a file asynchronously, either using System.js, or node's require().
  *
  * @param{string} name  The name of the file to load

--- a/mathjax3-ts/util/AsyncLoad.ts
+++ b/mathjax3-ts/util/AsyncLoad.ts
@@ -28,8 +28,8 @@ declare var __dirname: string;
 /**
  * Load a file asynchronously, either using System.js, or node's require().
  *
- * @param{string} name  The name of the file to load
- * @return{Promise}     The promise that is satisfied when the file is loaded
+ * @param {string} name  The name of the file to load
+ * @return {Promise}     The promise that is satisfied when the file is loaded
  */
 export function asyncLoad(name: string) {
     if (name.charAt(0) === '.') {

--- a/mathjax3-ts/util/Entities.ts
+++ b/mathjax3-ts/util/Entities.ts
@@ -25,20 +25,20 @@ import {retryAfter} from './Retries.js';
 import {asyncLoad} from './AsyncLoad.js';
 import {userOptions, defaultOptions, OptionList} from './Options.js';
 
-/*
+/**
  * The type for lists of entities
  */
 export type EntityList = {[name: string]: string};
 
 
-/*
+/**
  *  Options controlling the process of conversion
  */
 export const options: OptionList = {
     loadMissingEntities: true           // True means load entity files dynamically if needed
 };
 
-/*
+/**
  *  The entity name-to-value translation table
  *  (basic math entities -- others are loaded from external files)
  */
@@ -448,12 +448,12 @@ const entities: EntityList = {
     zigrarr: '\u21DD'
 };
 
-/*
+/**
  * The files that have been loaded
  */
 const loaded: {[name: string]: boolean} = {};
 
-/*
+/**
  * Used by entity files to add more entities to the table
  *
  * @param {EntityList} entities  The entities to add
@@ -464,7 +464,7 @@ export function add(entities: EntityList, file: string) {
    loaded[file] = true;
 }
 
-/*
+/**
  * Used to remove an entity from the list, if needed
  *
  * @param {string} entity  The name of the entity to remove
@@ -473,7 +473,7 @@ export function remove(entity: string) {
     delete entities[entity];
 }
 
-/*
+/**
  * @param {string} text  The text whose entities are to be replaced
  * @return {string}      The text with entries replaced
  */
@@ -481,7 +481,7 @@ export function translate(text: string) {
     return text.replace(/&([a-z][a-z0-9]*|#(?:[0-9]+|x[0-9a-f]+));/ig, replace);
 }
 
-/*
+/**
  * Returns the unicode character for an entity, if found
  * If not, loads an entity file to see if it is there (and retries after loading)
  * Otherwire, returns the original entity string
@@ -507,7 +507,7 @@ function replace(match: string, entity: string) {
     return match;
 }
 
-/*
+/**
  * @param{string} entity  The character code point as a string
  * @return{srting}        The character(s) with the given code point
  */

--- a/mathjax3-ts/util/Entities.ts
+++ b/mathjax3-ts/util/Entities.ts
@@ -508,8 +508,8 @@ function replace(match: string, entity: string) {
 }
 
 /**
- * @param{string} entity  The character code point as a string
- * @return{srting}        The character(s) with the given code point
+ * @param {string} entity  The character code point as a string
+ * @return {srting}        The character(s) with the given code point
  */
 export function numeric(entity: string) {
     let n = (entity.charAt(0) === 'x' ?

--- a/mathjax3-ts/util/FunctionList.ts
+++ b/mathjax3-ts/util/FunctionList.ts
@@ -24,20 +24,20 @@
 import {PrioritizedList, PrioritizedListItem} from './PrioritizedList.js';
 
 /*****************************************************************/
-/*
- *  The FunctionListItem interface (extends PrioritizedListItem<Function>
+/**
+ *  The FunctionListItem interface (extends PrioritizedListItem<Function>)
  */
 
 export interface FunctionListItem extends PrioritizedListItem<Function> {}
 
 /*****************************************************************/
-/*
- *  Implements the FunctionList class (extends PrioritizedList<Function>
+/**
+ *  Implements the FunctionList class (extends PrioritizedList<Function>)
  */
 
 export class FunctionList extends PrioritizedList<Function> {
 
-    /*
+    /**
      * Executes the functions in the list (in prioritized order),
      *   passing the given data to the functions.  If any return
      *   false, the list is terminated.
@@ -56,7 +56,7 @@ export class FunctionList extends PrioritizedList<Function> {
         return true;
     }
 
-    /*
+    /**
      * Executes the functions in the list (in prioritied order) asynchronously,
      *   passing the given data to the functions, and doing the next function
      *   only when the previous one completes.  If the function returns a

--- a/mathjax3-ts/util/FunctionList.ts
+++ b/mathjax3-ts/util/FunctionList.ts
@@ -42,8 +42,8 @@ export class FunctionList extends PrioritizedList<Function> {
      *   passing the given data to the functions.  If any return
      *   false, the list is terminated.
      *
-     * @param{any[]} data  The array of arguments to pass to the functions
-     * @return{boolean}    False if any function stopped the list by
+     * @param {any[]} data  The array of arguments to pass to the functions
+     * @return {boolean}    False if any function stopped the list by
      *                       returning false, true otherwise
      */
     public execute(...data: any[]) {
@@ -67,8 +67,8 @@ export class FunctionList extends PrioritizedList<Function> {
      *   succeeds, but passes false as its argument.  Otherwise it succeeds
      *   and passes true.
      *
-     * @param{any[]} data  The array of arguments to pass to the functions
-     * @return{Promise}    The promise that is satisfied when the function
+     * @param {any[]} data  The array of arguments to pass to the functions
+     * @return {Promise}    The promise that is satisfied when the function
      *                       list completes (with argument true or false
      *                       depending on whether some function returned
      *                       false or not).

--- a/mathjax3-ts/util/LinkedList.ts
+++ b/mathjax3-ts/util/LinkedList.ts
@@ -57,7 +57,7 @@ export class ListItem<DataClass> {
     public prev: ListItem<DataClass> = null;
 
     /**
-     * @param{any} data  The data to be stored in the list item
+     * @param {any} data  The data to be stored in the list item
      * @constructor
      */
     constructor (data: any = null) {
@@ -88,7 +88,7 @@ export class LinkedList<DataClass> {
      *    item in the list, without having to handle special
      *    cases.
      *
-     * @param{DataClass[]} args  The data items that form the initial list
+     * @param {DataClass[]} args  The data items that form the initial list
      * @constructor
      */
     constructor(...args: DataClass[]) {
@@ -104,7 +104,7 @@ export class LinkedList<DataClass> {
      *
      * so use toArray() to convert to array, when needed
      *
-     * @return{DataClass[]}  The list converted to an array
+     * @return {DataClass[]}  The list converted to an array
      */
     public toArray() {
         return Array.from(this) as DataClass[];
@@ -113,9 +113,9 @@ export class LinkedList<DataClass> {
     /**
      *  Used for sorting and merging lists (Overridden by subclasses)
      *
-     * @param{DataClass} a   The first item to compare
-     * @param{DataClass} b   The second item to compare
-     * @return{boolean}      True if a is before b, false otherwise
+     * @param {DataClass} a   The first item to compare
+     * @param {DataClass} b   The second item to compare
+     * @return {boolean}      True if a is before b, false otherwise
      */
     public isBefore(a: DataClass, b: DataClass) {
         return (a < b);
@@ -124,8 +124,8 @@ export class LinkedList<DataClass> {
     /**
      * Push items on the end of the list
      *
-     * @param{DataClass[]} args   The list of data items to be pushed
-     * @return{LinkedList}        The LinkedList object (for chaining)
+     * @param {DataClass[]} args   The list of data items to be pushed
+     * @return {LinkedList}        The LinkedList object (for chaining)
      */
     public push(...args: DataClass[]) {
         for (const data of args) {
@@ -141,7 +141,7 @@ export class LinkedList<DataClass> {
     /**
      * Pop the end item off the list and return its data
      *
-     * @return{DataClass}  The data from the last item in the list
+     * @return {DataClass}  The data from the last item in the list
      */
     public pop(): DataClass {
         let item = this.list.prev;
@@ -157,8 +157,8 @@ export class LinkedList<DataClass> {
     /**
      * Push items at the head of the list
      *
-     * @param{DataClass[]} args   The list of data items to inserted
-     * @return{LinkedList}        The LinkedList object (for chaining)
+     * @param {DataClass[]} args   The list of data items to inserted
+     * @return {LinkedList}        The LinkedList object (for chaining)
      */
     public unshift(...args: DataClass[]) {
         for (const data of args.slice(0).reverse()) {
@@ -174,7 +174,7 @@ export class LinkedList<DataClass> {
     /**
      * Remove an item from the head of the list and return its data
      *
-     * @return{DataClass}  The data from the first item in the list
+     * @return {DataClass}  The data from the first item in the list
      */
     public shift(): DataClass {
         let item = this.list.next;
@@ -190,7 +190,7 @@ export class LinkedList<DataClass> {
     /**
      * Empty the list
      *
-     * @return{LinkedList}  The LinkedList object (for chaining)
+     * @return {LinkedList}  The LinkedList object (for chaining)
      */
     public clear() {
         this.list.next.prev = this.list.prev.next = null;
@@ -201,7 +201,7 @@ export class LinkedList<DataClass> {
     /**
      * Make the list iterable and return the data from the items in the list
      *
-     * @return{{next: Function}}  The object containing the iterator's next() function
+     * @return {{next: Function}}  The object containing the iterator's next() function
      */
     public [Symbol.iterator](): Iterator<DataClass> {
         let current = this.list;
@@ -218,7 +218,7 @@ export class LinkedList<DataClass> {
     /**
      * An iterator for the list in reverse order
      *
-     * @return{Object}  The iterator for walking the list in reverse
+     * @return {Object}  The iterator for walking the list in reverse
      */
     public reversed() {
         let current = this.list;
@@ -241,9 +241,9 @@ export class LinkedList<DataClass> {
     /**
      * Insert a new item into a sorted list in the correct locations
      *
-     * @param{DataClass} data   The data item to add
-     * @param{SortFn} isBefore  The function used to order the data
-     * @param{LinkedList}       The LinkedList object (for chaining)
+     * @param {DataClass} data   The data item to add
+     * @param {SortFn} isBefore   The function used to order the data
+     * @param {LinkedList}        The LinkedList object (for chaining)
      */
     public insert(data: DataClass, isBefore: SortFn<DataClass> = null) {
         if (isBefore === null) {
@@ -263,8 +263,8 @@ export class LinkedList<DataClass> {
     /**
      * Sort the list using an optional sort function
      *
-     * @param{SortFn} isBefore  The function used to order the data
-     * @return{LinkedList}      The LinkedList object (for chaining)
+     * @param {SortFn} isBefore  The function used to order the data
+     * @return {LinkedList}      The LinkedList object (for chaining)
      */
     public sort(isBefore: SortFn<DataClass> = null) {
         if (isBefore === null) {
@@ -302,9 +302,9 @@ export class LinkedList<DataClass> {
     /**
      * Merge a sorted list with another sorted list
      *
-     * @param{LinkedList} list  The list to merge into this instance's list
-     * @param{SortFn} isBefore  The function used to order the data
-     * @return{LinkedList}      The LinkedList instance (for chaining)
+     * @param {LinkedList} list  The list to merge into this instance's list
+     * @param {SortFn} isBefore  The function used to order the data
+     * @return {LinkedList}      The LinkedList instance (for chaining)
      */
     public merge(list: LinkedList<DataClass>, isBefore: SortFn<DataClass> = null) {
         if (isBefore === null) {

--- a/mathjax3-ts/util/LinkedList.ts
+++ b/mathjax3-ts/util/LinkedList.ts
@@ -22,37 +22,41 @@
  */
 
 /*****************************************************************/
-/*
+/**
  *  A symbol used to mark the special node used to indicate
  *  the start and end of the list.
  */
 const END = Symbol();
 
-/*
+/**
  * Shorthand type for the functions used to sort the data items
+ *
+ * @template DataClass   The type of data stored in the list
  */
 export type SortFn<DataClass> = (a: DataClass, b: DataClass) => boolean;
 
 /*****************************************************************/
-/*
+/**
  *  The ListItem interface (for a specific type of data item)
  *
  *  These are the items in the doubly-linked list.
+ *
+ * @template DataClass   The type of data stored in the list
  */
 
 export class ListItem<DataClass> {
-    /*
+    /**
      * The data for the list item
      */
     public data: DataClass | symbol;
 
-    /*
+    /**
      * Pointers to the next and previous items in the list
      */
     public next: ListItem<DataClass> = null;
     public prev: ListItem<DataClass> = null;
 
-    /*
+    /**
      * @param{any} data  The data to be stored in the list item
      * @constructor
      */
@@ -63,18 +67,20 @@ export class ListItem<DataClass> {
 
 
 /*****************************************************************/
-/*
+/**
  *  Implements the generic LinkedList class
+ *
+ * @template DataClass   The type of data stored in the list
  */
 
 export class LinkedList<DataClass> {
 
-    /*
+    /**
      * The linked list
      */
     protected list: ListItem<DataClass>;
 
-    /*
+    /**
      *  This.list is a special ListItem whose next property
      *    points to the head of the list and whose prev
      *    property points to the tail.  This lets us relink
@@ -91,7 +97,7 @@ export class LinkedList<DataClass> {
         this.push(...args);
     }
 
-    /*
+    /**
      * Typescript < 2.3 targeted at ES5 doesn't handle
      *
      *     for (const x of this) {...}
@@ -104,7 +110,7 @@ export class LinkedList<DataClass> {
         return Array.from(this) as DataClass[];
     }
 
-    /*
+    /**
      *  Used for sorting and merging lists (Overridden by subclasses)
      *
      * @param{DataClass} a   The first item to compare
@@ -115,7 +121,7 @@ export class LinkedList<DataClass> {
         return (a < b);
     }
 
-    /*
+    /**
      * Push items on the end of the list
      *
      * @param{DataClass[]} args   The list of data items to be pushed
@@ -132,7 +138,7 @@ export class LinkedList<DataClass> {
         return this;
     }
 
-    /*
+    /**
      * Pop the end item off the list and return its data
      *
      * @return{DataClass}  The data from the last item in the list
@@ -148,7 +154,7 @@ export class LinkedList<DataClass> {
         return item.data as DataClass;
     }
 
-    /*
+    /**
      * Push items at the head of the list
      *
      * @param{DataClass[]} args   The list of data items to inserted
@@ -165,7 +171,7 @@ export class LinkedList<DataClass> {
         return this;
     }
 
-    /*
+    /**
      * Remove an item from the head of the list and return its data
      *
      * @return{DataClass}  The data from the first item in the list
@@ -181,7 +187,7 @@ export class LinkedList<DataClass> {
         return item.data as DataClass;
     }
 
-    /*
+    /**
      * Empty the list
      *
      * @return{LinkedList}  The LinkedList object (for chaining)
@@ -192,7 +198,7 @@ export class LinkedList<DataClass> {
         return this;
     }
 
-    /*
+    /**
      * Make the list iterable and return the data from the items in the list
      *
      * @return{{next: Function}}  The object containing the iterator's next() function
@@ -209,7 +215,7 @@ export class LinkedList<DataClass> {
         };
     }
 
-    /*
+    /**
      * An iterator for the list in reverse order
      *
      * @return{Object}  The iterator for walking the list in reverse
@@ -232,7 +238,7 @@ export class LinkedList<DataClass> {
         };
     }
 
-    /*
+    /**
      * Insert a new item into a sorted list in the correct locations
      *
      * @param{DataClass} data   The data item to add
@@ -254,7 +260,7 @@ export class LinkedList<DataClass> {
         return this;
     }
 
-    /*
+    /**
      * Sort the list using an optional sort function
      *
      * @param{SortFn} isBefore  The function used to order the data
@@ -293,7 +299,7 @@ export class LinkedList<DataClass> {
         return this;
     }
 
-    /*
+    /**
      * Merge a sorted list with another sorted list
      *
      * @param{LinkedList} list  The list to merge into this instance's list
@@ -346,4 +352,5 @@ export class LinkedList<DataClass> {
         }
         return this;
     }
+
 }

--- a/mathjax3-ts/util/Options.ts
+++ b/mathjax3-ts/util/Options.ts
@@ -65,8 +65,8 @@ export function makeArray(x: any): any[] {
 /**
  * Get all keys and symbols from an object
  *
- * @param{Optionlist} def        The object whose keys are to be returned
- * @return{(string | symbol)[]}  The list of keys for the object
+ * @param {Optionlist} def        The object whose keys are to be returned
+ * @return {(string | symbol)[]}  The list of keys for the object
  */
 export function keys(def: OptionList) {
     if (!def) {
@@ -79,8 +79,8 @@ export function keys(def: OptionList) {
 /**
  * Make a deep copy of an object
  *
- * @param{OptionList} def  The object to be copied
- * @return{OptionList}     The copy of the object
+ * @param {OptionList} def  The object to be copied
+ * @return {OptionList}     The copy of the object
  */
 export function copy(def: OptionList): OptionList {
     let props: OptionList = {};
@@ -104,10 +104,10 @@ export function copy(def: OptionList): OptionList {
  * Insert one object into another (with optional warnings about
  * keys that aren't in the original)
  *
- * @param{OptionList} dst  The option list to merge into
- * @param{OptionList} src  The options to be merged
- * @param{boolean} warn    True if a warning shoudl be issued for a src option that isn't already in dst
- * @return{OptionList}     The modified destination option list (dst)
+ * @param {OptionList} dst  The option list to merge into
+ * @param {OptionList} src  The options to be merged
+ * @param {boolean} warn    True if a warning shoudl be issued for a src option that isn't already in dst
+ * @return {OptionList}     The modified destination option list (dst)
  */
 export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
     for (let key of keys(src)) {
@@ -142,9 +142,9 @@ export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
  * Merge options without warnings (so we can add new default values into an
  * existing default list)
  *
- * @param{OptionList} options  The option list to be merged into
- * @param{OptionList[]} defs   The option lists to merge into the first one
- * @return{OptionList}         The modified options list
+ * @param {OptionList} options  The option list to be merged into
+ * @param {OptionList[]} defs   The option lists to merge into the first one
+ * @return {OptionList}         The modified options list
  */
 export function defaultOptions(options: OptionList, ...defs: OptionList[]) {
     defs.forEach(def => insert(options, def, false));
@@ -156,9 +156,9 @@ export function defaultOptions(options: OptionList, ...defs: OptionList[]) {
  * Merge options with warnings about undefined ones (so we can merge
  * user options into the default list)
  *
- * @param{OptionList} options  The option list to be merged into
- * @param{OptionList[]} defs   The option lists to merge into the first one
- * @return{OptionList}         The modified options list
+ * @param {OptionList} options  The option list to be merged into
+ * @param {OptionList[]} defs   The option lists to merge into the first one
+ * @return {OptionList}         The modified options list
  */
 export function userOptions(options: OptionList, ...defs: OptionList[]) {
     defs.forEach(def => insert(options, def, true));
@@ -169,9 +169,9 @@ export function userOptions(options: OptionList, ...defs: OptionList[]) {
 /**
  * Select a subset of options by key name
  *
- * @param{OptionList} options  The option list from which option values will be taken
- * @param{string[]} keys       The names of the options to extract
- * @return{OptionList}         The option list consisting of only the ones whose keys were given
+ * @param {OptionList} options  The option list from which option values will be taken
+ * @param {string[]} keys       The names of the options to extract
+ * @return {OptionList}         The option list consisting of only the ones whose keys were given
  */
 export function selectOptions(options: OptionList, ...keys: string[]) {
     let subset: OptionList = {};
@@ -187,9 +187,9 @@ export function selectOptions(options: OptionList, ...keys: string[]) {
 /**
  * Select a subset of options by keys from an object
  *
- * @param{OptionList} options  The option list from which the option values will be taken
- * @param{OptionList} object   The option list whose keys will be used to select the options
- * @return{OptionList}         The option list consisting of the option values from the first
+ * @param {OptionList} options  The option list from which the option values will be taken
+ * @param {OptionList} object   The option list whose keys will be used to select the options
+ * @return {OptionList}         The option list consisting of the option values from the first
  *                               list whose keys are those from the second list.
  */
 export function selectOptionsFromKeys(options: OptionList, object: OptionList) {
@@ -203,10 +203,10 @@ export function selectOptionsFromKeys(options: OptionList, object: OptionList) {
  *  (Used to separate an option list into the options needed for several
  *   subobjects.)
  *
- * @param{OptionList} options    The option list to be split into parts
- * @param{OptionList[]} objects  The list of option lists whose keys are used to break up
+ * @param {OptionList} options    The option list to be split into parts
+ * @param {OptionList[]} objects  The list of option lists whose keys are used to break up
  *                                 the original options into separate pieces.
- * @return{OptionList[]}         The option lists taken from the original based on the
+ * @return {OptionList[]}         The option lists taken from the original based on the
  *                                 keys of the other objects.  The first one in the list
  *                                 consists of the values not appearing in any of the others
  *                                 (i.e., whose keys were not in any of the others).

--- a/mathjax3-ts/util/Options.ts
+++ b/mathjax3-ts/util/Options.ts
@@ -23,7 +23,7 @@
 
 
 /*****************************************************************/
-/*
+/**
  *  Check if an object is an object literal (as opposed to an instance of a class)
  */
 
@@ -33,13 +33,13 @@ function isObject(obj: any) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Generic list of options
  */
 export type OptionList = {[name: string]: any};
 
 /*****************************************************************/
-/*
+/**
  *  Used to append an array to an array in default options
  *  E.g., an option of the form
  *
@@ -54,7 +54,7 @@ export const APPEND = Symbol('Append to option array');
 
 
 /*****************************************************************/
-/*
+/**
  *  Make sure an option is an Array
  */
 export function makeArray(x: any): any[] {
@@ -62,7 +62,7 @@ export function makeArray(x: any): any[] {
 }
 
 /*****************************************************************/
-/*
+/**
  * Get all keys and symbols from an object
  *
  * @param{Optionlist} def        The object whose keys are to be returned
@@ -76,7 +76,7 @@ export function keys(def: OptionList) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Make a deep copy of an object
  *
  * @param{OptionList} def  The object to be copied
@@ -100,7 +100,7 @@ export function copy(def: OptionList): OptionList {
 }
 
 /*****************************************************************/
-/*
+/**
  * Insert one object into another (with optional warnings about
  * keys that aren't in the original)
  *
@@ -138,7 +138,7 @@ export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Merge options without warnings (so we can add new default values into an
  * existing default list)
  *
@@ -152,7 +152,7 @@ export function defaultOptions(options: OptionList, ...defs: OptionList[]) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Merge options with warnings about undefined ones (so we can merge
  * user options into the default list)
  *
@@ -166,7 +166,7 @@ export function userOptions(options: OptionList, ...defs: OptionList[]) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Select a subset of options by key name
  *
  * @param{OptionList} options  The option list from which option values will be taken
@@ -184,7 +184,7 @@ export function selectOptions(options: OptionList, ...keys: string[]) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Select a subset of options by keys from an object
  *
  * @param{OptionList} options  The option list from which the option values will be taken
@@ -197,7 +197,7 @@ export function selectOptionsFromKeys(options: OptionList, object: OptionList) {
 }
 
 /*****************************************************************/
-/*
+/**
  *  Separate options into sets: the ones having the same keys
  *  as the second object, the third object, etc, and the ones that don't.
  *  (Used to separate an option list into the options needed for several

--- a/mathjax3-ts/util/PrioritizedList.ts
+++ b/mathjax3-ts/util/PrioritizedList.ts
@@ -70,7 +70,7 @@ export class PrioritizedList<DataClass> {
     /**
      * Make the list iterable, and return the data for the items in the list
      *
-     * @return{{next: Function}}  The object containing the iterator's next() function
+     * @return {{next: Function}}  The object containing the iterator's next() function
      */
     public [Symbol.iterator](): Iterator<PrioritizedListItem<DataClass>> {
         let i = 0;
@@ -85,9 +85,9 @@ export class PrioritizedList<DataClass> {
     /**
      * Add an item to the list
      *
-     * @param{DataClass} item   The data for the item to be added
-     * @param{number} priority  The priority for the item
-     * @return{DataClass}       The data itself
+     * @param {DataClass} item   The data for the item to be added
+     * @param {number} priority  The priority for the item
+     * @return {DataClass}       The data itself
      */
     public add(item: DataClass, priority: number = PrioritizedList.DEFAULTPRIORITY) {
         let i = this.items.length;
@@ -101,7 +101,7 @@ export class PrioritizedList<DataClass> {
     /**
      * Remove an item from the list
      *
-     * @param{DataClass} item   The data for the item to be removed
+     * @param {DataClass} item   The data for the item to be removed
      */
     public remove(item: DataClass) {
         let i = this.items.length;
@@ -120,7 +120,7 @@ export class PrioritizedList<DataClass> {
      *
      * so use toArray() to convert to array, when needed
      *
-     * @return{PrioritizedListItem<DataClass>[]}  The list converted to an array
+     * @return {PrioritizedListItem<DataClass>[]}  The list converted to an array
      */
     public toArray() {
         return Array.from(this);

--- a/mathjax3-ts/util/PrioritizedList.ts
+++ b/mathjax3-ts/util/PrioritizedList.ts
@@ -22,48 +22,52 @@
  */
 
 /*****************************************************************/
-/*
+/**
  *  The PrioritizedListItem<DataClass> interface
+ *
+ * @template DataClass   The class of data stored in the item
  */
 
 export interface PrioritizedListItem<DataClass> {
 
-    /*
+    /**
      * The priority of this item
      */
     priority: number;
 
-    /*
+    /**
      * The data for the list item
      */
     item: DataClass;
 }
 
 /*****************************************************************/
-/*
+/**
  *  Implements the PrioritizedList<DataClass> class
+ *
+ * @template DataClass   The class of data stored in the list
  */
 
 export class PrioritizedList<DataClass> {
 
-    /*
+    /**
      * The default priority for items added to the list
      */
     public static DEFAULTPRIORITY: number = 5;
 
-    /*
+    /**
      * The list of items, sorted by priority (smallest number first)
      */
     protected items: PrioritizedListItem<DataClass>[] = [];
 
-    /*
+    /**
      * @constructor
      */
     constructor() {
         this.items = [];
     }
 
-    /*
+    /**
      * Make the list iterable, and return the data for the items in the list
      *
      * @return{{next: Function}}  The object containing the iterator's next() function
@@ -78,7 +82,7 @@ export class PrioritizedList<DataClass> {
         };
     }
 
-    /*
+    /**
      * Add an item to the list
      *
      * @param{DataClass} item   The data for the item to be added
@@ -94,7 +98,7 @@ export class PrioritizedList<DataClass> {
         return item;
     }
 
-    /*
+    /**
      * Remove an item from the list
      *
      * @param{DataClass} item   The data for the item to be removed
@@ -109,7 +113,7 @@ export class PrioritizedList<DataClass> {
         }
     }
 
-    /*
+    /**
      * Typescript < 2.3 targeted at ES5 doesn't handle
      *
      *     for (const x of this) {...}

--- a/mathjax3-ts/util/Retries.ts
+++ b/mathjax3-ts/util/Retries.ts
@@ -24,14 +24,14 @@
 
 /*****************************************************************/
 /*
- *  The legacy MathJax object
+ *  The legacy MathJax object  (FIXME: remove this after all v2 code is gone)
  */
 
 declare var MathJax: {Callback: {After: Function}};
 
 
 /*****************************************************************/
-/*
+/**
  *  Allow us to pass a promise as part of an Error object
  */
 
@@ -40,7 +40,7 @@ export interface RetryError extends Error {
 }
 
 /*****************************************************************/
-/*
+/**
  * A wrapper for actions that may be asynchronous.  This will
  *   rerun the action after the asychronous action completes.
  *   Usually, this is for dynamic loading of files.  Legacy
@@ -76,6 +76,7 @@ export function handleRetriesFor(code: Function) {
                 err.retry.then(() => run(ok, fail))
                          .catch((perr: Error) => fail(perr));
             } else if (err.restart && err.restart.isCallback) {
+                // FIXME: Remove this branch when all legacy code is gone
                 MathJax.Callback.After(() => run(ok, fail), err.restart);
             } else {
                 fail(err);
@@ -85,7 +86,7 @@ export function handleRetriesFor(code: Function) {
 }
 
 /*****************************************************************/
-/*
+/**
  * Tells HandleRetriesFor() to wait for this promise to be fulfilled
  *   before rerunning the code.  Causes an error to be thrown, so
  *   calling this terminates the code at that point.

--- a/mathjax3-ts/util/Retries.ts
+++ b/mathjax3-ts/util/Retries.ts
@@ -61,8 +61,8 @@ export interface RetryError extends Error {
  *       console.log(err.message);
  *     });
  *
- * @param{Function} code  The code to run that might cause retries
- * @return{Promise}       A promise that is satisfied when the code
+ * @param {Function} code  The code to run that might cause retries
+ * @return {Promise}       A promise that is satisfied when the code
  *                         runs completely, and fails if the code
  *                         generates an error (that is not a retry).
  */
@@ -91,7 +91,7 @@ export function handleRetriesFor(code: Function) {
  *   before rerunning the code.  Causes an error to be thrown, so
  *   calling this terminates the code at that point.
  *
- * @param{Promise} promise  The promise that must be satisfied before
+ * @param {Promise} promise  The promise that must be satisfied before
  *                            actions will continue
  */
 

--- a/mathjax3-ts/util/Styles.ts
+++ b/mathjax3-ts/util/Styles.ts
@@ -22,12 +22,12 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-/*
+/**
  * An object contining name: value pairs
  */
 export type StyleList = {[name: string]: string};
 
-/*
+/**
  * Data for how to map a combined style (like border) to its children
  */
 export type connection = {
@@ -36,19 +36,19 @@ export type connection = {
     combine: (name: string) => void   // function to combine the child values when one changes
 };
 
-/*
+/**
  * A collection of connections
  */
 export type connections = {[name: string]: connection};
 
 /*********************************************************/
-/*
+/**
  * Some common children arrays
  */
 const TRBL = ['top', 'right', 'bottom', 'left'];
 const WSC = ['width', 'style', 'color'];
 
-/*
+/**
  * Split a style at spaces (taking quotation marks and commas into account)
  *
  * @param{string} text  The combined styles to be split at spaces
@@ -65,7 +65,7 @@ function splitSpaces(text: string) {
 }
 
 /*********************************************************/
-/*
+/**
  * Split a top-right-bottom-left group into its parts
  * Format:
  *    x           all are the same value
@@ -95,7 +95,7 @@ function splitTRBL(name: string) {
     }
 }
 
-/*
+/**
  * Combine top-right-bottom-left into one entry
  * (removing unneeded values)
  *
@@ -125,7 +125,7 @@ function combineTRBL(name: string) {
 }
 
 /*********************************************************/
-/*
+/**
  * Use the same value for all children
  *
  * @param{string} name   The style to be processed
@@ -136,7 +136,7 @@ function splitSame(name: string) {
     }
 }
 
-/*
+/**
  * Check that all children have the same values and
  * if so, set the parent to that value
  *
@@ -155,7 +155,7 @@ function combineSame(name: string) {
 }
 
 /*********************************************************/
-/*
+/**
  * Patterns for the parts of a boarder
  */
 const BORDER: {[name: string]: RegExp} = {
@@ -163,7 +163,7 @@ const BORDER: {[name: string]: RegExp} = {
     style: /^(?:none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset|inherit|initial|unset)$/
 };
 
-/*
+/**
  * Split a width-style-color border definition
  *
  * @param{string} name   The style to be processed
@@ -184,7 +184,7 @@ function splitWSC(name: string) {
     }
 }
 
-/*
+/**
  * Combine with-style-color border definition from children
  *
  * @param{string} name   The style to be processed
@@ -205,7 +205,7 @@ function combineWSC(name: string) {
 }
 
 /*********************************************************/
-/*
+/**
  * Patterns for the parts of a font declaration
  */
 const FONT: {[name: string]: RegExp} = {
@@ -238,7 +238,7 @@ const FONT: {[name: string]: RegExp} = {
                      '(?:\/(?:normal|[\d.\+](?:%|[a-z]+)?))?$')
 };
 
-/*
+/**
  * Split a font declaration into is parts (not perfect but good enough for now)
  *
  * @param{string} name   The style to be processed
@@ -282,7 +282,7 @@ function splitFont(name: string) {
     delete this.styles[name]; // only use the parts, not the font declaration itself
 }
 
-/*
+/**
  * @param{string} name   The style to be processed
  * @param{{[name: string]: string | string[]}} value  The list of parts detected above
  */
@@ -300,18 +300,18 @@ function saveFontParts(name: string, value: {[name: string]: string | string[]})
     }
 }
 
-/*
+/**
  * Combine font parts into one (we don't actually do that)
  */
 function combineFont(name: string) {}
 
 /*********************************************************/
-/*
+/**
  * Implements the Styles object (lite version of CssStyleDeclaration)
  */
 export class Styles {
 
-    /*
+    /**
      * Patterns for style values and comments
      */
     public static pattern: {[name: string]: RegExp} = {
@@ -319,7 +319,7 @@ export class Styles {
         comment: /\/\*[^]*?\*\//g
     };
 
-    /*
+    /**
      * The mapping of parents to children, and how to split and combine them
      */
     public static connect: connections = {
@@ -377,12 +377,12 @@ export class Styles {
         }
     };
 
-    /*
+    /**
      * The list of styles defined for this declaration
      */
     protected styles: StyleList;
 
-    /*
+    /**
      * @param{string} cssText  The initial definition for the style
      * @constructor
      */
@@ -390,7 +390,7 @@ export class Styles {
         this.parse(cssText);
     }
 
-    /*
+    /**
      * @return{string}  The CSS string for the styles currently defined
      */
     public get cssText() {
@@ -404,7 +404,7 @@ export class Styles {
         return styles.join('; ');
     }
 
-    /*
+    /**
      * @param{string} name   The name of the style to set
      * @param{srting|number|boolean}  The value to set it to
      */
@@ -431,7 +431,7 @@ export class Styles {
         }
     }
 
-    /*
+    /**
      * @param{string} name  The name of the style to get
      * @return{string}      The value of the style (or empty string if not defined)
      */
@@ -440,7 +440,7 @@ export class Styles {
         return (this.styles.hasOwnProperty(name) ? this.styles[name] : '');
     }
 
-    /*
+    /**
      * @param{string} name   The name of the style to set (without causing parent updates)
      * @param{string} value  The value to set it to
      */
@@ -454,7 +454,7 @@ export class Styles {
         }
     }
 
-    /*
+    /**
      * @param{string} name   The name of the style whose parent is to be combined
      */
     protected combineChildren(name: string) {
@@ -465,7 +465,7 @@ export class Styles {
         }
     }
 
-    /*
+    /**
      * @param{string} name   The name of the style whose parent style is to be found
      * @return{string}       The name of the parent, or '' if none
      */
@@ -474,7 +474,7 @@ export class Styles {
         return (name === parent ? '' : parent);
     }
 
-    /*
+    /**
      * @param{string} name   The name of the parent style
      * @param{string} child  The suffix to be added to the parent
      * @preturn{string}      The combined name
@@ -497,7 +497,7 @@ export class Styles {
         return name + '-' + child;
     }
 
-    /*
+    /**
      * @param{string} name  The name of a style to normalize
      * @return{string}      The name converted from CamelCase to lowercase with dashes
      */
@@ -505,7 +505,7 @@ export class Styles {
         return name.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
     }
 
-    /*
+    /**
      * @param{string} cssText  A style text string to be parsed into separate styles
      *                         (by using this.set(), we get all the sub-styles created
      *                          as well as the merged style shorthands)

--- a/mathjax3-ts/util/Styles.ts
+++ b/mathjax3-ts/util/Styles.ts
@@ -51,8 +51,8 @@ const WSC = ['width', 'style', 'color'];
 /**
  * Split a style at spaces (taking quotation marks and commas into account)
  *
- * @param{string} text  The combined styles to be split at spaces
- * @return{string[]}    Array of parts of the style (separated by spaces)
+ * @param {string} text  The combined styles to be split at spaces
+ * @return {string[]}    Array of parts of the style (separated by spaces)
  */
 function splitSpaces(text: string) {
     const parts = text.split(/((?:'[^']*'|"[^"]*"|,[\s\n]|[^\s\n])*)/g);
@@ -73,7 +73,7 @@ function splitSpaces(text: string) {
  *    x y z       same as x y z y
  *    x y z w     each specified
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 
 function splitTRBL(name: string) {
@@ -99,7 +99,7 @@ function splitTRBL(name: string) {
  * Combine top-right-bottom-left into one entry
  * (removing unneeded values)
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function combineTRBL(name: string) {
     const children = Styles.connect[name].children;
@@ -128,7 +128,7 @@ function combineTRBL(name: string) {
 /**
  * Use the same value for all children
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function splitSame(name: string) {
     for (const child of Styles.connect[name].children) {
@@ -140,7 +140,7 @@ function splitSame(name: string) {
  * Check that all children have the same values and
  * if so, set the parent to that value
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function combineSame(name: string) {
     const children = [...Styles.connect[name].children];
@@ -166,7 +166,7 @@ const BORDER: {[name: string]: RegExp} = {
 /**
  * Split a width-style-color border definition
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function splitWSC(name: string) {
     let parts = {width: '', style: '', color: ''} as StyleList;
@@ -187,7 +187,7 @@ function splitWSC(name: string) {
 /**
  * Combine with-style-color border definition from children
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function combineWSC(name: string) {
     const parts = [] as string[];
@@ -241,7 +241,7 @@ const FONT: {[name: string]: RegExp} = {
 /**
  * Split a font declaration into is parts (not perfect but good enough for now)
  *
- * @param{string} name   The style to be processed
+ * @param {string} name   The style to be processed
  */
 function splitFont(name: string) {
     const parts = splitSpaces(this.styles[name]);
@@ -283,8 +283,8 @@ function splitFont(name: string) {
 }
 
 /**
- * @param{string} name   The style to be processed
- * @param{{[name: string]: string | string[]}} value  The list of parts detected above
+ * @param {string} name   The style to be processed
+ * @param {{[name: string]: string | string[]}} value  The list of parts detected above
  */
 function saveFontParts(name: string, value: {[name: string]: string | string[]}) {
     for (const child of Styles.connect[name].children) {
@@ -383,7 +383,7 @@ export class Styles {
     protected styles: StyleList;
 
     /**
-     * @param{string} cssText  The initial definition for the style
+     * @param {string} cssText  The initial definition for the style
      * @constructor
      */
     constructor(cssText: string = '') {
@@ -391,7 +391,7 @@ export class Styles {
     }
 
     /**
-     * @return{string}  The CSS string for the styles currently defined
+     * @return {string}  The CSS string for the styles currently defined
      */
     public get cssText() {
         const styles = [] as string[];
@@ -405,8 +405,8 @@ export class Styles {
     }
 
     /**
-     * @param{string} name   The name of the style to set
-     * @param{srting|number|boolean}  The value to set it to
+     * @param {string} name   The name of the style to set
+     * @param {srting|number|boolean}  The value to set it to
      */
     public set(name: string, value: string | number | boolean) {
         name = this.normalizeName(name);
@@ -432,8 +432,8 @@ export class Styles {
     }
 
     /**
-     * @param{string} name  The name of the style to get
-     * @return{string}      The value of the style (or empty string if not defined)
+     * @param {string} name  The name of the style to get
+     * @return {string}      The value of the style (or empty string if not defined)
      */
     public get(name: string) {
         name = this.normalizeName(name);
@@ -441,8 +441,8 @@ export class Styles {
     }
 
     /**
-     * @param{string} name   The name of the style to set (without causing parent updates)
-     * @param{string} value  The value to set it to
+     * @param {string} name   The name of the style to set (without causing parent updates)
+     * @param {string} value  The value to set it to
      */
     protected setStyle(name: string, value: string) {
         this.styles[name] = value;
@@ -455,7 +455,7 @@ export class Styles {
     }
 
     /**
-     * @param{string} name   The name of the style whose parent is to be combined
+     * @param {string} name   The name of the style whose parent is to be combined
      */
     protected combineChildren(name: string) {
         const parent = this.parentName(name);
@@ -466,8 +466,8 @@ export class Styles {
     }
 
     /**
-     * @param{string} name   The name of the style whose parent style is to be found
-     * @return{string}       The name of the parent, or '' if none
+     * @param {string} name   The name of the style whose parent style is to be found
+     * @return {string}       The name of the parent, or '' if none
      */
     protected parentName(name: string) {
         const parent = name.replace(/-[^-]*$/, '');
@@ -475,9 +475,9 @@ export class Styles {
     }
 
     /**
-     * @param{string} name   The name of the parent style
-     * @param{string} child  The suffix to be added to the parent
-     * @preturn{string}      The combined name
+     * @param {string} name   The name of the parent style
+     * @param {string} child  The suffix to be added to the parent
+     * @preturn {string}      The combined name
      */
     protected childName(name: string, child: string) {
         //
@@ -498,17 +498,17 @@ export class Styles {
     }
 
     /**
-     * @param{string} name  The name of a style to normalize
-     * @return{string}      The name converted from CamelCase to lowercase with dashes
+     * @param {string} name  The name of a style to normalize
+     * @return {string}      The name converted from CamelCase to lowercase with dashes
      */
     protected normalizeName(name: string) {
         return name.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
     }
 
     /**
-     * @param{string} cssText  A style text string to be parsed into separate styles
-     *                         (by using this.set(), we get all the sub-styles created
-     *                          as well as the merged style shorthands)
+     * @param {string} cssText  A style text string to be parsed into separate styles
+     *                          (by using this.set(), we get all the sub-styles created
+     *                           as well as the merged style shorthands)
      */
     protected parse(cssText: string = '') {
         let PATTERN = (this.constructor as typeof Styles).pattern;

--- a/mathjax3-ts/util/lengths.ts
+++ b/mathjax3-ts/util/lengths.ts
@@ -79,10 +79,10 @@ export const MATHSPACE: {[name: string]: number} = {
 
 
 /**
- * @param{string|number} length  A dimension (giving number and units) to be converted to ems
- * @param{number} size           The default size of the dimension (for percentage values)
- * @param{number} scale          The current scaling factor (to handle absolute units)
- * @return{number}               The dimension converted to ems
+ * @param {string|number} length  A dimension (giving number and units) to be converted to ems
+ * @param {number} size           The default size of the dimension (for percentage values)
+ * @param {number} scale          The current scaling factor (to handle absolute units)
+ * @return {number}               The dimension converted to ems
  */
 export function length2em(length: string | number, size: number = 0, scale: number = 1, em: number = 16) {
     if (typeof length !== 'string') {
@@ -112,16 +112,16 @@ export function length2em(length: string | number, size: number = 0, scale: numb
 }
 
 /**
- * @param{number} m  A number to be shown as a percent
- * @return{string}   The number m as a percent
+ * @param {number} m  A number to be shown as a percent
+ * @return {string}   The number m as a percent
  */
 export function percent(m: number) {
     return (100 * m).toFixed(1).replace(/\.?0+$/, '') + '%';
 }
 
 /**
- * @param{number} m  A number to be shown in ems
- * @return{string}   The number with units of ems
+ * @param {number} m  A number to be shown in ems
+ * @return {string}   The number with units of ems
  */
 export function em(m: number) {
     if (Math.abs(m) < .001) return '0';
@@ -129,9 +129,9 @@ export function em(m: number) {
 }
 
 /**
- * @param{number} m   A number to be shown in ems, but rounded to pixel boundaries
- * @param{number} em  The number of pixels in an em
- * @return{string}    The number with units of em
+ * @param {number} m   A number to be shown in ems, but rounded to pixel boundaries
+ * @param {number} em  The number of pixels in an em
+ * @return {string}    The number with units of em
  */
 export function emRounded(m: number, em: number = 16) {
     m = (Math.round(m * em) + .05) / em;
@@ -141,10 +141,10 @@ export function emRounded(m: number, em: number = 16) {
 
 
 /**
- * @param{number} m   A number of em's to be shown as pixels
- * @param{number} M   The minimum number of pixels to allow
- * @param{number} em  The number of pixels in an em
- * @return{string}    The number with units of px
+ * @param {number} m   A number of em's to be shown as pixels
+ * @param {number} M   The minimum number of pixels to allow
+ * @param {number} em  The number of pixels in an em
+ * @return {string}    The number with units of px
  */
 export function px(m: number, M: number = -BIGDIMEN, em: number = 16) {
     m *= em;

--- a/mathjax3-ts/util/lengths.ts
+++ b/mathjax3-ts/util/lengths.ts
@@ -21,12 +21,12 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-/*
+/**
  *  A very large number
  */
 export const BIGDIMEN = 1000000;
 
-/*
+/**
  *  Sizes of various units in pixels
  */
 export const UNITS: {[unit: string]: number} = {
@@ -38,7 +38,7 @@ export const UNITS: {[unit: string]: number} = {
     mm: 96 / 25.4        // 10 mm to a cm
 };
 
-/*
+/**
  *  Sizes of various relative units in em's
  */
 export const RELUNITS: {[unit: string]: number} = {
@@ -47,7 +47,7 @@ export const RELUNITS: {[unit: string]: number} = {
     mu: 1 / 18       // 18mu to an em for the scriptlevel
 };
 
-/*
+/**
  *  The various named spaces
  */
 export const MATHSPACE: {[name: string]: number} = {
@@ -78,7 +78,7 @@ export const MATHSPACE: {[name: string]: number} = {
 };
 
 
-/*
+/**
  * @param{string|number} length  A dimension (giving number and units) to be converted to ems
  * @param{number} size           The default size of the dimension (for percentage values)
  * @param{number} scale          The current scaling factor (to handle absolute units)
@@ -111,7 +111,7 @@ export function length2em(length: string | number, size: number = 0, scale: numb
     return m * size;            // relative to size
 }
 
-/*
+/**
  * @param{number} m  A number to be shown as a percent
  * @return{string}   The number m as a percent
  */
@@ -119,7 +119,7 @@ export function percent(m: number) {
     return (100 * m).toFixed(1).replace(/\.?0+$/, '') + '%';
 }
 
-/*
+/**
  * @param{number} m  A number to be shown in ems
  * @return{string}   The number with units of ems
  */
@@ -128,7 +128,7 @@ export function em(m: number) {
     return (m.toFixed(3).replace(/\.?0+$/, '')) + 'em';
 }
 
-/*
+/**
  * @param{number} m   A number to be shown in ems, but rounded to pixel boundaries
  * @param{number} em  The number of pixels in an em
  * @return{string}    The number with units of em
@@ -140,7 +140,7 @@ export function emRounded(m: number, em: number = 16) {
 }
 
 
-/*
+/**
  * @param{number} m   A number of em's to be shown as pixels
  * @param{number} M   The minimum number of pixels to allow
  * @param{number} em  The number of pixels in an em

--- a/mathjax3-ts/util/numeric.ts
+++ b/mathjax3-ts/util/numeric.ts
@@ -22,16 +22,16 @@
  */
 
 /**
- * @param{number[]} A  The array to sum
- * @return{number}     The summ of the elements in A
+ * @param {number[]} A  The array to sum
+ * @return {number}     The summ of the elements in A
  */
 export function sum(A: number[]) {
     return A.reduce((a, b) => a + b, 0);
 }
 
 /**
- * @param{number[]} A  The array whose maximum entry is sought
- * @return{number}     The largest entry in the array
+ * @param {number[]} A  The array whose maximum entry is sought
+ * @return {number}     The largest entry in the array
  */
 export function max(A: number[]) {
     return A.reduce((a, b) => Math.max(a, b), 0);

--- a/mathjax3-ts/util/numeric.ts
+++ b/mathjax3-ts/util/numeric.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-/*
+/**
  * @param{number[]} A  The array to sum
  * @return{number}     The summ of the elements in A
  */
@@ -29,7 +29,7 @@ export function sum(A: number[]) {
     return A.reduce((a, b) => a + b, 0);
 }
 
-/*
+/**
  * @param{number[]} A  The array whose maximum entry is sought
  * @return{number}     The largest entry in the array
  */

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -25,8 +25,8 @@
 /**
  * Sort strings by length
  *
- * @param{string} a, b  The strings to be compared
- * @return{number}  -1 id a < b, 0 of a === b, 1 if a > b
+ * @param {string} a, b  The strings to be compared
+ * @return {number}  -1 id a < b, 0 of a === b, 1 if a > b
  */
 export function sortLength(a: string, b: string) {
     return a.length !== b.length ? b.length - a.length : a === b ? 0 : a < b ? -1 : 1;
@@ -35,8 +35,8 @@ export function sortLength(a: string, b: string) {
 /**
  * Quote a string for use in regular expressions
  *
- * @param{string} text  The text whose regex characters are to be quoted
- * @return{string}  The quoted string
+ * @param {string} text  The text whose regex characters are to be quoted
+ * @return {string}  The quoted string
  */
 export function quotePattern(text: string) {
     return text.replace(/([\^$(){}+*?\-|\[\]\:\\])/g, '\\$1');
@@ -45,8 +45,8 @@ export function quotePattern(text: string) {
 /**
  * Convert a UTF-8 string to an array of unicode code points
  *
- * @param{string} text  The string to be turned into unicode positions
- * @return{number[]}  Array of numbers representing the string's unicode character positions
+ * @param {string} text  The string to be turned into unicode positions
+ * @return {number[]}  Array of numbers representing the string's unicode character positions
  */
 export function unicodeChars(text: string) {
     let unicode: number[] = [];
@@ -63,8 +63,8 @@ export function unicodeChars(text: string) {
 /**
  * Test if a value is a percentage
  *
- * @param{string} x   The string to test
- * @return{boolean}   True if the string ends with a percent sign
+ * @param {string} x   The string to test
+ * @return {boolean}   True if the string ends with a percent sign
  */
 export function isPercent(x: string) {
     return x.match(/%\s*$/);
@@ -73,8 +73,8 @@ export function isPercent(x: string) {
 /**
  * Split a space-separated string of values
  *
- * @param{string} x   The string to be split
- * @return{string[]}  The list of white-space-separated "words" in the string
+ * @param {string} x   The string to be split
+ * @return {string[]}  The list of white-space-separated "words" in the string
  */
 export function split(x: string) {
     return x.trim().split(/\s+/);

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -22,7 +22,7 @@
  */
 
 
-/*
+/**
  * Sort strings by length
  *
  * @param{string} a, b  The strings to be compared
@@ -32,7 +32,7 @@ export function sortLength(a: string, b: string) {
     return a.length !== b.length ? b.length - a.length : a === b ? 0 : a < b ? -1 : 1;
 }
 
-/*
+/**
  * Quote a string for use in regular expressions
  *
  * @param{string} text  The text whose regex characters are to be quoted
@@ -42,7 +42,7 @@ export function quotePattern(text: string) {
     return text.replace(/([\^$(){}+*?\-|\[\]\:\\])/g, '\\$1');
 }
 
-/*
+/**
  * Convert a UTF-8 string to an array of unicode code points
  *
  * @param{string} text  The string to be turned into unicode positions
@@ -60,7 +60,7 @@ export function unicodeChars(text: string) {
     return unicode;
 }
 
-/*
+/**
  * Test if a value is a percentage
  *
  * @param{string} x   The string to test
@@ -70,7 +70,7 @@ export function isPercent(x: string) {
     return x.match(/%\s*$/);
 }
 
-/*
+/**
  * Split a space-separated string of values
  *
  * @param{string} x   The string to be split


### PR DESCRIPTION
This PR add the proper comment opening delimiters (`/**` instead of `/*`) to the jsdoc comments in the files I wrote.  It also adds a few missing ones as well.

There shouldn't be anything to review, really, unless you see anything else wrong with the jsdoc comments.