### PR TITLE
Handling clipping for the extenders of stretchy characters in IE and Safari.  #153

### DIFF
--- a/mathjax3-ts/output/svg/Wrappers/mo.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mo.ts
@@ -175,6 +175,8 @@ export class SVGmo<N, T, D> extends CommonMoMixin<SVGConstructor<N, T, D>>(SVGWr
         const [h, d, w] = this.getChar(n);
         const Y = H + D - T - B;                 // The height of the extender
         const s = 1.5 * Y / (h + d);             // Scale height by 1.5 to avoid bad ends
+                                                 //   (glyphs with rounded or anti-aliased ends don't stretch well,
+                                                 //    so this makes for sharper ends)
         const y = (s * (h - d) - Y) / 2;         // The bottom point to clip the extender
         const svg = this.svg('svg', {
             width: this.fixed(w), height: this.fixed(Y),


### PR DESCRIPTION
This uses nested `<svg>` elements to do the clipping (via `overflow` CSS) rather than `clip-path` attributes, since IE doesn't implement `inset()` paths (it only handles `url()` references), and Safari requires CSS with `-webkit` prefix, not attributes.

Resolves #153.