### PR TITLE
Use only CSS for menclose notations in CHTML

### DIFF
--- a/mathjax3-ts/output/chtml/Notation.ts
+++ b/mathjax3-ts/output/chtml/Notation.ts
@@ -82,7 +82,7 @@ export const DiagonalStrike = <N, T, D>(name: string, neg: number) =>
             transform: 'rotate(' + node.units(-neg * a) + 'rad) translateY(' + t + 'em)',
         }}));
         node.adaptor.append(node.chtml, strike);
-    });
+    })(name, neg);
 
 /**
  * @param {string} name   The name of the diagonal arrow to define

--- a/mathjax3-ts/output/chtml/Notation.ts
+++ b/mathjax3-ts/output/chtml/Notation.ts
@@ -79,10 +79,10 @@ export const DiagonalStrike = <N, T, D>(name: string, neg: number) =>
         const t = neg * node.thickness / 2;
         const strike = node.adjustBorder(node.html(cname, {style: {
             width: node.em(W),
-            transform: 'rotate(' + node.units(-neg * a) + 'rad) translateY(' + t + 'em)',
+            transform: 'rotate(' + node.fixed(-neg * a) + 'rad) translateY(' + t + 'em)',
         }}));
         node.adaptor.append(node.chtml, strike);
-    })(name, neg);
+    })(name);
 
 /**
  * @param {string} name   The name of the diagonal arrow to define

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -403,7 +403,7 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
 
     /**
      * @param {N} line           The arrow shaft to be adjusted
-     * @param {number{ t         The arrow shaft thickness
+     * @param {number} t         The arrow shaft thickness
      * @param {number} x         The arrow head x size
      * @param {boolean} double   True if the arrow is double-headed
      */

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -31,6 +31,18 @@ import {MmlNode, AbstractMmlNode, AttributeList} from '../../../core/MmlTree/Mml
 import {OptionList} from '../../../util/Options.js';
 import {StyleList, StyleData} from '../../common/CssStyles.js';
 import {split} from '../../../util/string.js';
+import {em} from '../../../util/lengths.js';
+
+/*****************************************************************/
+
+/**
+ *  The skew angle needed for the arrow head pieces
+ */
+function Angle(x: number, dx: number) {
+    return Math.atan(dx / x).toFixed(3).replace(/\.?0+$/, '');
+}
+
+const ANGLE = Angle(Notation.ARROWX, Notation.ARROWDX);
 
 /*****************************************************************/
 /**
@@ -70,53 +82,85 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
             'border-top': Notation.SOLID,
             position: 'absolute',
             left: 0, right: 0, bottom: '50%',
-            transform: 'translateY(' + (Notation.THICKNESS / 2) + 'em)'
+            transform: 'translateY(' + em(Notation.THICKNESS / 2) + ')'
         },
         'mjx-menclose > mjx-vstrike': {
             'border-left': Notation.SOLID,
             position: 'absolute',
             top: 0, bottom: 0, right: '50%',
-            transform: 'translateX(' + (Notation.THICKNESS / 2) + 'em)'
+            transform: 'translateX(' + em(Notation.THICKNESS / 2) + ')'
         },
         'mjx-menclose > mjx-rbox': {
             position: 'absolute',
             top: 0, bottom: 0, right: 0, left: 0,
             'border': Notation.SOLID,
-            'border-radius': (Notation.THICKNESS + Notation.PADDING) + 'em'
+            'border-radius': em(Notation.THICKNESS + Notation.PADDING)
         },
-        'mjx-menclose > svg.mjx-circle': {
+        'mjx-menclose > mjx-cbox': {
             position: 'absolute',
             top: 0, bottom: 0, right: 0, left: 0,
-            width: '100%', height: '100%'
+            'border': Notation.SOLID,
+            'border-radius': '50%'
         },
-        'mjx-menclose > svg.mjx-circle > ellipse': {
-            'stroke-width': Notation.THICKNESS,
-            'stroke': 'currentColor',
-            'fill': 'none'
-        },
-        'mjx-menclose > svg.mjx-arrow': {
+        'mjx-menclose > mjx-arrow': {
             position: 'absolute',
+            left: 0, bottom: '50%', height: 0, width: 0
         },
-        'mjx-menclose > svg.mjx-arrow > path': {
-            'stroke': 'none',
-            'fill': 'currentColor'
-        },
-        'mjx-menclose > svg.mjx-arrow > line': {
-            'stroke': 'currentColor',
-            'stroke-width': Notation.THICKNESS,
-            'stroke-linecap': 'round'
-        },
-        'mjx-menclose > svg.mjx-longdiv': {
+        'mjx-menclose > mjx-arrow > *': {
+            display: 'block',
             position: 'absolute',
-            top: 0, bottom: 0, left: 0, right: 0,
-            width: '100%', height: '100%'
+            'transform-origin': 'bottom',
+            'border-left': em(Notation.THICKNESS * Notation.ARROWX) + ' solid',
+            'border-right': 0,
+            'box-sizing': 'border-box'
         },
-        'mjx-menclose > svg.mjx-longdiv > path': {
-            'stroke': 'currentColor',
-            'stroke-width': Notation.THICKNESS,
-            'stroke-linecap': 'round',
-            'stroke-linejoin': 'round',
-            fill: 'none',
+        'mjx-menclose > mjx-arrow > mjx-aline': {
+            left: 0, top: em(-Notation.THICKNESS / 2),
+            right: em(Notation.THICKNESS * (Notation.ARROWX - 1)), height: 0,
+            'border-top': em(Notation.THICKNESS) + ' solid',
+            'border-left': 0
+        },
+        'mjx-menclose > mjx-arrow[double] > mjx-aline': {
+            left: em(Notation.THICKNESS * (Notation.ARROWX - 1)), height: 0,
+        },
+        'mjx-menclose > mjx-arrow > mjx-rthead': {
+            transform: 'skewX(' + ANGLE + 'rad)',
+            right: 0, bottom: '-1px',
+            'border-bottom': '1px solid transparent',
+            'border-top': em(Notation.THICKNESS * Notation.ARROWY) + ' solid transparent'
+        },
+        'mjx-menclose > mjx-arrow > mjx-rbhead': {
+            transform: 'skewX(-' + ANGLE + 'rad)',
+            'transform-origin': 'top',
+            right: 0, top: '-1px',
+            'border-top': '1px solid transparent',
+            'border-bottom': em(Notation.THICKNESS * Notation.ARROWY) + ' solid transparent'
+        },
+        'mjx-menclose > mjx-arrow > mjx-lthead': {
+            transform: 'skewX(-' + ANGLE + 'rad)',
+            left: 0, bottom: '-1px',
+            'border-left': 0,
+            'border-right': em(Notation.THICKNESS * Notation.ARROWX) + ' solid',
+            'border-bottom': '1px solid transparent',
+            'border-top': em(Notation.THICKNESS * Notation.ARROWY) + ' solid transparent'
+        },
+        'mjx-menclose > mjx-arrow > mjx-lbhead': {
+            transform: 'skewX(' + ANGLE + 'rad)',
+            'transform-origin': 'top',
+            left: 0, top: '-1px',
+            'border-left': 0,
+            'border-right': em(Notation.THICKNESS * Notation.ARROWX) + ' solid',
+            'border-top': '1px solid transparent',
+            'border-bottom': em(Notation.THICKNESS * Notation.ARROWY) + ' solid transparent'
+        },
+        'mjx-menclose > dbox': {
+            position: 'absolute',
+            top: 0, bottom: 0, left: em(-1.5 * Notation.PADDING),
+            width: em(3 * Notation.PADDING),
+            border: em(Notation.THICKNESS) + ' solid',
+            'border-radius': '50%',
+            'clip-path': 'inset(0 0 0 ' + em(1.5 * Notation.PADDING) + ')',
+            'box-sizing': 'border-box'
         }
     };
 
@@ -161,12 +205,7 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
         }],
 
         ['circle', {
-            renderer: (node, child) => {
-                const adaptor = node.adaptor;
-                const {w, h, d} = node.getBBox();
-                const circle = node.svg('circle', [0, 0, w, h + d], [node.ellipse(w, h + d)]);
-                adaptor.append(node.chtml, circle);
-            },
+            renderer: Notation.RenderElement('cbox'),
             bbox: Notation.fullBBox
         }],
 
@@ -213,19 +252,22 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
 
         ['longdiv', {
             //
-            // Use a line along the top followed by a half arc at the left
+            // Use a line along the top followed by a half ellipse at the left
             //
             renderer: (node, child) => {
                 const adaptor = node.adaptor;
-                const {w, h, d} = node.getBBox();
-                const t = node.thickness / 2;
-                const p = 1.5 * node.padding;
-                adaptor.append(node.chtml, node.svg('longdiv', [0, 0, w, h + d], [
-                    node.path(
-                        'M', w - t, t,  'L', t, t,
-                        'a', p, (h + d) / 2 - t,  0, 0, 1,  t, h + d - 3 * t
-                    )
-                ]));
+                adaptor.setStyle(child, 'border-top', node.em(node.thickness) + ' solid');
+                const arc = adaptor.append(node.chtml, node.html('dbox'));
+                const t = node.thickness;
+                const p = node.padding;
+                if (t !== Notation.THICKNESS) {
+                    adaptor.setStyle(arc, 'border-width', node.em(t));
+                }
+                if (p !== Notation.PADDING) {
+                    adaptor.setStyle(arc, 'left', node.em(-1.5 * p));
+                    adaptor.setStyle(arc, 'width', node.em(3 * p));
+                    adaptor.setStyle(arc, 'clip-path', 'inset(0 0 0 ' + node.em(1.5 * p) + ')');
+                }
             },
             bbox: (node) => {
                 const p = node.padding;
@@ -300,15 +342,85 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
     /********************************************************/
 
     /**
-     * @override
+     * Create an arrow using HTML elements
+     *
+     * @param {number} w        The length of the arrow
+     * @param {number} a        The angle for the arrow
+     * @param {boolean} double  True if this is a double-headed arrow
+     * @return {N}               The newly created arrow
      */
-    public svgNode(kind: string, properties: OptionList = {}, nodes: N[] = []) {
-        return this.html(kind, properties, nodes);
+    public arrow(w: number, a: number, double: boolean = false) {
+        const W = this.getBBox().w;
+        const style = {width: this.em(w)} as OptionList;
+        if (W !== w) {
+            style.left = this.em((W - w) / 2);
+        }
+        if (a) {
+            style.transform = 'rotate(' + this.fixed(a) + 'rad)';
+        }
+        const arrow = this.html('mjx-arrow', {style: style}, [
+            this.html('mjx-aline'), this.html('mjx-rthead'), this.html('mjx-rbhead')
+        ]);
+        if (double) {
+            this.adaptor.append(arrow, this.html('mjx-lthead'));
+            this.adaptor.append(arrow, this.html('mjx-lbhead'));
+            this.adaptor.setAttribute(arrow, 'double', 'true');
+        }
+        this.adjustArrow(arrow, double);
+        return arrow;
     }
 
     /**
+     * @param {N} arrow          The arrow whose thickness and arrow head is to be adjusted
+     * @param {boolean} double   True if the arrow is double-headed
+     */
+    protected adjustArrow(arrow: N, double: boolean) {
+        const t = this.thickness;
+        const head = this.arrowhead;
+        if (head.x === Notation.ARROWX && head.y === Notation.ARROWY &&
+            head.dx === Notation.ARROWDX && t === Notation.THICKNESS) return;
+        const [x, y, dx] = [t * head.x, t * head.y, t * head.dx].map(x => this.em(x));
+        const a = Angle(head.x, head.dx);
+        const [line, rthead, rbhead, lthead, lbhead] = this.adaptor.childNodes(arrow);
+        this.adjustHead(rthead, [y, '0', '1px', x], a);
+        this.adjustHead(rbhead, ['1px', '0', y, x], '-' + a);
+        this.adjustHead(lthead, [y, x, '1px', '0'], '-' + a);
+        this.adjustHead(lbhead, ['1px', x, y, '0'], a);
+        this.adjustLine(line, t, head.x, double);
+    }
+
+    /**
+     * @param {N} head            The piece of arrow head to be adjusted
+     * @param {string[]} border   The border sizes [T, R, B, L]
+     * @param {string} a          The skew angle for the piece
+     */
+    protected adjustHead(head: N, border: string[], a: string) {
+        if (head) {
+            this.adaptor.setStyle(head, 'border-width', border.join(' '));
+            this.adaptor.setStyle(head, 'transform', 'skewX(' + a + 'rad)');
+        }
+    }
+
+    /**
+     * @param {N} line           The arrow shaft to be adjusted
+     * @param {number{ t         The arrow shaft thickness
+     * @param {number} x         The arrow head x size
+     * @param {boolean} double   True if the arrow is double-headed
+     */
+    protected adjustLine(line: N, t: number, x: number, double: boolean) {
+        this.adaptor.setStyle(line, 'borderTop', this.em(t) + ' solid');
+        this.adaptor.setStyle(line, 'top', this.em(-t / 2));
+        this.adaptor.setStyle(line, 'right', this.em(t * (x - 1)));
+        if (double) {
+            this.adaptor.setStyle(line, 'left', this.em(t * (x - 1)));
+        }
+    }
+
+    /********************************************************/
+
+    /**
      * @param {N} node   The HTML element whose border width must be
-     *                  adjusted if the thickness isn't the default
+     *                   adjusted if the thickness isn't the default
      * @return {N}       The adjusted element
      */
     public adjustBorder(node: N) {
@@ -316,6 +428,18 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
             this.adaptor.setStyle(node, 'borderWidth', this.em(this.thickness));
         }
         return node;
+    }
+
+    /**
+     * @param {N} shape   The svg element whose stroke-thickness must be
+     *                    adjusted if the thickness isn't the default
+     * @return {N}        The adjusted element
+     */
+    public adjustThickness(shape: N) {
+        if (this.thickness !== Notation.THICKNESS) {
+            this.adaptor.setStyle(shape, 'strokeWidth', this.units(this.thickness));
+        }
+        return shape;
     }
 
     /********************************************************/
@@ -326,6 +450,16 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
      */
     public em(m: number) {
         return super.em(m);
+    }
+
+    /**
+     * @param {number} m    A number to be shown with a fixed number of digits
+     * @param {number=} n   The number of digits to use
+     * @return {string}     The formatted number
+     */
+    fixed(m: number, n: number = 3) {
+        if (Math.abs(m) < .0006) return "0";
+        return m.toFixed(n).replace(/\.?0+$/,"");
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -448,8 +448,10 @@ CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstruc
      * @return {string}     The formatted number
      */
     fixed(m: number, n: number = 3) {
-        if (Math.abs(m) < .0006) return "0";
-        return m.toFixed(n).replace(/\.?0+$/,"");
+        if (Math.abs(m) < .0006) {
+            return '0';
+        }
+        return m.toFixed(n).replace(/\.?0+$/, '');
     }
 
     /**

--- a/mathjax3-ts/output/common/Notation.ts
+++ b/mathjax3-ts/output/common/Notation.ts
@@ -99,6 +99,8 @@ export const fullBBox = ((node) => new Array(4).fill(node.thickness + node.paddi
 export const fullPadding = ((node) => new Array(4).fill(node.padding)) as BBoxExtender<Menclose>;
 export const fullBorder = ((node) => new Array(4).fill(node.thickness)) as BBoxBorder<Menclose>;
 
+/*****************************************************************/
+
 /**
  * The length of an arrowhead
  */
@@ -166,6 +168,8 @@ export const arrowBBox = {
     updown:    (node) => arrowBBoxW(node, [arrowHead(node), 0, arrowHead(node), 0]),
     leftright: (node) => arrowBBoxHD(node, [0, arrowHead(node), 0, arrowHead(node)])
 } as {[name: string]: BBoxExtender<Menclose>};
+
+/*****************************************************************/
 
 /**
  * @param {Renderer} render     The function for adding the border to the node
@@ -249,6 +253,8 @@ export const CommonBorder2 = <W extends Menclose, N>(render: Renderer<W, N>) => 
     }
 };
 
+/*****************************************************************/
+
 /**
  * @param {string => Renderer} render      The function for adding the strike to the node
  * @return {(string, number) => DefPair}   The function returning the notation definition for the diagonal strike
@@ -256,10 +262,9 @@ export const CommonBorder2 = <W extends Menclose, N>(render: Renderer<W, N>) => 
 export const CommonDiagonalStrike = <W extends Menclose, N>(render: (sname: string) => Renderer<W, N>) => {
     /**
      * @param {string} name  The name of the diagonal strike to define
-     * @param {number} neg   1 or -1 to use with the angle
      * @return {DefPair}     The notation definition for the diagonal strike
      */
-    return (name: string, neg: number) => {
+    return (name: string) => {
         const cname = 'mjx-' + name.charAt(0) + 'strike';
         return [name + 'diagonalstrike', {
             //
@@ -273,6 +278,8 @@ export const CommonDiagonalStrike = <W extends Menclose, N>(render: (sname: stri
         }] as DefPair<W, N>;
     }
 };
+
+/*****************************************************************/
 
 /**
  * @param {Renderer} render     The function to add the arrow to the node

--- a/mathjax3-ts/output/common/Notation.ts
+++ b/mathjax3-ts/output/common/Notation.ts
@@ -93,13 +93,6 @@ export type Side = keyof typeof sideIndex;
 export const sideNames = Object.keys(sideIndex) as Side[];
 
 /**
- * the spacing to leave for an arrowhead
- */
-export const arrowHead = (node: Menclose) => {
-    return Math.max(node.padding, node.thickness * (node.arrowhead.x + node.arrowhead.dx + 1));
-};
-
-/**
  * Common BBox and Border functions
  */
 export const fullBBox = ((node) => new Array(4).fill(node.thickness + node.padding)) as BBoxExtender<Menclose>;
@@ -107,44 +100,71 @@ export const fullPadding = ((node) => new Array(4).fill(node.padding)) as BBoxEx
 export const fullBorder = ((node) => new Array(4).fill(node.thickness)) as BBoxBorder<Menclose>;
 
 /**
+ * The length of an arrowhead
+ */
+export const arrowHead = (node: Menclose) => {
+    return Math.max(node.padding, node.thickness * (node.arrowhead.x + node.arrowhead.dx + 1));
+};
+
+/**
+ * Adjust short bbox for tall arrow heads
+ */
+export const arrowBBoxHD = (node: Menclose, TRBL: number[]) => {
+    if (node.childNodes[0]) {
+        const {h, d} = node.childNodes[0].getBBox();
+        TRBL[0] = TRBL[2] = Math.max(0, node.thickness * node.arrowhead.y - (h + d) / 2);
+    }
+    return TRBL;
+}
+
+/**
+ * Adjust thin bbox for wide arrow heads
+ */
+export const arrowBBoxW = (node: Menclose, TRBL: number[]) => {
+    if (node.childNodes[0]) {
+        const {w} = node.childNodes[0].getBBox();
+        TRBL[1] = TRBL[3] = Math.max(0, node.thickness * node.arrowhead.y - w / 2);
+    }
+    return TRBL;
+}
+
+/**
  * The data for horizontal and vertical arrow notations
- *   [angle, neg, double, origin, offset, isVertical, remove]
+ *   [angle, double, isVertical, remove]
  */
 export const arrowDef = {
-    up:    [-Math.PI / 2,  1, false, 'bottom left', 'X', true,  'verticalstrike'],
-    down:  [ Math.PI / 2, -1, false, 'top left',    'X', true,  'verticakstrike'],
-    right: [  0,          -1, false, 'top left',    'Y', false, 'horizontalstrike'],
-    left:  [  Math.PI,    -1, false, 'top right',   'Y', false, 'horizontalstrike'],
-    updown:    [Math.PI / 2, -1, true, 'top left',  'X', true,  'verticalstrike uparrow downarrow'],
-    leftright: [0,           -1, true, 'top left',  'Y', false, 'horizontalstrike leftarrow rightarrow']
-} as {[name: string]: [number, number, boolean, string, string, boolean, string]};
+    up:        [-Math.PI / 2, false, true,  'verticalstrike'],
+    down:      [ Math.PI / 2, false, true,  'verticakstrike'],
+    right:     [ 0,           false, false, 'horizontalstrike'],
+    left:      [ Math.PI,     false, false, 'horizontalstrike'],
+    updown:    [ Math.PI / 2, true,  true,  'verticalstrike uparrow downarrow'],
+    leftright: [ 0,           true,  false, 'horizontalstrike leftarrow rightarrow']
+} as {[name: string]: [number, boolean, boolean, string]};
 
 /**
  * The data for diagonal arrow notations
- *   [neg, c, pi, double, origin, remove]
+ *   [c, pi, double, remove]
  */
 export const diagonalArrowDef = {
-    updiagonal: [ 1, -1, 0,       false, 'bottom left',  'updiagonalstrike'],
-    northeast:  [ 1, -1, 0,       false, 'bottom left',  'updiagonalstrike'],
-    southeast:  [-1,  1, 0,       false, 'top left',     'downdiagonalstrike'],
-    northwest:  [ 1,  1, Math.PI, false, 'bottom right', 'downdiagonalstrike'],
-    southwest:  [-1, -1, Math.PI, false, 'top right',    'updiagonalstrike'],
-    northeastsouthwest: [ 1, -1, 0, true, 'bottom left',
-                          'updiagonalstrike northeastarrow updiagonalarrow southwestarrow'],
-    northwestsoutheast: [-1,  1, 0, true, 'top left',
-                          'downdiagonalstrike northwestarrow southeastarrow']
-} as {[name: string]: [number, number, number, boolean, string, string]};
+    updiagonal:         [-1, 0,       false, 'updiagonalstrike'],
+    northeast:          [-1, 0,       false, 'updiagonalstrike'],
+    southeast:          [ 1, 0,       false, 'downdiagonalstrike'],
+    northwest:          [ 1, Math.PI, false, 'downdiagonalstrike'],
+    southwest:          [-1, Math.PI, false, 'updiagonalstrike'],
+    northeastsouthwest: [-1, 0,       true,  'updiagonalstrike northeastarrow updiagonalarrow southwestarrow'],
+    northwestsoutheast: [ 1, 0,       true,  'downdiagonalstrike northwestarrow southeastarrow']
+} as {[name: string]: [number, number, boolean, string]};
 
 /**
  * The BBox functions for horizontal and vertical arrows
  */
 export const arrowBBox = {
-    up:    (node) => [arrowHead(node), 0, node.padding, 0],
-    down:  (node) => [node.padding, 0, arrowHead(node), 0],
-    right: (node) => [0, arrowHead(node), 0, node.padding],
-    left:  (node) => [0, node.padding, 0, arrowHead(node)],
-    updown:    (node) => [arrowHead(node), 0, arrowHead(node), 0],
-    leftright: (node) => [0, arrowHead(node), 0, arrowHead(node)]
+    up:    (node) => arrowBBoxW(node, [arrowHead(node), 0, node.padding, 0]),
+    down:  (node) => arrowBBoxW(node, [node.padding, 0, arrowHead(node), 0]),
+    right: (node) => arrowBBoxHD(node, [0, arrowHead(node), 0, node.padding]),
+    left:  (node) => arrowBBoxHD(node, [0, node.padding, 0, arrowHead(node)]),
+    updown:    (node) => arrowBBoxW(node, [arrowHead(node), 0, arrowHead(node), 0]),
+    leftright: (node) => arrowBBoxHD(node, [0, arrowHead(node), 0, arrowHead(node)])
 } as {[name: string]: BBoxExtender<Menclose>};
 
 /**
@@ -264,25 +284,27 @@ export const CommonDiagonalArrow = <W extends Menclose, N>(render: Renderer<W, N
      * @return {DefPair}      The notation definition for the diagonal arrow
      */
     return (name: string) => {
-        const [neg, c, pi, double, origin, remove] = diagonalArrowDef[name];
+        const [c, pi, double, remove] = diagonalArrowDef[name];
         return [name + 'arrow', {
             //
             // Find the angle and width from the bounding box size and create
             //   the arrow from them and the other arrow data
             //
             renderer: (node, child) => {
-                const {w, h, d} = node.getBBox();
-                const [a, W] = node.getArgMod(w, h + d);
-                const arrow = node.arrow(W, c * (a - pi), neg, origin, '', 0, double);
+                const {a, W} = node.arrowData();
+                const arrow = node.arrow(W, c * (a - pi), double);
                 render(node, arrow);
             },
             //
-            // Add roughly the right amount of space for the arrowhead all around
+            // Add space for the arrowhead all around
             //
             bbox: (node) => {
-                const t = Math.max(node.padding,
-                                   node.thickness * (node.arrowhead.x + node.arrowhead.dx) / Math.sqrt(2));
-                return [t, t, t, t];
+                const {a, x, y} = node.arrowData();
+                const [ax, ay, adx] = [node.arrowhead.x, node.arrowhead.y, node.arrowhead.dx];
+                const [b, ar] = node.getArgMod(ax + adx, ay);
+                const dy = y + (b > a ? node.thickness * ar * Math.sin(b - a) : 0);
+                const dx = x + (b > Math.PI / 2 - a ? node.thickness * ar * Math.sin(b + a - Math.PI / 2) : 0);
+                return [dy, dx, dy, dx];
             },
             //
             // Remove redundant notations
@@ -302,7 +324,7 @@ export const CommonArrow = <W extends Menclose, N>(render: Renderer<W, N>) => {
      * @return {DefPair}      The notation definition for the arrow
      */
     return (name: string) => {
-        const [angle, neg, double, origin, offset, isVertical, remove] = arrowDef[name];
+        const [angle, double, isVertical, remove] = arrowDef[name];
         return [name + 'arrow', {
             //
             // Get the arrow height and depth from the bounding box and the arrow direction
@@ -311,11 +333,11 @@ export const CommonArrow = <W extends Menclose, N>(render: Renderer<W, N>) => {
             renderer: (node, child) => {
                 const {w, h, d} = node.getBBox();
                 const [W, H] = (isVertical ? [h + d, w] : [w, h + d]);
-                const arrow = node.arrow(W, angle, neg, origin, offset, H / 2, double);
+                const arrow = node.arrow(W, angle, double);
                 render(node, arrow);
             },
             //
-            // Add the padding to teh proper sides
+            // Add the padding to the proper sides
             //
             bbox: arrowBBox[name],
             //

--- a/mathjax3-ts/output/common/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/common/Wrappers/menclose.ts
@@ -110,80 +110,20 @@ export interface CommonMenclose<W extends AnyWrapper, S extends CommonMsqrt, N> 
     getArgMod(w: number, h: number): number[];
 
     /**
-     * Create an svg tree
-     *
-     * @param {string} type        The class for the new svg element
-     * @param {number[]} box       The viewBox values for the svg element
-     * @param {N[]} nodes          The children for the svg element
-     * @param {StyleData=} styles  Styles to set on the svg element, if any
-     * @return {N}                 The newly created svg element
-     */
-    svg(type: string, box: number[], nodes: N[], styles?: StyleData): void;
-
-    /**
-     * @param {string} kind              The name of the svg node
-     * @param {OptionList=} properties   The properties to set for the node
-     * @param {N[]=} nodes               The children of the node
-     */
-    svgNode(kind: string, properties?: OptionList, nodes?: N[]): N;
-
-    /**
-     * Create an ellipse element
-     *
-     * @param {number} w  The width of the ellipse
-     * @param {number} h  The height of the ellipse
-     * @return {N}        The newly created ellipse node
-     */
-    ellipse(w: number, h: number): N;
-
-    /**
-     * Create a line element
-     *
-     * @param {number} x1   The x-coordinate of the starting point
-     * @param {number} y1   The y-coordinate of the starting point
-     * @param {number} x2   The x-coordinate of the ending point
-     * @param {number} y2   The y-coordinate of the ending point
-     * @return {N}          The newly created line element
-     */
-    line(x1: number, y1: number, x2: number, y2: number): N;
-
-    /**
-     * Create a path element from the commands the specify it
-     *
-     * @param {(string|number)[]} P   The list of commands and coordinates for the path
-     * @return {N}                    The newly created path
-     */
-    path(...P: (string | number)[]): N;
-
-    /**
-     * Create a filled path element from the commands the specify it
-     *   (same as path above, but no thickness adjustments)
-     *
-     * @param {(string|number)[]} P   The list of commands and coordinates for the path
-     * @return {N}                    The newly created path
-     */
-    fill(...P: (string | number)[]): N;
-
-    /**
      * Create an arrow using an svg element
      *
      * @param {number} w         The length of the arrow
      * @param {number} a         The angle for the arrow
-     * @param {number} neg       The direction to shift the arrow's Y coordinate before rotating it (1 or -1)
-     * @param {string} origin    The transform-origin for the rotation
-     * @param {string=} offset   The axis alogn which to offset the rotated arrow
-     * @param {number=} d        The distance to offset by
      * @param {boolean=} double  True if this is a double-headed arrow
      * @return {N}               The newly created arrow
      */
-    arrow(w: number, a: number, neg: number, origin: string, offset?: string, d?: number, double?: boolean): N;
+    arrow(w: number, a: number, double?: boolean): N;
 
     /**
-     * @param {N} shape   The svg element whose stroke-thickness must be
-     *                    adjusted if the thickness isn't the default
-     * @return {N}        The adjusted element
+     * Get the angle and width of a diagonal arrow, plus the x and y extension
+     *   past the content bounding box
      */
-    adjustThickness(shape: N): N;
+    arrowData(): {a: number, W: number, x: number, y: number};
 
     /**
      * Create an unattached msqrt wrapper to render the 'radical' notation.
@@ -421,148 +361,32 @@ export function CommonMencloseMixin<W extends AnyWrapper,
         }
 
         /**
-         * Create an svg tree
-         *
-         * @param {string} type        The class for the new svg element
-         * @param {number[]} box       The viewBox values for the svg element
-         * @param {N[]} nodes          The children for the svg element
-         * @param {StyleData=} styles  Styles to set on the svg element, if any
-         * @return {N}                 The newly created svg element
-         */
-        public svg(type: string, box: number[], nodes: N[], styles: StyleData = null) {
-            const properties: OptionList = {
-                class: 'mjx-' + type,
-                viewbox: box.join(' ')
-            };
-            if (styles) {
-                properties.style = styles;
-            }
-            return this.svgNode('svg', properties, nodes);
-        }
-
-        /**
-         * @param {string} kind              The name of the svg node
-         * @param {OptionList=} properties   The properties to set for the node
-         * @param {N[]=} nodes               The children of the node
-         */
-        public svgNode(kind: string, properties: OptionList = {}, nodes: N[] = null) {
-            // implemented in subclasses
-            return null as N;
-        }
-
-        /**
-         * Create an ellipse element
-         *
-         * @param {number} w  The width of the ellipse
-         * @param {number} h  The height of the ellipse
-         * @return {N}        The newly created ellipse node
-         */
-        public ellipse(w: number, h: number) {
-            const t = this.thickness;
-            return this.adjustThickness(this.svgNode('ellipse', {
-                rx: this.units((w - t) / 2), ry: this.units((h - t) / 2),
-                cx: this.units(w / 2), cy: this.units(h / 2)
-            }));
-        }
-
-        /**
-         * Create a line element
-         *
-         * @param {number} x1   The x-coordinate of the starting point
-         * @param {number} y1   The y-coordinate of the starting point
-         * @param {number} x2   The x-coordinate of the ending point
-         * @param {number} y2   The y-coordinate of the ending point
-         * @return {N}          The newly created line element
-         */
-        public line(x1: number, y1: number, x2: number, y2: number) {
-            return this.adjustThickness(this.svgNode('line', {
-                x1: this.units(x1), y1: this.units(y1),
-                x2: this.units(x2), y2: this.units(y2)
-            }));
-        }
-
-        /**
-         * Create a path element from the commands the specify it
-         *
-         * @param {(string|number)[]} P   The list of commands and coordinates for the path
-         * @return {N}                    The newly created path
-         */
-        public path(...P: (string | number)[]) {
-            return this.adjustThickness(this.svgNode('path', {
-                d: P.map(x => (typeof x === 'string' ? x : this.units(x))).join(' ')
-            }));
-        }
-
-        /**
-         * Create a filled path element from the commands the specify it
-         *   (same as path above, but no thickness adjustments)
-         *
-         * @param {(string|number)[]} P   The list of commands and coordinates for the path
-         * @return {N}                    The newly created path
-         */
-        public fill(...P: (string | number)[]) {
-            return this.svgNode('path', {
-                d: P.map(x => (typeof x === 'string' ? x : this.units(x))).join(' ')
-            });
-        }
-
-        /**
          * Create an arrow using an svg element
          *
          * @param {number} w        The length of the arrow
          * @param {number} a        The angle for the arrow
-         * @param {number} neg      The direction to shift the arrow's Y coordinate before rotating it (1 or -1)
-         * @param {string} origin   The transform-origin for the rotation
-         * @param {string} offset   The axis alogn which to offset the rotated arrow
-         * @param {number} d        The distance to offset by
          * @param {boolean} double  True if this is a double-headed arrow
+         * @return {N}              The newly created arrow
          */
-        public arrow(w: number, a: number, neg: number, origin: string, offset: string = '',
-                     d: number = 0, double: boolean = false) {
-            const t = this.thickness;
-            const head = this.arrowhead;
-            const [x, y, dx] = [t * head.x, t * head.y, t * head.dx];
-            //
-            //  Get the offset, if any,
-            //  and translate by the width if rotating by more than 90 degrees
-            //
-            if (offset) {
-                offset = 'translate' + offset + '(' + this.em(d) + ') ';
-            }
-            if (Math.abs(a) >  Math.PI / 2) {
-                offset = 'translateX(' + this.em(w) + ') ' + offset;
-            }
-            //
-            //  Create the svg holding the arrow with the one or two arrow heads and the line between them
-            //
-            const svg = this.svg('arrow', [0, -y, w, 2 * y], [
-                this.line(double ? x : t / 2, 0, w - x, 0),
-                this.fill('M', w - x, 0,  'L', w - x - dx, y,  'L', w, 0,  'L', w - x - dx, -y)
-            ], {
-                width: this.em(w), height: this.em(2 * y),
-                transform: offset + 'rotate(' + this.units(a) + 'rad) translateY(' + this.units(neg * y) + 'em)',
-                'transform-origin': origin.replace(/right/, 'left')
-            });
-            double && this.adaptor.append(svg, this.fill('M', x, 0,  'L', x + dx, y,  'L', 0, 0,  'L', x + dx, -y));
-            //
-            // Align the arrow with the givin origin sides
-            //
-            for (const side of split(origin)) {
-                this.adaptor.setStyle(svg, side, '0');
-            }
-            return svg;
+        public arrow(w: number, a: number, double: boolean = false) {
+            return null as N;
         }
 
         /**
-         * @param {N} shape   The svg element whose stroke-thickness must be
-         *                    adjusted if the thickness isn't the default
-         * @return {N}        The adjusted element
+         * Get the angle and width of a diagonal arrow, plus the x and y extension
+         *   past the content bounding box
+         *
+         * @return {Obejct}  The angle, width, and x and y extentions
          */
-        public adjustThickness(shape: N) {
-            if (this.thickness !== Notation.THICKNESS) {
-                this.adaptor.setStyle(shape, 'strokeWidth', this.units(this.thickness));
-            }
-            return shape;
+        public arrowData() {
+            const [p, t] = [this.padding, this.thickness];
+            const r = t * (this.arrowhead.x + Math.max(1, this.arrowhead.dx));
+            const {h, d, w} = this.childNodes[0].getBBox();
+            const H = h + d;
+            const R = Math.sqrt(H * H + w * w);
+            const [x, y] = [Math.max(p, r * w / R), Math.max(p, r * H / R)];
+            const [a, W] = this.getArgMod(w + 2 * x, H + 2 * y);
+            return {a, W, x, y};
         }
 
         /********************************************************/

--- a/mathjax3-ts/output/common/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/common/Wrappers/menclose.ts
@@ -97,12 +97,6 @@ export interface CommonMenclose<W extends AnyWrapper, S extends CommonMsqrt, N> 
     maximizeEntries(X: number[], Y: number[]): void;
 
     /**
-     * @param {number} m  A number to trim to 4 decimal places
-     * @return {string}   The number trimmed to 4 places, with trailing 0's removed
-     */
-    units(m: number): string;
-
-    /**
      * @param {number} w    The width of the box whose diagonal is needed
      * @param {number} h    The height of the box whose diagonal is needed
      * @return {number[]}   The angle and width of the diagonal of the box
@@ -333,23 +327,6 @@ export function CommonMencloseMixin<W extends AnyWrapper,
         }
 
         /********************************************************/
-
-        /**
-         * @override
-         * (make it public so it can be called by the notation functions)
-         */
-        public em(m: number) {
-            return super.em(m);
-        }
-
-        /**
-         * @param {number} m  A number to trim to 4 decimal places
-         * @return {string}   The number trimmed to 4 places, with trailing 0's removed
-         */
-        public units(m: number) {
-            if (Math.abs(m) < .001) return '0';
-            return m.toFixed(4).replace(/\.?0+$/, '');
-        }
 
         /**
          * @param {number} w    The width of the box whose diagonal is needed

--- a/mathjax3-ts/output/common/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/common/Wrappers/menclose.ts
@@ -361,7 +361,8 @@ export function CommonMencloseMixin<W extends AnyWrapper,
             const {h, d, w} = this.childNodes[0].getBBox();
             const H = h + d;
             const R = Math.sqrt(H * H + w * w);
-            const [x, y] = [Math.max(p, r * w / R), Math.max(p, r * H / R)];
+            const x = Math.max(p, r * w / R);
+            const y = Math.max(p, r * H / R);
             const [a, W] = this.getArgMod(w + 2 * x, H + 2 * y);
             return {a, W, x, y};
         }

--- a/mathjax3-ts/output/common/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/common/Wrappers/menclose.ts
@@ -376,7 +376,7 @@ export function CommonMencloseMixin<W extends AnyWrapper,
          * Get the angle and width of a diagonal arrow, plus the x and y extension
          *   past the content bounding box
          *
-         * @return {Obejct}  The angle, width, and x and y extentions
+         * @return {Object}  The angle, width, and x and y extentions
          */
         public arrowData() {
             const [p, t] = [this.padding, this.thickness];


### PR DESCRIPTION
This PR improves the CHTML implementation of `<menclose>` so that it no longer uses SVG elements, but instead uses only CSS.  SVG used to be used for `circle`, `longdiv`, and the various arrows (`rightarrow`, `northeastarrow`, etc.), but now only CSS is used for this.  The ellipse was easy to do using a rectangle with rounded corners with `border-radius: 50%`, and this could be used for `longdiv` as well.  The arrows took more work, but ended up better than I expected.  The CSS used for placing the arrows has been simplified, so that some of the data that used to be used is no longer needed (we place the arrow in the center and rotation around the center rather than place at lower left and rotation about lower left).

This also improves the bounding box computations for arrows so that the arrow head is included in the box (this will be important for the SVG output jax).