### PR TITLE
Allow svg elements to overflow.  #157

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -82,6 +82,16 @@ export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
         if (display) {
             adaptor.setAttribute(chtml, 'display', 'true');
             adaptor.setAttribute(parent, 'display', 'true');
+        } else {
+            //
+            // Transfer right margin to container (for things like $x\hskip -2em y$)
+            //
+            const margin = adaptor.getStyle(chtml, 'margin-right');
+            if (margin) {
+                adaptor.setStyle(chtml, 'margin-right', '');
+                adaptor.setStyle(parent, 'margin-right', margin);
+                adaptor.setStyle(parent, 'width', '0');
+            }
         }
         adaptor.addClass(chtml, 'MJX-TEX');
         const [align, shift] = this.getAlignShift();

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -143,6 +143,9 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
         }, [g])) as N;
         if (W === .001) {
             adaptor.setAttribute(svg, 'preserveAspectRatio', 'xMidYMid slice');
+            if (w < 0) {
+                adaptor.setStyle(parent, 'margin-right', this.ex(w));
+            }
         }
         if (pwidth) {
             //

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -123,6 +123,7 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
         const px = (this.font.params.x_height / wrapper.metrics.ex);
         const H = (Math.ceil(h / px) + 1) * px + 2/1000;  // round to pixels and add a little padding
         const D = (Math.ceil(d / px) + 1) * px + 2/1000;
+        const W = Math.max(w, .001); // make sure we are at least one unit wide (needed for e.g. \llap)
         //
         //  The container that flips the y-axis and sets the colors to inherit from the surroundings
         //
@@ -136,10 +137,13 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
         const adaptor = this.adaptor;
         const svg = adaptor.append(parent, this.svg('svg', {
             xmlns: SVGNS,
-            width: this.ex(w), height: this.ex(H + D),
+            width: this.ex(W), height: this.ex(H + D),
             style: {'vertical-align': this.ex(-D)},
-            viewBox: [0, this.fixed(-H * 1000, 1), this.fixed(w * 1000, 1), this.fixed((H + D) * 1000, 1)].join(' ')
+            viewBox: [0, this.fixed(-H * 1000, 1), this.fixed(W * 1000, 1), this.fixed((H + D) * 1000, 1)].join(' ')
         }, [g])) as N;
+        if (W === .001) {
+            adaptor.setAttribute(svg, 'preserveAspectRatio', 'xMidYMid slice');
+        }
         if (pwidth) {
             //
             // These aren't needed for full-width tables

--- a/mathjax3-ts/output/svg/Wrapper.ts
+++ b/mathjax3-ts/output/svg/Wrapper.ts
@@ -87,6 +87,9 @@ CommonWrapper<SVG<N, T, D>, SVGWrapper<N, T, D>, SVGWrapperClass<N, T, D>> {
      *  The default styles for SVG
      */
     public static styles: StyleList = {
+        'mjx-container[jax="SVG"] > svg': {
+            'overflow': 'visible'
+        },
         'mjx-container[jax="SVG"] > svg a': {
             fill: 'blue', stroke: 'blue'
         }


### PR DESCRIPTION
Allow svg elements to overflow (so that `\llap`, `\rlap`, `\smash`, etc will not cause clipping at the border of the svg).  That is, `$\llap{x}$ will have the x overlaps the text to the left of the math.

This also makes things like `$x\hskip -2em y$` show up and have the correct width in both SVG and CHTML.

Resolves issue #157.