### PR TITLE
Add css for mstyle so bounding box is correct.  #137.

### DIFF
--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -152,6 +152,9 @@ CommonWrapper<CHTML<N, T, D>, CHTMLWrapper<N, T, D>, CHTMLWrapperClass<N, T, D>>
         'mjx-mtext': {
             display: 'inline-block'
         },
+        'mjx-mstyle': {
+            display: 'inline-block'
+        },
         'mjx-merror': {
             display: 'inline-block',
             color: 'red',


### PR DESCRIPTION
Add css for mstyle so bounding box is correct.  (This was supposed to have been in the beta.2 release, but I lost it along the way somewhere, probably when I was unraveling some changes near the end.)

Resolves issue #137.