### PR TITLE
Fix stretchy characters in SVG and CHTML.  #156 and #152.

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -56,7 +56,8 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(C
             width: '100%'
         },
         'mjx-stretchy-h > mjx-ext > mjx-c': {
-            transform: 'scalex(500)'
+            transform: 'scalex(500)',
+            'margin-right': '-2em'
         },
         'mjx-stretchy-h > mjx-ext > mjx-c::before': {
             padding: '.001em 0'                  // for blink

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -230,7 +230,7 @@ export class TeXFont extends CommonTeXFont {
         },
 
         '.MJX-TEX mjx-stretchy-v mjx-c, .MJX-TEX mjx-stretchy-h mjx-c': {
-            'font-family': 'MJXZERO, MJXTEX, MJXTEX-S4 ! important'
+            'font-family': 'MJXZERO, MJXTEX-S1, MJXTEX-S4, MJXTEX, MJXTEX-A ! important'
         }
     };
 
@@ -451,13 +451,14 @@ export class TeXFont extends CommonTeXFont {
      * @param {DelimiterData} data  The data for the delimiter whose CSS is to be added
      */
     protected addDelimiterVStyles(styles: StyleList, c: string, data: DelimiterData) {
+        const W = data.HDW[2];
         const [beg, ext, end, mid] = data.stretch;
-        const Hb = this.addDelimiterVPart(styles, c, 'beg', beg);
-        this.addDelimiterVPart(styles, c, 'ext', ext);
-        const He = this.addDelimiterVPart(styles, c, 'end', end);
+        const Hb = this.addDelimiterVPart(styles, c, W, 'beg', beg);
+        this.addDelimiterVPart(styles, c, W, 'ext', ext);
+        const He = this.addDelimiterVPart(styles, c, W, 'end', end);
         const css: StyleData = {};
         if (mid) {
-            const Hm = this.addDelimiterVPart(styles, c, 'mid', mid);
+            const Hm = this.addDelimiterVPart(styles, c, W, 'mid', mid);
             css.height = '50%';
             styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] > mjx-mid'] = {
                 'margin-top': this.em(-Hm/2),
@@ -483,12 +484,15 @@ export class TeXFont extends CommonTeXFont {
      * @param {number} n          The unicode character to use for the part
      * @return {number}           The total height of the character
      */
-    protected addDelimiterVPart(styles: StyleList, c: string, part: string, n: number) {
+    protected addDelimiterVPart(styles: StyleList, c: string, W: number, part: string, n: number) {
         if (!n) return 0;
-        const data = this.getChar('normal', n) || this.getChar('-size4', n);
-        const css: StyleData = {content: '"' + this.char(n, true) + '"'};
+        const data = this.getDelimiterData(n);
+        const dw = (W - data[2]) / 2
+        const css: StyleData = {content: '"' + this.char(n, true) + '"', width: this.em0(W - dw)};
         if (part !== 'ext') {
-            css.padding = this.em0(data[0]) + ' 0 ' + this.em0(data[1]);
+            css.padding = this.em0(data[0]) + ' 0 ' + this.em0(data[1]) + (dw ? ' ' + this.em0(dw) : '');
+        } else if (dw) {
+            css['padding-left'] = this.em0(dw);
         }
         styles['.MJX-TEX mjx-stretchy-v[c="' + c + '"] mjx-' + part + ' mjx-c::before'] = css;
         return data[0] + data[1];
@@ -522,12 +526,12 @@ export class TeXFont extends CommonTeXFont {
         if (!n) {
             return 0;
         }
-        const data = this.getChar('normal', n) || this.getChar('-size4', n);
+        const data = this.getDelimiterData(n);
         const options = data[3] as CharOptions;
         const C = (options && options.c ? options.c : this.char(n, true));
         const css: StyleData = {content: '"' + C + '"'};
         if (part !== 'ext' || force) {
-          css.padding = this.em0(data[0]) + ' 0 ' + this.em0(data[1]);
+            css.padding = this.em0(data[0]) + ' 0 ' + this.em0(data[1]);
         }
         styles['.MJX-TEX mjx-stretchy-h[c="' + c + '"] mjx-' + part + ' mjx-c::before'] = css;
     }
@@ -567,4 +571,3 @@ export class TeXFont extends CommonTeXFont {
     }
 
 }
-

--- a/mathjax3-ts/output/common/Wrappers/mo.ts
+++ b/mathjax3-ts/output/common/Wrappers/mo.ts
@@ -261,6 +261,9 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
          * @param {DelimiterData} C  The delimiter data for the stretchy character
          */
         public getStretchBBox(WHD: number[], D: number, C: DelimiterData) {
+            if (C.hasOwnProperty('min') && C.min > D) {
+                D = C.min;
+            }
             let [h, d, w] = C.HDW;
             if (this.stretch.dir === DIRECTION.Vertical) {
                 [h, d] = this.getBaseline(WHD, D, C);

--- a/mathjax3-ts/output/common/fonts/tex.ts
+++ b/mathjax3-ts/output/common/fonts/tex.ts
@@ -92,5 +92,13 @@ export class CommonTeXFont extends FontData {
         return em(Math.max(0, n));
     }
 
+    /**
+     * @param {number} n    The character number to find
+     * @return {CharData}   The data for that character to be used for stretchy delimiters
+     */
+    protected getDelimiterData(n: number) {
+        return this.getChar('-smallop', n) || this.getChar('-size4', n);
+    }
+
 }
 

--- a/mathjax3-ts/output/common/fonts/tex/delimiters.ts
+++ b/mathjax3-ts/output/common/fonts/tex/delimiters.ts
@@ -30,7 +30,7 @@ const DELIM2013 = {c: 0x2013, dir: H, sizes: [.5], stretch: [0, 0x2013], HDW: [.
 const DELIM2190 = {c: 0x2190, dir: H, sizes: [1], stretch: [0x2190, 0x2212], HDW: HDW2};
 const DELIM2192 = {c: 0x2192, dir: H, sizes: [1], stretch: [0, 0x2212, 0x2192], HDW: HDW2};
 const DELIM2194 = {c: 0x2194, dir: H, sizes: [1], stretch: [0x2190, 0x2212, 0x2192], HDW: HDW2};
-const DELIM21A4 = {c: 0x21A4, dir: H, stretch: [0x2190, 0x2212, 0x2223], HDW: HDW3, min: 1};
+const DELIM21A4 = {c: 0x21A4, dir: H, stretch: [0x2190, 0x2212, 0x2223], HDW: HDW3, min: 1.278};
 const DELIM21A6 = {c: 0x21A6, dir: H, sizes: [1], stretch: [0x2223, 0x2212, 0x2192], HDW: HDW2};
 const DELIM21D0 = {c: 0x21D0, dir: H, sizes: [1], stretch: [0x21D0, 0x3D], HDW: HDW2};
 const DELIM21D2 = {c: 0x21D2, dir: H, sizes: [1], stretch: [0, 0x3D, 0x21D2], HDW: HDW2};
@@ -41,12 +41,12 @@ const DELIM23DC = {c: 0x23DC, dir: H, sizes: [.778, 1], schar: [0x2322, 0x2322],
                    HDW: [.32, .2, .5]};
 const DELIM23DD = {c: 0x23DD, dir: H, sizes: [.778, 1], schar: [0x2323, 0x2323], stretch: [0xE152, 0xE154, 0xE153],
                    HDW: [.32, .2, .5]};
-const DELIM23DE = {c: 0x23DE, dir: H, stretch: [0xE150, 0xE154, 0xE151, 0xE155], HDW: [.32, .2, .5], min: .9};
-const DELIM23DF = {c: 0x23DF, dir: H, stretch: [0xE152, 0xE154, 0xE153, 0xE156], HDW: [.32, .2, .5], min: .9};
+const DELIM23DE = {c: 0x23DE, dir: H, stretch: [0xE150, 0xE154, 0xE151, 0xE155], HDW: [.32, .2, .5], min: 1.8};
+const DELIM23DF = {c: 0x23DF, dir: H, stretch: [0xE152, 0xE154, 0xE153, 0xE156], HDW: [.32, .2, .5], min: 1.8};
 const DELIM27E8 = {c: 0x27E8, dir: V, sizes: VSIZES};
 const DELIM27E9 = {c: 0x27E9, dir: V, sizes: VSIZES};
-const DELIM2906 = {c: 0x2906, dir: H, stretch: [0x21D0, 0x3D, 0x2223], HDW: HDW3, min: 1};
-const DELIM2907 = {c: 0x2907, dir: H, stretch: [0x22A8, 0x3D, 0x21D2], HDW: HDW3, min: .7};
+const DELIM2906 = {c: 0x2906, dir: H, stretch: [0x21D0, 0x3D, 0x2223], HDW: HDW3, min: 1.278};
+const DELIM2907 = {c: 0x2907, dir: H, stretch: [0x22A8, 0x3D, 0x21D2], HDW: HDW3, min: 1.278};
 
 
 export const delimiters: DelimiterMap = {
@@ -87,9 +87,9 @@ export const delimiters: DelimiterMap = {
   0x219E: {dir: H, sizes: [1], stretch: [0x219E, 0x2212], HDW: HDW2},
   0x21A0: {dir: H, sizes: [1], stretch: [0, 0x2212, 0x21A0], HDW: HDW2},
   0x21A4: DELIM21A4,
-  0x21A5: {dir: V, stretch: [0x2191, 0x23D0, 0x22A5], HDW: HDW1, min: .6},
+  0x21A5: {dir: V, stretch: [0x2191, 0x23D0, 0x22A5], HDW: HDW1, min: 1.555},
   0x21A6: DELIM21A6,
-  0x21A7: {dir: V, stretch: [0x22A4, 0x23D0, 0x2193], HDW: HDW1, min: .6},
+  0x21A7: {dir: V, stretch: [0x22A4, 0x23D0, 0x2193], HDW: HDW1, min: 1.555},
   0x21B0: {dir: V, sizes: [.722], stretch: [0x21B0, 0x23D0], HDW: [.722, 0, .667]},
   0x21B1: {dir: V, sizes: [.722], stretch: [0x21B1, 0x23D0], HDW: [.722, 0, .667]},
   0x21BC: {dir: H, sizes: [1], stretch: [0x21BC, 0x2212], HDW: HDW2},
@@ -101,11 +101,11 @@ export const delimiters: DelimiterMap = {
   0x21C2: {dir: V, sizes: [.888], stretch: [0, 0x23D0, 0x21C2], HDW: [.694, .194, .667]},
   0x21C3: {dir: V, sizes: [.888], stretch: [0, 0x23D0, 0x21C3], HDW: [.694, .194, .667]},
   0x21D0: DELIM21D0,
-  0x21D1: {dir: V, sizes: [.888], stretch: [0x21D1, 0x2016], HDW: [.694, .194, .5]},
+  0x21D1: {dir: V, sizes: [.888], stretch: [0x21D1, 0x2016], HDW: [.694, .194, .778]},
   0x21D2: DELIM21D2,
-  0x21D3: {dir: V, sizes: [.888], stretch: [0, 0x2016, 0x21D3], HDW: [.694, .194, .5]},
+  0x21D3: {dir: V, sizes: [.888], stretch: [0, 0x2016, 0x21D3], HDW: [.694, .194, .778]},
   0x21D4: DELIM21D4,
-  0x21D5: {dir: V, sizes: [1.044], stretch: [0x21D1, 0x2016, 0x21D3], HDW: [.772, .272, .5]},
+  0x21D5: {dir: V, sizes: [1.044], stretch: [0x21D1, 0x2016, 0x21D3], HDW: [.772, .272, .778]},
   0x21DA: {dir: H, sizes: [1], stretch: [0x21DA, 0x2261], HDW: [.464, -0.036, 1]},
   0x21DB: {dir: H, sizes: [1], stretch: [0, 0x2261, 0x21DB], HDW: [.464, -0.036, 1]},
   0x2212: DELIM2212,
@@ -126,15 +126,15 @@ export const delimiters: DelimiterMap = {
   0x23AF: DELIM2013,
   0x23B0: {dir: V, sizes: [.989], stretch: [0x23A7, 0x23AA, 0x23AD], HDW: [.744, .244, .889]},
   0x23B1: {dir: V, sizes: [.989], stretch: [0x23AB, 0x23AA, 0x23A9], HDW: [.744, .244, .889]},
-  0x23B4: {dir: H, stretch: [0x250C, 0x2212, 0x2510], HDW: HDW3, min: .5},
-  0x23B5: {dir: H, stretch: [0x2514, 0x2212, 0x2518], HDW: HDW3, min: .5},
+  0x23B4: {dir: H, stretch: [0x250C, 0x2212, 0x2510], HDW: HDW3, min: 1},
+  0x23B5: {dir: H, stretch: [0x2514, 0x2212, 0x2518], HDW: HDW3, min: 1},
   0x23D0: {dir: V, sizes: [.602, 1], schar: [0, 0x2223], stretch: [0, 0x2223], HDW: [.602, 0, .278]},
   0x23DC: DELIM23DC,
   0x23DD: DELIM23DD,
   0x23DE: DELIM23DE,
   0x23DF: DELIM23DF,
-  0x23E0: {dir: H, stretch: [0x2CA, 0x2C9, 0x2CB], HDW: [.59, -0.544, .5], min: 1.25},
-  0x23E1: {dir: H, stretch: [0x2CB, 0x2C9, 0x2CA], HDW: [.59, -0.544, .5], min: 1.5},
+  0x23E0: {dir: H, stretch: [0x2CA, 0x2C9, 0x2CB], HDW: [.59, -0.544, .5], min: 1},
+  0x23E1: {dir: H, stretch: [0x2CB, 0x2C9, 0x2CA], HDW: [.59, -0.544, .5], min: 1},
   0x2500: DELIM2013,
   0x2758: DELIM2223,
   0x27E8: DELIM27E8,
@@ -153,18 +153,18 @@ export const delimiters: DelimiterMap = {
   0x27FE: DELIM2907,
   0x2906: DELIM2906,
   0x2907: DELIM2907,
-  0x294E: {dir: H, stretch: [0x21BC, 0x2212, 0x21C0], HDW: HDW3, min: .5},
-  0x294F: {dir: V, stretch: [0x21BE, 0x23D0, 0x21C2], HDW: HDW1, min: .5},
-  0x2950: {dir: H, stretch: [0x21BD, 0x2212, 0x21C1], HDW: HDW3, min: .5},
+  0x294E: {dir: H, stretch: [0x21BC, 0x2212, 0x21C0], HDW: HDW3, min: 2},
+  0x294F: {dir: V, stretch: [0x21BE, 0x23D0, 0x21C2], HDW: HDW1, min: 1.776},
+  0x2950: {dir: H, stretch: [0x21BD, 0x2212, 0x21C1], HDW: HDW3, min: 2},
   0x2951: {dir: V, stretch: [0x21BF, 0x23D0, 0x21C3], HDW: HDW1, min: .5},
-  0x295A: {dir: H, stretch: [0x21BC, 0x2212, 0x2223], HDW: HDW3, min: 1},
-  0x295B: {dir: H, stretch: [0x2223, 0x2212, 0x21C0], HDW: HDW3, min: 1},
-  0x295C: {dir: V, stretch: [0x21BE, 0x23D0, 0x22A5], HDW: HDW1, min: .7},
-  0x295D: {dir: V, stretch: [0x22A4, 0x23D0, 0x21C2], HDW: HDW1, min: .7},
-  0x295E: {dir: H, stretch: [0x21BD, 0x2212, 0x2223], HDW: HDW3, min: 1},
-  0x295F: {dir: H, stretch: [0x2223, 0x2212, 0x21C1], HDW: HDW3, min: 1},
-  0x2960: {dir: V, stretch: [0x21BF, 0x23D0, 0x22A5], HDW: HDW1, min: .7},
-  0x2961: {dir: V, stretch: [0x22A4, 0x23D0, 0x21C3], HDW: HDW1, min: .7},
+  0x295A: {dir: H, stretch: [0x21BC, 0x2212, 0x2223], HDW: HDW3, min: 1.278},
+  0x295B: {dir: H, stretch: [0x2223, 0x2212, 0x21C0], HDW: HDW3, min: 1.278},
+  0x295C: {dir: V, stretch: [0x21BE, 0x23D0, 0x22A5], HDW: HDW1, min: 1.556},
+  0x295D: {dir: V, stretch: [0x22A4, 0x23D0, 0x21C2], HDW: HDW1, min: 1.556},
+  0x295E: {dir: H, stretch: [0x21BD, 0x2212, 0x2223], HDW: HDW3, min: 1.278},
+  0x295F: {dir: H, stretch: [0x2223, 0x2212, 0x21C1], HDW: HDW3, min: 1.278},
+  0x2960: {dir: V, stretch: [0x21BF, 0x23D0, 0x22A5], HDW: HDW1, min: 1.776},
+  0x2961: {dir: V, stretch: [0x22A4, 0x23D0, 0x21C3], HDW: HDW1, min: 1.776},
   0x3008: DELIM27E8,
   0x3009: DELIM27E9,
   0xFE37: DELIM23DE,


### PR DESCRIPTION
Fix problem with stretchy character minimum width when there are no single-character versions, and update the minimum sizes to be correct (those values were taken from the v2 font data, but are incorrect -- the new ones have been computed from the widths of the pieces used).  Also improve placement of glyphs in CHTML stretchy characters, and add the missing fonts to the stretchy font list.  Resolves issues #156 and #152.