### PR TITLE
Nested tables

### DIFF
--- a/lib/Mml-lab.js
+++ b/lib/Mml-lab.js
@@ -68,7 +68,8 @@ const Lab = window.Lab = {
   },
   
   Init() {
-    let test = chtml.getTestElement(this.output);
+    let text = this.output.appendChild(document.createTextNode(''));
+    let test = chtml.getTestElement(text, true);
     let {em, ex, containerWidth, lineWidth, scale} = chtml.measureMetrics(test);
     this.metrics = [em, ex, containerWidth, lineWidth, scale];
     this.output.removeChild(test);

--- a/lib/TeX-lab.js
+++ b/lib/TeX-lab.js
@@ -75,7 +75,8 @@ const Lab = window.Lab = {
   },
   
   Init() {
-    let test = chtml.getTestElement(this.output);
+    let text = this.output.appendChild(document.createTextNode(''));
+    let test = chtml.getTestElement(text, true);
     let {em, ex, containerWidth, lineWidth, scale} = chtml.measureMetrics(test);
     this.metrics = [em, ex, containerWidth, lineWidth, scale];
     this.output.removeChild(test);

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -51,6 +51,13 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
     }
 
     /**
+     * @override
+     */
+    public get notParent() {
+        return true;
+    }
+
+    /**
      * Handle scriptlevel changes, and add mstyle attributes to the ones being inherited.
      *
      * @override

--- a/mathjax3-ts/output/chtml/Wrapper.ts
+++ b/mathjax3-ts/output/chtml/Wrapper.ts
@@ -354,11 +354,14 @@ CommonWrapper<CHTML<N, T, D>, CHTMLWrapper<N, T, D>, CHTMLWrapperClass<N, T, D>>
      * @param {number} shift  The indent (positive or negative) for the node
      */
     protected setIndent(chtml: N, align: string, shift: number) {
+        const adaptor = this.adaptor;
         if (align === 'center' || align === 'left') {
-            this.adaptor.setStyle(chtml, 'margin-left', this.em(shift));
+            const L = this.getBBox().L;
+            adaptor.setStyle(chtml, 'margin-left', this.em(shift + L));
         }
         if (align === 'center' || align === 'right') {
-            this.adaptor.setStyle(chtml, 'margin-right', this.em(-shift));
+            const R = this.getBBox().R;
+            adaptor.setStyle(chtml, 'margin-right', this.em(-shift + R));
         }
     }
 

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -21,8 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
 import {CHTMLWrapperFactory} from '../WrapperFactory.js';
+import {CommonMath, CommonMathMixin} from '../../common/Wrappers/math.js';
 import {MmlMath} from '../../../core/MmlTree/MmlNodes/math.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../../common/CssStyles.js';
@@ -35,7 +36,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
+export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
     public static kind = MmlMath.prototype.kind;
 
     public static styles: StyleList = {
@@ -91,6 +92,13 @@ export class CHTMLmath<N, T, D> extends CHTMLWrapper<N, T, D> {
         if (display && shift && !adaptor.hasAttribute(chtml, 'width')) {
             this.setIndent(chtml, align, shift);
         }
+    }
+
+    /**
+     * @override
+     */
+    public setChildPWidths(recompute: boolean, w: number = null, clear: boolean = true) {
+        return (this.parent ? super.setChildPWidths(recompute, w) : false);
     }
 
 }

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -60,7 +60,7 @@ export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<N, T, D
             'text-align': 'center',
             margin: '1em 0'
         },
-        'mjx-container[display="true"] mjx-math': {
+        'mjx-container[jax="CHTML"][display="true"] mjx-math': {
             padding: 0
         },
         'mjx-container[jax="CHTML"][justify="left"]': {

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -70,9 +70,6 @@ export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<N, T,
             display: 'block',
             'font-size': '5%'
         },
-        'mjx-row': {
-            display: 'table-row'
-        },
         'mjx-num': {
             display: 'block',
             'text-align': 'center'
@@ -80,6 +77,12 @@ export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<N, T,
         'mjx-den': {
             display: 'block',
             'text-align': 'center'
+        },
+        'mjx-mfrac[bevelled] > mjx-num': {
+            display: 'inline-block'
+        },
+        'mjx-mfrac[bevelled] > mjx-den': {
+            display: 'inline-block'
         },
 
         'mjx-den[align="right"], mjx-num[align="right"]': {
@@ -240,20 +243,21 @@ export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<N, T,
         //
         //  Create HTML tree
         //
-        this.childNodes[0].toCHTML(this.chtml);
+        adaptor.setAttribute(this.chtml, 'bevelled', 'ture');
+        const num = adaptor.append(this.chtml, this.html('mjx-num'));
+        this.childNodes[0].toCHTML(num);
         this.bevel.toCHTML(this.chtml);
-        this.childNodes[1].toCHTML(this.chtml);
+        const den = adaptor.append(this.chtml, this.html('mjx-den'));
+        this.childNodes[1].toCHTML(den);
         //
         //  Place the parts
         //
         const {u, v, delta, nbox, dbox} = this.getBevelData(display);
         if (u) {
-            const num = this.childNodes[0].chtml;
             adaptor.setStyle(num, 'verticalAlign', this.em(u / nbox.scale));
         }
         if (v) {
-            const denom = this.childNodes[1].chtml;
-            adaptor.setStyle(denom, 'verticalAlign', this.em(v / dbox.scale));
+            adaptor.setStyle(den, 'verticalAlign', this.em(v / dbox.scale));
         }
         const dx = this.em(-delta / 2);
         adaptor.setStyle(this.bevel.chtml, 'marginLeft', dx);

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -55,7 +55,7 @@ export class CHTMLmpadded<N, T, D> extends CommonMpaddedMixin<CHTMLConstructor<N
         let chtml = this.standardCHTMLnode(parent);
         const content: N[] = [];
         const style: StringMap = {};
-        const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
+        const [H, D, W, dh, dd, dw, x, y, dx] = this.getDimens();
         //
         // If the width changed, set the width explicitly
         //
@@ -72,9 +72,14 @@ export class CHTMLmpadded<N, T, D> extends CommonMpaddedMixin<CHTMLConstructor<N
         // If there is a horizontal or vertical shift,
         //   use relative positioning to move the contents
         //
-        if (x || y) {
+        if (x + dx || y) {
             style.position = 'relative';
-            content.push(this.html('mjx-rbox', {style: {left: this.em(x), top: this.em(-y)}}));
+            const rbox = this.html('mjx-rbox', {style: {left: this.em(x + dx), top: this.em(-y)}});
+            if (x + dx && this.childNodes[0].getBBox().pwidth) {
+                this.adaptor.setAttribute(rbox, 'width', 'full');
+                this.adaptor.setStyle(rbox, 'left', this.em(x));
+            }
+            content.push(rbox);
         }
         //
         //  Create the HTML with the proper styles and content

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -30,6 +30,8 @@ import {MmlMtable} from '../../../core/MmlTree/MmlNodes/mtable.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../../common/CssStyles.js';
 import {isPercent} from '../../../util/string.js';
+import {OptionList} from '../../../util/Options.js';
+import {BBox} from '../BBox.js';
 
 /*****************************************************************/
 /**
@@ -51,45 +53,54 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
             'position': 'relative',
             'box-sizing': 'border-box'
         },
-        'mjx-mtable > mjx-itable': {
+        'mjx-labels': {
+            position: 'absolute',
+            left: 0,
+            top: 0
+        },
+        'mjx-table': {
+            'display': 'inline-block',
+        },
+        'mjx-table > mjx-itable': {
             'vertical-align': 'middle',
             'text-align': 'left',
             'box-sizing': 'border-box'
         },
-        'mjx-labels': {
-            display: 'inline-table',
+        'mjx-labels > mjx-itable': {
             position: 'absolute',
             top: 0
         },
+        'mjx-mtable[justify="left"]': {
+            'text-align': 'left'
+        },
+        'mjx-mtable[justify="right"]': {
+            'text-align': 'right'
+        },
         'mjx-mtable[justify="left"][side="left"]': {
-            'text-align': 'left',
             'padding-right': '0 ! important'
         },
         'mjx-mtable[justify="left"][side="right"]': {
-            'text-align': 'left',
             'padding-left': '0 ! important'
         },
         'mjx-mtable[justify="right"][side="left"]': {
-            'text-align': 'right',
             'padding-right': '0 ! important'
         },
         'mjx-mtable[justify="right"][side="right"]': {
-            'text-align': 'right',
             'padding-left': '0 ! important'
         },
         'mjx-mtable[align]': {
             'vertical-align': 'baseline'
         },
-        'mjx-mtable[align="top"] > mjx-itable': {
+        'mjx-mtable[align="top"] > mjx-table': {
             'vertical-align': 'top'
         },
-        'mjx-mtable[align="bottom"] > mjx-itable': {
+        'mjx-mtable[align="bottom"] > mjx-table': {
             'vertical-align': 'bottom'
         },
-        'mjx-mtable[align="center"] > mjx-itable': {
+        'mjx-mtable[align="center"] > mjx-table': {
             'vertical-align': 'middle'
         },
-        'mjx-mtable[align="baseline"] > mjx-itable': {
+        'mjx-mtable[align="baseline"] > mjx-table': {
             'vertical-align': 'middle'
         }
     };
@@ -99,6 +110,11 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      */
     public labels: N;
 
+    /**
+     * The inner table DOM node
+     */
+    public itable: N;
+
     /******************************************************************/
 
     /**
@@ -106,7 +122,19 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      */
     constructor(factory: CHTMLWrapperFactory<N, T, D>, node: MmlNode, parent: CHTMLWrapper<N, T, D> = null) {
         super(factory, node, parent);
-        this.labels = this.html('mjx-labels');
+        this.itable = this.html('mjx-itable');
+        this.labels = this.html('mjx-itable');
+    }
+
+    /**
+     * @override
+     */
+    public getAlignShift() {
+        const data = super.getAlignShift();
+        if (!this.isTop) {
+            data[1] = 0;
+        }
+        return data;
     }
 
     /**
@@ -117,9 +145,9 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
         //  Create the rows inside an mjx-itable (which will be used to center the table on the math axis)
         //
         const chtml = this.standardCHTMLnode(parent);
-        const table = this.adaptor.append(chtml, this.html('mjx-itable')) as N;
+        this.adaptor.append(chtml, this.html('mjx-table', {}, [this.itable]));
         for (const child of this.childNodes) {
-            child.toCHTML(table);
+            child.toCHTML(this.itable);
         }
         //
         //  Pad the rows of the table, if needed
@@ -146,10 +174,11 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      * only colored on the main part of the table.
      */
     protected shiftColor() {
-        const color = this.adaptor.getStyle(this.chtml, 'backgroundColor');
+        const adaptor = this.adaptor;
+        const color = adaptor.getStyle(this.chtml, 'backgroundColor');
         if (color) {
-            this.adaptor.setStyle(this.chtml, 'backgroundColor', '');
-            this.adaptor.setStyle(this.adaptor.firstChild(this.chtml) as N, 'backgroundColor', color);
+            adaptor.setStyle(this.chtml, 'backgroundColor', '');
+            adaptor.setStyle(this.itable, 'backgroundColor', color);
         }
     }
 
@@ -159,9 +188,10 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      * Pad any short rows with extra cells
      */
     protected padRows() {
-        for (const row of this.adaptor.childNodes(this.adaptor.firstChild(this.chtml) as N) as N[]) {
-            while (this.adaptor.childNodes(row).length < this.numCols) {
-                this.adaptor.append(row, this.html('mjx-mtd'));
+        const adaptor = this.adaptor;
+        for (const row of adaptor.childNodes(this.itable) as N[]) {
+            while (adaptor.childNodes(row).length < this.numCols) {
+                adaptor.append(row, this.html('mjx-mtd'));
             }
         }
     }
@@ -365,8 +395,7 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      */
     protected handleFrame() {
         if (this.frame) {
-            this.adaptor.setStyle(this.adaptor.firstChild(this.chtml) as N,
-                                  'border', '.07em ' + this.node.attributes.get('frame'));
+            this.adaptor.setStyle(this.itable, 'border', '.07em ' + this.node.attributes.get('frame'));
         }
     }
 
@@ -374,14 +403,28 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      * Handle percentage widths and fixed widths
      */
     protected handleWidth() {
-        let w = this.node.attributes.get('width') as string;
-        const hasLabels = (this.adaptor.childNodes(this.labels).length > 0);
-        if (!(isPercent(w) || hasLabels)) {
-            if (w === 'auto') return;
-            w = this.em(this.length2em(w) + 2 * this.fLine);
+        const adaptor = this.adaptor;
+        const {w, L, R} = this.getBBox();
+        adaptor.setStyle(this.chtml, 'minWidth', this.em(L + w + R));
+        let W = this.node.attributes.get('width') as string;
+        if (isPercent(W)) {
+            adaptor.setStyle(this.chtml, 'width', '');
+            adaptor.setAttribute(this.chtml, 'width', 'full');
+        } else if (!this.hasLabels) {
+            if (W === 'auto') return;
+            W = this.em(this.length2em(W) + 2 * this.fLine);
         }
-        const table = this.adaptor.firstChild(this.chtml) as N;
-        this.adaptor.setStyle(table, 'minWidth', w);
+        const table = adaptor.firstChild(this.chtml) as N;
+        adaptor.setStyle(table, 'minWidth', W);
+        if (L || R) {
+            adaptor.setStyle(this.chtml, 'margin', '');
+            if (L === R) {
+                adaptor.setStyle(table, 'margin', '0 ' + this.em(R));
+            } else {
+                adaptor.setStyle(table, 'margin', '0 ' + this.em(R) + ' 0 ' + this.em(L));
+            }
+        }
+        adaptor.setAttribute(this.itable, 'width', 'full');
     }
 
     /**
@@ -416,10 +459,10 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
      * Handle addition of labels to the table
      */
     protected handleLabels() {
+        if (!this.hasLabels) return;
         const labels = this.labels;
         const attributes = this.node.attributes;
         const adaptor = this.adaptor;
-        if (adaptor.childNodes(labels).length === 0) return;
         //
         //  Set the side for the labels
         //
@@ -430,22 +473,10 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
         //
         //  Make sure labels don't overlap table
         //
-        const {L} = this.getTableData();
-        const sep = this.length2em(attributes.get('minlabelspacing'));
-        let pad = L + sep;
-        const [lpad, rpad] = (this.styles == null ? ['', ''] :
-                              [this.styles.get('padding-left'), this.styles.get('padding-right')]);
-        if (lpad || rpad) {
-            pad = Math.max(pad, this.length2em(lpad || '0'), this.length2em(rpad || '0'));
-        }
-        adaptor.setStyle(this.chtml, 'padding', '0 ' + this.em(pad));
+        const [align, shift] = this.addLabelPadding(side);
         //
         //  Handle indentation
         //
-        let [align, shift] = this.getAlignShift();
-        if (align === side) {
-            shift = (side === 'left' ? Math.max(pad, shift) - pad : Math.min(-pad, shift) + pad);
-        }
         if (shift) {
             const table = adaptor.firstChild(this.chtml) as N;
             this.setIndent(table, align, shift);
@@ -455,7 +486,25 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
         //
         this.updateRowHeights();
         this.addLabelSpacing();
-        adaptor.append(this.chtml, labels);
+    }
+
+    /**
+     * @param {string} side         The side for the labels
+     * @return {[string, number]}   The alignment and shift values
+     */
+    protected addLabelPadding(side: string) {
+        const [pad, align, shift] = this.getPadAlignShift(side);
+        const styles: OptionList = {};
+        if (side === 'right') {
+            const W = this.node.attributes.get('width') as string;
+            const {w, L, R} = this.getBBox();
+            styles.style = {
+                width: (isPercent(W) ? 'calc(' + W + ' + ' + this.em(L + R) + ')' : this.em(L + w + R)),
+                minWidth: '100%'
+            };
+        }
+        this.adaptor.append(this.chtml, this.html('mjx-labels', styles, [this.labels]));
+        return [align, shift] as [string, number];
     }
 
     /**

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -415,7 +415,8 @@ CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D
             W = this.em(this.length2em(W) + 2 * this.fLine);
         }
         const table = adaptor.firstChild(this.chtml) as N;
-        adaptor.setStyle(table, 'minWidth', W);
+        adaptor.setStyle(table, 'width', W);
+        adaptor.setStyle(table, 'minWidth', this.em(w));
         if (L || R) {
             adaptor.setStyle(this.chtml, 'margin', '');
             if (L === R) {

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -21,7 +21,8 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CHTMLWrapper} from '../Wrapper.js';
+import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
+import {CommonMtd, CommonMtdMixin} from '../../common/Wrappers/mtd.js';
 import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
 import {StyleList} from '../../common/CssStyles.js';
 
@@ -33,7 +34,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
+export class CHTMLmtd<N, T, D> extends CommonMtdMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
 
     public static kind = MmlMtd.prototype.kind;
 
@@ -49,16 +50,10 @@ export class CHTMLmtd<N, T, D> extends CHTMLWrapper<N, T, D> {
         'mjx-mtd:last-child': {
             'padding-right': 0
         },
-        'mjx-mtable > mjx-itable > *:first-child > mjx-mtd': {
+        'mjx-mtable > * > mjx-itable > *:first-child > mjx-mtd': {
             'padding-top': 0
         },
-        'mjx-mtable > mjx-itable > *:last-child > mjx-mtd': {
-            'padding-bottom': 0
-        },
-        'mjx-mtable > mjx-labels > *:first-child > mjx-mtd': {
-            'padding-top': 0
-        },
-        'mjx-mtable > mjx-labels > *:last-child > mjx-mtd': {
+        'mjx-mtable > * > mjx-itable > *:last-child > mjx-mtd': {
             'padding-bottom': 0
         },
         'mjx-tstrut': {

--- a/mathjax3-ts/output/common/BBox.ts
+++ b/mathjax3-ts/output/common/BBox.ts
@@ -38,7 +38,7 @@ export const BBoxStyleAdjust = [
 ];
 
 /**
- *  The data used to initialie a BBox
+ *  The data used to initialize a BBox
  */
 export type BBoxData = {
     w?: number,
@@ -63,8 +63,6 @@ export class BBox {
     public w: number;
     public h: number;
     public d: number;
-    public x: number;
-    public y: number;
     public scale: number;
     public rscale: number; // scale relative to the parent's scale
     public L: number;      // extra space on the left
@@ -98,7 +96,7 @@ export class BBox {
         this.w = def.w || 0;
         this.h = ('h' in def ? def.h : -BIGDIMEN);
         this.d = ('d' in def ? def.d : -BIGDIMEN);
-        this.x = this.y = this.L = this.R = this.ic = this.sk = 0;
+        this.L = this.R = this.ic = this.sk = 0;
         this.scale = this.rscale = 1;
         this.pwidth = '';
     }
@@ -137,8 +135,6 @@ export class BBox {
      * @param {number} y   A y-offset for the child bounding box
      */
     public combine(cbox: BBox, x: number = 0, y: number = 0) {
-        cbox.x = x;
-        cbox.x = y;
         let rscale = cbox.rscale;
         let w = x + rscale * (cbox.w + cbox.L + cbox.R);
         let h = y + rscale * cbox.h;

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -274,7 +274,7 @@ AbstractOutputJax<N, T, D> {
         const maps = [new Map() as MetricMap<N>, new Map() as MetricMap<N>];
         for (const i of maps.keys()) {
             for (const node of domMaps[i].keys()) {
-                maps[i].set(node, this.measureMetrics(domMaps[0].get(node)));
+                maps[i].set(node, this.measureMetrics(domMaps[i].get(node)));
             }
         }
         //
@@ -335,7 +335,7 @@ AbstractOutputJax<N, T, D> {
             adaptor.setStyle(right, 'width', '10000em');
             adaptor.setStyle(right, 'float', '');
         }
-        return adaptor.append(node, adaptor.clone(display? this.testDisplay : this.testInline) as N);
+        return adaptor.append(node, adaptor.clone(display? this.testDisplay : this.testInline) as N) as N;
     }
 
     /**

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -266,7 +266,9 @@ AbstractOutputJax<N, T, D> {
         for (const math of html.math) {
             const node = adaptor.parent(math.start.node);
             const map = domMaps[math.display? 1 : 0];
-            map.set(node, this.getTestElement(node, math.display));
+            if (!map.has(node)) {
+                map.set(node, this.getTestElement(node, math.display));
+            }
         }
         //
         // Measure the metrics for all the mapped elements

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -93,6 +93,11 @@ AbstractOutputJax<N, T, D> {
     public container: N;
 
     /**
+     * The pixels per em for the math item being processed
+     */
+    public pxPerEm: number;
+
+    /**
      * The data for the font in use
      */
     public font: FontData;
@@ -191,6 +196,7 @@ AbstractOutputJax<N, T, D> {
     public toDOM(math: MathItem<N, T, D>, node: N, html: MathDocument<N, T, D> = null) {
         this.setDocument(html);
         this.math = math;
+        this.pxPerEm = math.metrics.ex / this.font.params.x_height;
         math.root.setTeXclass(null);
         this.setScale(node);
         this.nodeMap = new Map<MmlNode, W>();

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -284,7 +284,7 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
 
     /**
      * @param {BBox} bbox           The bounding box to modify (either this.bbox, or an empty one)
-     * @param {boolean} recompute   True if we are recomputing due to changes in percentage width children
+     * @param {boolean} recompute   True if we are recomputing due to changes in children that have percentage widths
      */
     protected computeBBox(bbox: BBox, recompute: boolean = false) {
         bbox.empty();
@@ -292,10 +292,8 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
             bbox.append(child.getBBox());
         }
         bbox.clean();
-        if (this.fixesPWidth) {
-            if (this.setChildPWidths(recompute)) {
-                this.computeBBox(bbox, true);
-            }
+        if (this.fixesPWidth && this.setChildPWidths(recompute)) {
+            this.computeBBox(bbox, true);
         }
     }
 
@@ -318,10 +316,8 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         let changed = false;
         for (const child of this.childNodes) {
             const cbox = child.getBBox();
-            if (cbox.pwidth) {
-                if (child.setChildPWidths(recompute, w === null ? cbox.w : w, clear)) {
-                    changed = true;
-                }
+            if (cbox.pwidth && child.setChildPWidths(recompute, w === null ? cbox.w : w, clear)) {
+                changed = true;
             }
         }
         return changed;
@@ -608,9 +604,9 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
      * @return {number}        The x position of the aligned width
      */
     protected getAlignX(W: number, bbox: BBox, align: string) {
-        if (align === 'right') return W - (bbox.w + bbox.R) * bbox.rscale;
-        if (align === 'left') return bbox.L * bbox.rscale;
-        return (W - bbox.w * bbox.rscale) / 2;
+        return (align === 'right' ? W - (bbox.w + bbox.R) * bbox.rscale :
+                align === 'left' ? bbox.L * bbox.rscale :
+                (W - bbox.w * bbox.rscale) / 2);
     }
 
     /**
@@ -622,10 +618,10 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
      * @return {number}         The y position of the aligned baseline
      */
     protected getAlignY(H: number, D: number, h: number, d: number, align: string) {
-        if (align === 'top') return H - h ;
-        if (align === 'bottom') return d - D;
-        if (align === 'middle') return ((H - h) - (D - d)) / 2;
-        return 0; // baseline and axis
+        return (align === 'top' ? H - h :
+                align === 'bottom' ? d - D :
+                align === 'middle' ? ((H - h) - (D - d)) / 2 :
+                0); // baseline and axis
     }
 
     /**

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -220,6 +220,13 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         return this.factory.jax.math.metrics;
     }
 
+    /**
+     * True if children with percentage widths should be resolved by this container
+     */
+    get fixesPWidth() {
+        return !this.node.notParent && !this.node.isToken;
+    }
+
     /*******************************************************************/
 
     /**
@@ -234,9 +241,9 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         this.getVariant();
         this.getScale();
         this.getSpace();
-        this.childNodes = node.childNodes.map((child: Node) => {
-            const wrapped = this.wrap(child as MmlNode);
-            if (wrapped.bbox.pwidth) {
+        this.childNodes = node.childNodes.map((child: MmlNode) => {
+            const wrapped = this.wrap(child);
+            if (wrapped.bbox.pwidth && (node.notParent || node.isKind('math'))) {
                 this.bbox.pwidth = BBox.fullWidth;
             }
             return wrapped;
@@ -276,14 +283,48 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
     }
 
     /**
-     * @param {BBox} bbox  The bounding box to modify (either this.bbox, or an empty one)
+     * @param {BBox} bbox           The bounding box to modify (either this.bbox, or an empty one)
+     * @param {boolean} recompute   True if we are recomputing due to changes in percentage width children
      */
-    protected computeBBox(bbox: BBox) {
+    protected computeBBox(bbox: BBox, recompute: boolean = false) {
         bbox.empty();
         for (const child of this.childNodes) {
             bbox.append(child.getBBox());
         }
         bbox.clean();
+        if (this.fixesPWidth) {
+            if (this.setChildPWidths(recompute)) {
+                this.computeBBox(bbox, true);
+            }
+        }
+    }
+
+    /**
+     * Recursively resolve any percentage widths in the child nodes using the given
+     *   container width (or the child width, if none was passed).
+     *   Overriden for mtables in order to compute the width.
+     *
+     * @param {(number|null)=} w   The width of the container (from which percentages are computed)
+     * @param {boolean=} clear     True if pwidth marker is to be cleared
+     * @return {boolean}           True if a percentage width was found
+     */
+    public setChildPWidths(recompute: boolean, w: (number | null) = null, clear: boolean = true) {
+        if (recompute) {
+            return false;
+        }
+        if (clear) {
+           this.bbox.pwidth = '';
+        }
+        let changed = false;
+        for (const child of this.childNodes) {
+            const cbox = child.getBBox();
+            if (cbox.pwidth) {
+                if (child.setChildPWidths(recompute, w === null ? cbox.w : w, clear)) {
+                    changed = true;
+                }
+            }
+        }
+        return changed;
     }
 
     /**
@@ -482,6 +523,9 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         }
     }
 
+    /**
+     * @return {boolean}   True if the parent element is an embellished operator
+     */
     protected isTopEmbellished() {
         return (this.node.isEmbellished &&
                 !(this.node.Parent && this.node.Parent.isEmbellished));
@@ -557,6 +601,49 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         return [indentalign, shift] as [string, number];
     }
 
+    /**
+     * @param {number} W       The total width
+     * @param {BBox} bbox      The bbox to be aligned
+     * @param {string} align   How to align (left, center, right)
+     * @return {number}        The x position of the aligned width
+     */
+    protected getAlignX(W: number, bbox: BBox, align: string) {
+        if (align === 'right') return W - (bbox.w + bbox.R) * bbox.rscale;
+        if (align === 'left') return bbox.L * bbox.rscale;
+        return (W - bbox.w * bbox.rscale) / 2;
+    }
+
+    /**
+     * @param {number} H        The total height
+     * @param {number} D        The total depth
+     * @param {number} h        The height to be aligned
+     * @param {number} d        The depth to be aligned
+     * @param {string} align    How to align (top, bottom, middle, axis, baseline)
+     * @return {number}         The y position of the aligned baseline
+     */
+    protected getAlignY(H: number, D: number, h: number, d: number, align: string) {
+        if (align === 'top') return H - h ;
+        if (align === 'bottom') return d - D;
+        if (align === 'middle') return ((H - h) - (D - d)) / 2;
+        return 0; // baseline and axis
+    }
+
+    /**
+     * @param {number} i   The index of the child element whose container is needed
+     * @return {number}    The inner width as a container (for percentage widths)
+     */
+    public getWrapWidth(i: number) {
+        return this.childNodes[i].getBBox().w;
+    }
+
+    /**
+     * @param {number} i   The index of the child element whose container is needed
+     * @return {string}    The alignment child element
+     */
+    public getChildAlign(i: number) {
+        return 'left';
+    }
+
     /*******************************************************************/
     /*
      * Easy access to some utility routines
@@ -597,7 +684,7 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         if (scale === null) {
             scale = this.bbox.scale;
         }
-        return LENGTHS.length2em(length as string, size, scale, this.metrics.em);
+        return LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm);
     }
 
     /**

--- a/mathjax3-ts/output/common/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/common/Wrappers/TeXAtom.ts
@@ -49,8 +49,8 @@ export function CommonTeXAtomMixin<T extends WrapperConstructor>(Base: T): TeXAt
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
-            super.computeBBox(bbox);
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
+            super.computeBBox(bbox, recompute);
             if (this.childNodes[0] && this.childNodes[0].bbox.ic) {
                 bbox.ic = this.childNodes[0].bbox.ic;
             }

--- a/mathjax3-ts/output/common/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/common/Wrappers/TextNode.ts
@@ -50,7 +50,7 @@ export function CommonTextNodeMixin<T extends WrapperConstructor>(Base: T): Text
        /**
         * @override
         */
-       public computeBBox(bbox: BBox) {
+       public computeBBox(bbox: BBox, recompute: boolean = false) {
            const variant = this.parent.variant;
            const text = (this.node as TextNode).getText();
            if (variant === '-explicitFont') {

--- a/mathjax3-ts/output/common/Wrappers/maction.ts
+++ b/mathjax3-ts/output/common/Wrappers/maction.ts
@@ -175,8 +175,9 @@ export function CommonMactionMixin<W extends AnyWrapper,
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             bbox.updateFrom(this.selected.getBBox());
+            this.selected.setChildPWidths(recompute);
         }
 
     };

--- a/mathjax3-ts/output/common/Wrappers/math.ts
+++ b/mathjax3-ts/output/common/Wrappers/math.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2017 The MathJax Consortium
+ *  Copyright (c) 2018 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the CommonMspace wrapper mixin for the MmlMspace object
+ * @fileoverview  Implements the CommonMath wrapper mixin for the MmlMath object
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */
@@ -26,41 +26,37 @@ import {BBox} from '../BBox.js';
 
 /*****************************************************************/
 /**
- * The CommonMspance interface
+ * The CommonMath interface
  */
-export interface CommonMspace extends AnyWrapper {
+export interface CommonMath extends AnyWrapper {
 }
 
 /**
- * Shorthand for the CommonMspace constructor
+ * Shorthand for the CommonMath constructor
  */
-export type MspaceConstructor = Constructor<CommonMspace>;
+export type MathConstructor = Constructor<CommonMath>;
 
 /*****************************************************************/
 /**
- * The CommonMspace wrapper mixin for the MmlMspace object
+ *  The CommonMath wrapper mixin for the MmlMath object
  *
  * @template T  The Wrapper class constructor type
  */
-export function CommonMspaceMixin<T extends WrapperConstructor>(Base: T): MspaceConstructor & T {
+export function CommonMathMixin<T extends WrapperConstructor>(Base: T): MathConstructor & T {
     return class extends Base {
 
         /**
          * @override
          */
-        public computeBBox(bbox: BBox, recompute: boolean = false) {
-            const attributes = this.node.attributes;
-            bbox.w = this.length2em(attributes.get('width'), 0);
-            bbox.h = this.length2em(attributes.get('height'), 0);
-            bbox.d = this.length2em(attributes.get('depth'), 0);
+        public setChildPWidths(recompute: boolean, w: number = null, clear: boolean = true) {
+            return (this.parent ? super.setChildPWidths(recompute, w) : false);
         }
 
         /**
-         * No contents, so no need for variant class
-         *
          * @override
          */
-        public handleVariant() {
+        public getWrapWidth(i: number) {
+            return (this.parent ? this.getBBox().w : this.metrics.containerWidth / this.jax.pxPerEm);
         }
 
     };

--- a/mathjax3-ts/output/common/Wrappers/math.ts
+++ b/mathjax3-ts/output/common/Wrappers/math.ts
@@ -48,13 +48,6 @@ export function CommonMathMixin<T extends WrapperConstructor>(Base: T): MathCons
         /**
          * @override
          */
-        public setChildPWidths(recompute: boolean, w: number = null, clear: boolean = true) {
-            return (this.parent ? super.setChildPWidths(recompute, w) : false);
-        }
-
-        /**
-         * @override
-         */
         public getWrapWidth(i: number) {
             return (this.parent ? this.getBBox().w : this.metrics.containerWidth / this.jax.pxPerEm);
         }

--- a/mathjax3-ts/output/common/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/common/Wrappers/menclose.ts
@@ -273,7 +273,7 @@ export function CommonMencloseMixin<W extends AnyWrapper,
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             //
             //  Combine the BBox from the child and add the extenders
             //
@@ -283,6 +283,7 @@ export function CommonMencloseMixin<W extends AnyWrapper,
             bbox.h += T;
             bbox.d += B;
             bbox.w += R;
+            this.setChildPWidths(recompute);
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/mfenced.ts
+++ b/mathjax3-ts/output/common/Wrappers/mfenced.ts
@@ -139,8 +139,9 @@ export function CommonMfencedMixin<T extends WrapperConstructor>(Base: T): Mfenc
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             bbox.updateFrom(this.mrow.getBBox());
+            this.setChildPWidths(recompute);
         }
 
     };

--- a/mathjax3-ts/output/common/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/common/Wrappers/mfrac.ts
@@ -97,6 +97,11 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
 
         public bevel: CommonMo = null;
 
+        /**
+         * Padding around fractions
+         */
+        public pad: number;
+
         /************************************************/
 
         /**
@@ -105,6 +110,7 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
          */
         constructor(...args: any[]) {
             super(...args);
+            this.pad = (this.node.getProperty('withDelims') as boolean ? 0 : this.font.params.nulldelimiterspace);
             //
             //  create internal bevel mo element
             //
@@ -119,21 +125,25 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             bbox.empty();
             const {linethickness, bevelled} = this.node.attributes.getList('linethickness', 'bevelled');
             const display = this.isDisplay();
+            let w = null as (number | null);
             if (bevelled) {
                 this.getBevelledBBox(bbox, display);
             } else {
                 const thickness = this.length2em(String(linethickness));
+                w = bbox.w - 2 * this.pad;
                 if (thickness === 0) {
                     this.getAtopBBox(bbox, display);
                 } else {
                     this.getFractionBBox(bbox, display, thickness);
+                    w -= .2;
                 }
             }
             bbox.clean();
+            this.setChildPWidths(recompute, w);
         }
 
         /************************************************/
@@ -147,12 +157,11 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
             const nbox = this.childNodes[0].getBBox();
             const dbox = this.childNodes[1].getBBox();
             const tex = this.font.params;
-            const pad = (this.node.getProperty('withDelims') as boolean ? 0 : tex.nulldelimiterspace);
             const a = tex.axis_height;
             const {T, u, v} = this.getTUV(display, t);
             bbox.combine(nbox, 0, a + T + Math.max(nbox.d * nbox.rscale, u));
             bbox.combine(dbox, 0, a - T - Math.max(dbox.h * dbox.rscale, v));
-            bbox.w += 2 * pad + .2;
+            bbox.w += 2 * this.pad + .2;
         }
 
         /**
@@ -178,11 +187,10 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
          */
         public getAtopBBox(bbox: BBox, display: boolean) {
             const tex = this.font.params;
-            const pad = (this.node.getProperty('withDelims') as boolean ? 0 : tex.nulldelimiterspace);
             const {u, v, nbox, dbox} = this.getUVQ(display);
             bbox.combine(nbox, 0, u);
             bbox.combine(dbox, 0, -v);
-            bbox.w += 2 * pad;
+            bbox.w += 2 * this.pad;
         }
 
         /**
@@ -260,6 +268,27 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
         public isDisplay() {
             const {displaystyle, scriptlevel} = this.node.attributes.getList('displaystyle', 'scriptlevel');
             return displaystyle && scriptlevel === 0;
+        }
+
+        /**
+         * @override
+         */
+        public getWrapWidth(i: number) {
+            const attributes = this.node.attributes;
+            if (attributes.get('bevelled')) {
+                return this.childNodes[i].getBBox().w;
+            }
+            const w = this.getBBox().w;
+            const thickness = this.length2em(attributes.get('linethickness'));
+            return w - (thickness ? .2 : 0) -  2 * this.pad;
+        }
+
+        /**
+         * @override
+         */
+        public getChildAlign(i: number) {
+            const attributes = this.node.attributes;
+            return (attributes.get('bevelled') ? 'left' : attributes.get(['numalign', 'denomalign'][i]) as string);
         }
 
     };

--- a/mathjax3-ts/output/common/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/common/Wrappers/mfrac.ts
@@ -134,13 +134,14 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
                 this.getBevelledBBox(bbox, display);
             } else {
                 const thickness = this.length2em(String(linethickness));
-                w = bbox.w - 2 * this.pad;
+                w = -2 * this.pad;
                 if (thickness === 0) {
                     this.getAtopBBox(bbox, display);
                 } else {
                     this.getFractionBBox(bbox, display, thickness);
                     w -= .2;
                 }
+                w += bbox.w;
             }
             bbox.clean();
             this.setChildPWidths(recompute, w);

--- a/mathjax3-ts/output/common/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/common/Wrappers/mglyph.ts
@@ -92,7 +92,7 @@ export function CommonMglyphMixin<T extends WrapperConstructor>(Base: T): Mglyph
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             bbox.w = this.width;
             bbox.h = this.height - this.voffset;
             bbox.d = this.voffset;

--- a/mathjax3-ts/output/common/Wrappers/mi.ts
+++ b/mathjax3-ts/output/common/Wrappers/mi.ts
@@ -57,7 +57,7 @@ export function CommonMiMixin<T extends WrapperConstructor>(Base: T): MiConstruc
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             super.computeBBox(bbox);
             this.copySkewIC(bbox);
             if (this.noIC) {

--- a/mathjax3-ts/output/common/Wrappers/mmultiscripts.ts
+++ b/mathjax3-ts/output/common/Wrappers/mmultiscripts.ts
@@ -173,7 +173,7 @@ export function CommonMmultiscriptsMixin<W extends AnyWrapper,
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             //
             // Get the bounding boxes, and combine the pre- and post-scripts
             //  to get a common offset for both
@@ -199,6 +199,7 @@ export function CommonMmultiscriptsMixin<W extends AnyWrapper,
                 bbox.w += scriptspace;
             }
             bbox.clean();
+            this.setChildPWidths(recompute);
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/mo.ts
+++ b/mathjax3-ts/output/common/Wrappers/mo.ts
@@ -135,7 +135,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             const stretchy = (this.stretch.dir !== DIRECTION.None);
             if (stretchy && this.size === null) {
                 this.getStretchedVariant([0]);

--- a/mathjax3-ts/output/common/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/common/Wrappers/mpadded.ts
@@ -77,7 +77,7 @@ export function CommonMpaddedMixin<T extends WrapperConstructor>(Base: T): Mpadd
             const values = this.node.attributes.getList('width', 'height', 'depth', 'lspace', 'voffset');
             const bbox = this.childNodes[0].getBBox();  // get unmodified bbox of children
             let {w, h, d} = bbox;
-            let W = w, H = h, D = d, x = 0, y = 0;
+            let W = w, H = h, D = d, x = 0, y = 0, dx = 0;
             if (values.width !== '')   w = this.dimen(values.width, bbox, 'w', 0);
             if (values.height !== '')  h = this.dimen(values.height, bbox, 'h', 0);
             if (values.depth !== '')   d = this.dimen(values.depth, bbox, 'd', 0);
@@ -85,9 +85,9 @@ export function CommonMpaddedMixin<T extends WrapperConstructor>(Base: T): Mpadd
             if (values.lspace !== '')  x = this.dimen(values.lspace, bbox);
             const align = this.node.attributes.get('data-align') as string;
             if (align) {
-                x += this.getAlignX(w, bbox, align);
+                dx = this.getAlignX(w, bbox, align);
             }
-            return [H, D, W, h - H, d - D, w - W, x, y];
+            return [H, D, W, h - H, d - D, w - W, x, y, dx];
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/common/Wrappers/mpadded.ts
@@ -83,6 +83,10 @@ export function CommonMpaddedMixin<T extends WrapperConstructor>(Base: T): Mpadd
             if (values.depth !== '')   d = this.dimen(values.depth, bbox, 'd', 0);
             if (values.voffset !== '') y = this.dimen(values.voffset, bbox);
             if (values.lspace !== '')  x = this.dimen(values.lspace, bbox);
+            const align = this.node.attributes.get('data-align') as string;
+            if (align) {
+                x += this.getAlignX(w, bbox, align);
+            }
             return [H, D, W, h - H, d - D, w - W, x, y];
         }
 
@@ -114,12 +118,26 @@ export function CommonMpaddedMixin<T extends WrapperConstructor>(Base: T): Mpadd
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
             bbox.w = W + dw;
             bbox.h = H + dh;
             bbox.d = D + dd;
+            this.setChildPWidths(recompute, bbox.w);
         }
 
+        /**
+         * @override
+         */
+        public getWrapWidth(i: number) {
+            return this.getBBox().w;
+        }
+
+        /**
+         * @override
+         */
+        public getChildAlign(i: number) {
+            return this.node.attributes.get('data-align') as string || 'left';
+        }
     };
 }

--- a/mathjax3-ts/output/common/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/common/Wrappers/mrow.ts
@@ -54,6 +54,13 @@ export function CommonMrowMixin<T extends WrapperConstructor>(Base: T): MrowCons
 
         /**
          * @override
+         */
+        get fixesPWidth() {
+            return false;
+        }
+
+        /**
+         * @override
          * @constructor
          */
         constructor(...args: any[]) {
@@ -139,7 +146,7 @@ export function CommonInferredMrowMixin<T extends MrowConstructor>(Base: T): Inf
          *
          * @override
          */
-        protected getScale() {
+        public getScale() {
             this.bbox.scale = this.parent.bbox.scale;
             this.bbox.rscale = 1;
         }

--- a/mathjax3-ts/output/common/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/common/Wrappers/msqrt.ts
@@ -141,7 +141,7 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             const surdbox = this.childNodes[this.surd].getBBox();
             const basebox = new BBox(this.childNodes[this.base].getBBox());
             const [p, q] = this.getPQ(surdbox);
@@ -153,6 +153,7 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
             bbox.combine(surdbox, x, H - surdbox.h);
             bbox.combine(basebox, x + surdbox.w, 0);
             bbox.clean();
+            this.setChildPWidths(recompute);
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/common/Wrappers/msubsup.ts
@@ -198,7 +198,7 @@ export function CommonMsubsupMixin<W extends AnyWrapper,
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             const basebox = this.baseChild.getBBox();
             const subbox  = this.subChild.getBBox();
             const supbox  = this.supChild.getBBox();
@@ -210,6 +210,7 @@ export function CommonMsubsupMixin<W extends AnyWrapper,
             bbox.combine(supbox, w + this.coreIC(), u);
             bbox.w += this.font.params.scriptspace;
             bbox.clean();
+            this.setChildPWidths(recompute);
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtable.ts
@@ -648,10 +648,11 @@ export function CommonMtableMixin<C extends AnyWrapper,
             if (!isPercent(width)) return;
             if (!this.hasLabels) {
                 this.bbox.pwidth = '';
+                this.container.bbox.pwidth = '';
             }
             const {w, L, R} = this.bbox;
             const W = Math.max(w, this.length2em(width, cwidth));
-            const cols = (this.node.attributes.get('equalcolumns') ?
+            const cols = (this.node.attributes.get('equalcolumns') as boolean ?
                           Array(this.numCols).fill(this.percent(1 / Math.max(1, this.numCols))) :
                           this.getColumnAttributes('columnwidth', 0));
             this.cWidths = this.getColumnWidthsFixed(cols, W);

--- a/mathjax3-ts/output/common/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtable.ts
@@ -647,7 +647,7 @@ export function CommonMtableMixin<C extends AnyWrapper,
             bbox.L = L;
             bbox.R = R;
             //
-            //  Handle cell widths if width is not a percent
+            //  Handle cell widths if width is not a percentage
             //
             if (!isPercent(w)) {
                 this.setColumnPWidths();

--- a/mathjax3-ts/output/common/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtable.ts
@@ -410,7 +410,7 @@ export function CommonMtableMixin<C extends AnyWrapper,
             this.numRows = this.childNodes.length;
             this.hasLabels = this.childNodes.reduce((value, row) => value || row.node.isKind('mlabeledtr'), false);
             this.findContainer();
-            this.isTop = (top && this.container.node.isKind('math') && !this.container.parent);
+            this.isTop = (this.container.node.isKind('math') && !this.container.parent);
             this.getPercentageWidth();
             //
             // Get the frame, row, and column parameters

--- a/mathjax3-ts/output/common/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtd.ts
@@ -1,0 +1,83 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CommonMtd wrapper mixin for the MmlMtd object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {AnyWrapper, WrapperConstructor, Constructor} from '../Wrapper.js';
+import {CommonMtable} from '../../common/Wrappers/mtable.js';
+import {CommonMtr} from '../../common/Wrappers/mtr.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/**
+ * The CommonMtd interface
+ */
+export interface CommonMtd extends AnyWrapper {
+}
+
+/**
+ * Shorthand for the CommonMtd constructor
+ */
+export type MtdConstructor = Constructor<CommonMtd>;
+
+/*****************************************************************/
+/**
+ *  The CommonMtd wrapper mixin for the MmlMtd object
+ *
+ * @template T  The Wrapper class constructor type
+ */
+export function CommonMtdMixin<T extends WrapperConstructor>(Base: T): MtdConstructor & T {
+    return class extends Base {
+
+        /**
+         * @override
+         */
+        get fixesPWidth() {
+            return false;
+        }
+
+        /**
+         * @override
+         */
+        public invalidateBBox() {
+            this.bboxComputed = false;
+        }
+
+        /**
+         * @override
+         */
+        public getWrapWidth(j: number) {
+            const table = this.parent.parent as any as CommonMtable<AnyWrapper, CommonMtr<AnyWrapper>>;
+            const row = this.parent as CommonMtr<AnyWrapper>;
+            const i = this.node.childPosition() - (row.labeled ? 1 : 0);
+            return (typeof(table.cWidths[i]) === 'number' ? table.cWidths[i] : table.getTableData().W[i]) as number;
+        }
+
+        /**
+         * @override
+         */
+        public getChildAlign(i: number) {
+            return this.node.attributes.get('columnalign') as string;
+        }
+
+    };
+
+}

--- a/mathjax3-ts/output/common/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtr.ts
@@ -34,6 +34,7 @@ import {DIRECTION} from '../FontData.js';
  * @template C  The class for table cells
  */
 export interface CommonMtr<C extends AnyWrapper> extends AnyWrapper {
+
     /**
      * The number of mtd's in the mtr
      */
@@ -93,6 +94,13 @@ export type MtrConstructor<C extends AnyWrapper> = Constructor<CommonMtr<C>>;
 export function CommonMtrMixin<C extends AnyWrapper,
                                T extends WrapperConstructor>(Base: T): MtrConstructor<C> & T {
     return class extends Base {
+
+        /**
+         * @override
+         */
+        get fixesPWidth() {
+            return false;
+        }
 
         /**
          * @return {number}   The number of mtd's in the mtr

--- a/mathjax3-ts/output/common/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/common/Wrappers/munderover.ts
@@ -73,9 +73,9 @@ export function CommonMunderMixin<W extends AnyWrapper,
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             if (this.hasMovableLimits()) {
-                super.computeBBox(bbox);
+                super.computeBBox(bbox, recompute);
                 return;
             }
             bbox.empty();
@@ -89,6 +89,7 @@ export function CommonMunderMixin<W extends AnyWrapper,
             bbox.d += this.font.params.big_op_spacing5;
             bbox.ic = -this.baseCore.bbox.ic;
             bbox.clean();
+            this.setChildPWidths(recompute);
         }
 
     };

--- a/mathjax3-ts/output/common/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/common/Wrappers/scriptbase.ts
@@ -232,7 +232,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          *
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             const basebox = this.baseChild.getBBox();
             const scriptbox = this.script.getBBox();
             const [x, y] = this.getOffset(basebox, scriptbox);
@@ -240,6 +240,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
             bbox.combine(scriptbox, bbox.w + x, y);
             bbox.w += this.font.params.scriptspace;
             bbox.clean();
+            this.setChildPWidths(recompute);
         }
 
         /**

--- a/mathjax3-ts/output/common/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/common/Wrappers/semantics.ts
@@ -48,7 +48,7 @@ export function CommonSemanticsMixin<T extends WrapperConstructor>(Base: T): Sem
         /**
          * @override
          */
-        public computeBBox(bbox: BBox) {
+        public computeBBox(bbox: BBox, recompute: boolean = false) {
             if (this.childNodes.length) {
                 const {w, h, d} = this.childNodes[0].getBBox();
                 bbox.w = w;

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -56,7 +56,6 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
      * Minimum width for tables with labels,
      * and shift and align for main equation
      */
-    public minwidth: number = 0;
     public shift: number = 0;
 
     /**
@@ -121,8 +120,6 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
         const wrapper = this.factory.wrap(math);
         const {w, h, d, pwidth} = wrapper.getBBox();
         const px = (this.font.params.x_height / wrapper.metrics.ex);
-        const H = (Math.ceil(h / px) + 1) * px + 2/1000;  // round to pixels and add a little padding
-        const D = (Math.ceil(d / px) + 1) * px + 2/1000;
         //
         //  The container that flips the y-axis and sets the colors to inherit from the surroundings
         //
@@ -136,26 +133,28 @@ export class SVG<N, T, D> extends CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, 
         const adaptor = this.adaptor;
         const svg = adaptor.append(parent, this.svg('svg', {
             xmlns: SVGNS,
-            width: this.ex(w), height: this.ex(H + D),
-            style: {'vertical-align': this.ex(-D)},
-            viewBox: [0, this.fixed(-H * 1000, 1), this.fixed(w * 1000, 1), this.fixed((H + D) * 1000, 1)].join(' ')
+            width: this.ex(w), height: this.ex(h + d),
+            style: {'vertical-align': this.ex(-d)},
+            viewBox: [0, this.fixed(-h * 1000, 1), this.fixed(w * 1000, 1), this.fixed((h + d) * 1000, 1)].join(' ')
         }, [g])) as N;
         if (pwidth) {
             //
-            // These aren't needed for full-width tables
+            // Use width 100% with no viewbox, and instead scale and translate to achieve the same result
             //
             adaptor.setAttribute(svg, 'width', pwidth);
             adaptor.removeAttribute(svg, 'viewBox');
-            adaptor.removeAttribute(g, 'transform');
+            const scale = wrapper.metrics.ex / (this.font.params.x_height * 1000);
+            adaptor.setAttribute(g, 'transform', 'matrix(1 0 0 -1 0 0) scale(' +
+                                 this.fixed(scale, 6) + ') translate(0, ' + this.fixed(-h * 1000, 1) + ')');
         }
         //
-        //  Typeset the math and add minwith (from mtables), or set the alignment and indentation
+        //  Typeset the math and add minWith (from mtables), or set the alignment and indentation
         //    of the finalized expression
         //
-        this.minwidth = this.shift = 0;
+        this.shift = 0;
         wrapper.toSVG(g);
-        if (this.minwidth) {
-            adaptor.setStyle(svg, 'minWidth', this.ex(this.minwidth));
+        if (wrapper.bbox.pwidth) {
+            adaptor.setStyle(svg, 'minWidth', this.ex(wrapper.bbox.w));
         } else if (this.shift) {
             const align = adaptor.getAttribute(parent, 'justify') || 'center';
             this.setIndent(svg, align, this.shift);

--- a/mathjax3-ts/output/svg/Wrapper.ts
+++ b/mathjax3-ts/output/svg/Wrapper.ts
@@ -248,20 +248,6 @@ CommonWrapper<SVG<N, T, D>, SVGWrapper<N, T, D>, SVGWrapperClass<N, T, D>> {
     /*******************************************************************/
 
     /**
-     * @param {N} svg         The HTML node whose indentation is to be adjusted
-     * @param {string} align  The alignment for the node
-     * @param {number} shift  The indent (positive or negative) for the node
-     */
-    protected setIndent(svg: N, align: string, shift: number) {
-        if (align === 'center' || align === 'left') {
-            // FIXME
-        }
-        if (align === 'center' || align === 'right') {
-            // FIXME
-        }
-    }
-
-    /**
      * @param {number} x   The x-offset for the element
      * @param {number} y   The y-offset for the element
      * @param {N} eleemnt  The element to be placed
@@ -310,33 +296,6 @@ CommonWrapper<SVG<N, T, D>, SVGWrapper<N, T, D>, SVGWrapperClass<N, T, D>> {
             return this.jax.measureTextNodeWithCache(text, char, variant).w;
         }
         return w;
-    }
-
-    /**
-     * @param {number} W       The total width
-     * @param {number} w       The width to be aligned
-     * @param {string} align   How to align (left, center, right)
-     * @return {number}        The x position of the aligned width
-     */
-    protected getAlignX(W: number, w: number, align: string) {
-        if (align === 'right') return W - w ;
-        if (align === 'left') return 0;
-        return (W - w) / 2;
-    }
-
-    /**
-     * @param {number} H        The total height
-     * @param {number} D        The total depth
-     * @param {number} h        The height to be aligned
-     * @param {number} d        The depth to be aligned
-     * @param {string} align    How to align (top, bottom, middle, axis, baseline)
-     * @return {number}         The y position of the aligned baseline
-     */
-    protected getAlignY(H: number, D: number, h: number, d: number, align: string) {
-        if (align === 'top') return H - h ;
-        if (align === 'bottom') return d - D;
-        if (align === 'middle') return ((H - h) - (D - d)) / 2;
-        return 0; // baseline and axis
     }
 
     /*******************************************************************/

--- a/mathjax3-ts/output/svg/Wrappers/math.ts
+++ b/mathjax3-ts/output/svg/Wrappers/math.ts
@@ -21,8 +21,8 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {SVGWrapper} from '../Wrapper.js';
-import {SVGWrapperFactory} from '../WrapperFactory.js';
+import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
+import {CommonMath, CommonMathMixin} from '../../common/Wrappers/math.js';
 import {MmlMath} from '../../../core/MmlTree/MmlNodes/math.js';
 import {StyleList} from '../../common/CssStyles.js';
 
@@ -34,7 +34,8 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmath<N, T, D> extends SVGWrapper<N, T, D> {
+export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+
     public static kind = MmlMath.prototype.kind;
 
     public static styles: StyleList = {
@@ -68,6 +69,15 @@ export class SVGmath<N, T, D> extends SVGWrapper<N, T, D> {
         if (display && shift) {
             this.jax.shift = shift;
         }
+    }
+
+    /**
+     * @override
+     */
+    public setChildPWidths(recompute: boolean, w: number = null, clear: boolean = true) {
+        return super.setChildPWidths(recompute,
+                                     this.parent ? w : this.metrics.containerWidth / this.jax.pxPerEm,
+                                     false);
     }
 
 }

--- a/mathjax3-ts/output/svg/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mfrac.ts
@@ -79,8 +79,8 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>
         const d = .1; // line's extra left- and right-padding
         const pad = (this.node.getProperty('withDelims') ? 0 : tex.nulldelimiterspace);
         const W = Math.max(nbox.w * nbox.rscale, dbox.w * dbox.rscale);
-        const nx = this.getAlignX(W, nbox.w * nbox.rscale, numalign as string) + d + pad;
-        const dx = this.getAlignX(W, dbox.w * dbox.rscale, denomalign as string) + d + pad;
+        const nx = this.getAlignX(W, nbox, numalign as string) + d + pad;
+        const dx = this.getAlignX(W, dbox, denomalign as string) + d + pad;
         const {T, u, v} = this.getTUV(display, t);
 
         num.toSVG(svg);
@@ -109,8 +109,8 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>
         const tex = this.font.params;
         const pad = (this.node.getProperty('withDelims') ? 0 : tex.nulldelimiterspace);
         const W = Math.max(nbox.w * nbox.rscale, dbox.w * dbox.rscale);
-        const nx = this.getAlignX(W, nbox.w * nbox.rscale, numalign as string) + pad;
-        const dx = this.getAlignX(W, dbox.w * dbox.rscale, denomalign as string) + pad;
+        const nx = this.getAlignX(W, nbox, numalign as string) + pad;
+        const dx = this.getAlignX(W, dbox, denomalign as string) + pad;
         const {u, v} = this.getUVQ(display);
 
         num.toSVG(svg);
@@ -127,16 +127,16 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>
     protected makeBevelled(display: boolean) {
         const svg = this.element;
         const [num, den] = this.childNodes;
-        const {u, v, delta, nbox} = this.getBevelData(display);
-        const w = nbox.w * nbox.rscale;
+        const {u, v, delta, nbox, dbox} = this.getBevelData(display);
+        const w = (nbox.L + nbox.w + nbox.R) * nbox.rscale;
 
         num.toSVG(svg);
         this.bevel.toSVG(svg);
         den.toSVG(svg);
 
-        num.place(0, u);
+        num.place(nbox.L * nbox.rscale, u);
         this.bevel.place(w - delta / 2, 0);
-        den.place(w + this.bevel.getBBox().w - delta, v);
+        den.place(w + this.bevel.getBBox().w + dbox.L * dbox.rscale - delta, v);
     }
 
 }

--- a/mathjax3-ts/output/svg/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mfrac.ts
@@ -78,7 +78,8 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>
         const a = tex.axis_height;
         const d = .1; // line's extra left- and right-padding
         const pad = (this.node.getProperty('withDelims') ? 0 : tex.nulldelimiterspace);
-        const W = Math.max(nbox.w * nbox.rscale, dbox.w * dbox.rscale);
+        const W = Math.max((nbox.L + nbox.w + nbox.R) * nbox.rscale,
+                           (dbox.L + dbox.w + dbox.R) * dbox.rscale);
         const nx = this.getAlignX(W, nbox, numalign as string) + d + pad;
         const dx = this.getAlignX(W, dbox, denomalign as string) + d + pad;
         const {T, u, v} = this.getTUV(display, t);
@@ -108,7 +109,8 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>
 
         const tex = this.font.params;
         const pad = (this.node.getProperty('withDelims') ? 0 : tex.nulldelimiterspace);
-        const W = Math.max(nbox.w * nbox.rscale, dbox.w * dbox.rscale);
+        const W = Math.max((nbox.L + nbox.w + nbox.R) * nbox.rscale,
+                           (dbox.L + dbox.w + dbox.R) * dbox.rscale);
         const nx = this.getAlignX(W, nbox, numalign as string) + pad;
         const dx = this.getAlignX(W, dbox, denomalign as string) + pad;
         const {u, v} = this.getUVQ(display);

--- a/mathjax3-ts/output/svg/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mpadded.ts
@@ -42,13 +42,13 @@ export class SVGmpadded<N, T, D> extends CommonMpaddedMixin<SVGConstructor<N, T,
      */
     public toSVG(parent: N) {
         let svg = this.standardSVGnode(parent);
-        const [H, D, W, dh, dd, dw, x, y] = this.getDimens();
+        const [H, D, W, dh, dd, dw, x, y, dx] = this.getDimens();
         //
         // If there is a horizontal or vertical shift,
         //   use relative positioning to move the contents
         //
-        if (x || y) {
-            const translate = 'translate(' + this.fixed(x) + ' ' + this.fixed(y) + ')';
+        if (x + dx || y) {
+            const translate = 'translate(' + this.fixed(x + dx) + ' ' + this.fixed(y) + ')';
             svg = this.adaptor.append(svg, this.svg('g', {transform: translate}));
         }
         this.addChildren(svg);

--- a/mathjax3-ts/output/svg/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mpadded.ts
@@ -43,13 +43,15 @@ export class SVGmpadded<N, T, D> extends CommonMpaddedMixin<SVGConstructor<N, T,
     public toSVG(parent: N) {
         let svg = this.standardSVGnode(parent);
         const [H, D, W, dh, dd, dw, x, y, dx] = this.getDimens();
+        const align = (this.node.attributes.get('data-align') as string) || 'left';
+        const X = x + dx - (dw < 0 && align !== 'left' ? align === 'center' ? dw / 2 : dw : 0);
         //
         // If there is a horizontal or vertical shift,
         //   use relative positioning to move the contents
         //
-        if (x + dx || y) {
-            const translate = 'translate(' + this.fixed(x + dx) + ' ' + this.fixed(y) + ')';
-            svg = this.adaptor.append(svg, this.svg('g', {transform: translate}));
+        if (X || y) {
+            svg = this.adaptor.append(svg, this.svg('g'));
+            this.place(X, y, svg);
         }
         this.addChildren(svg);
     }

--- a/mathjax3-ts/output/svg/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtable.ts
@@ -161,7 +161,9 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
         let x = this.fLine;
         for (let i = 0; i < lines.length; i++) {
             x += cSpace[i] + cWidth[i] + cSpace[i+1];
-            this.adaptor.append(svg, this.makeVLine(x, lines[i], cLines[i]));
+            if (lines[i] !== 'none') {
+                this.adaptor.append(svg, this.makeVLine(x, lines[i], cLines[i]));
+            }
             x += cLines[i];
         }
     }
@@ -184,7 +186,9 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
         for (let i = 0; i < lines.length; i++) {
             const [rH, rD] = this.getRowHD(equal, HD, H[i], D[i]);
             y -= rSpace[i] + rH + rD + rSpace[i+1]
-            this.adaptor.append(svg, this.makeHLine(y, lines[i], rLines[i]));
+            if (lines[i] !== 'none') {
+                this.adaptor.append(svg, this.makeHLine(y, lines[i], rLines[i]));
+            }
             y -= rLines[i];
         }
 

--- a/mathjax3-ts/output/svg/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtable.ts
@@ -365,19 +365,18 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
         const scale = `scale(${this.jax.fixed((this.font.params.x_height * 1000) / this.metrics.ex, 2)})`;
         const transform = `translate(0, ${this.fixed(h)}) matrix(1 0 0 -1 0 0) ${scale}`;
         let table = this.svg('svg', {
-            'data-table': true, transform: transform,
+            'data-table': true,
             preserveAspectRatio: (align === 'left' ? 'xMinYMid' : align === 'right' ? 'xMaxYMid' : 'xMidYMid'),
             viewBox: [this.fixed(-L), this.fixed(-h), this.fixed(W), this.fixed(h + d)].join(' ')
         }, [
             this.svg('g', {transform: 'matrix(1 0 0 -1 0 0)' + translate}, adaptor.childNodes(svg))
         ]);
         labels = this.svg('svg', {
-            'data-labels': true, transform: transform,
+            'data-labels': true,
             preserveAspectRatio: (side === 'left' ? 'xMinYMid' : 'xMaxYMid'),
             viewBox: [0, this.fixed(-h), this.fixed(LW), this.fixed(h + d)].join(' ')
         }, [labels]);
-        adaptor.append(svg, table)
-        adaptor.append(svg, labels);
+        adaptor.append(svg, this.svg('g', {transform: transform}, [table, labels]));
         this.place(-L, 0, svg);  // remove spacing for L, which is added by the parent during appending
     }
 

--- a/mathjax3-ts/output/svg/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtable.ts
@@ -35,6 +35,8 @@ import {BBox} from '../BBox.js';
 
 const WFUZZ = .25;  // a little padding for min-width
 
+const CLASSPREFIX = 'mjx-';
+
 /*****************************************************************/
 /**
  * The SVGmtable wrapper for the MmlMtable object
@@ -127,7 +129,7 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
      * @param {number} HD       The height of equal-height rows
      * @param {number} H        The natural height of the row
      * @param {number} D        The natural depth of the row
-     * @return {number[]}       The (possibly scaled) height and depth to use
+     * @returns {number[]}      The (possibly scaled) height and depth to use
      */
     protected getRowHD(equal: boolean, HD: number, H: number, D: number) {
         return (equal ? [(HD + H - D) / 2, (HD - H + D) / 2] : [H, D]);
@@ -208,10 +210,12 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
     }
 
     /**
-     * @return {number}   The x-adjustement needed to handle the true size of percentage-width tables
+     * @returns {number}   The x-adjustement needed to handle the true size of percentage-width tables
      */
     protected handlePWidth(svg: N) {
-        if (!this.pWidth) return 0;
+        if (!this.pWidth) {
+            return 0;
+        }
         const {w, L, R} = this.getBBox();
         const W = L + this.pWidth + R;
         const [align, shift] = this.getAlignShift();
@@ -229,16 +233,24 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
     /******************************************************************/
 
     /**
+     * @param {string} style   The line style whose class is to be obtained
+     * @returns {string}       The class name for the style
+     */
+    protected lineClass(style: string) {
+        return CLASSPREFIX + style;
+    }
+
+    /**
      * @param {number} w       The width of the frame
      * @param {number} h       The height of the frame
      * @param {number} d       The depth of the frame
      * @param {string} style   The border style for the frame
-     * @return {N}             The SVG element for the frame
+     * @returns {N}            The SVG element for the frame
      */
     protected makeFrame(w: number, h: number, d: number, style: string) {
         const t = this.fLine;
         return this.svg('rect', this.setLineThickness(t, style, {
-            'data-frame': true, 'class': 'mjx-' + style,
+            'data-frame': true, 'class': this.lineClass(style),
             width: this.fixed(w - t), height: this.fixed(h + d - t),
             x: this.fixed(t / 2), y: this.fixed(t / 2 - d)
         }));
@@ -248,14 +260,14 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
      * @param {number} x       The x location of the line
      * @param {string} style   The border style for the line
      * @param {number} t       The line thickness
-     * @return {N}             The SVG element for the line
+     * @returns {N}            The SVG element for the line
      */
     protected makeVLine(x: number, style: string, t: number) {
         const {h, d} = this.getBBox();
         const dt = (style === 'dotted' ? t / 2 : 0);
         const X = this.fixed(x + t / 2);
         return this.svg('line', this.setLineThickness(t, style, {
-            'data-line': 'v', 'class': 'mjx-' + style,
+            'data-line': 'v', 'class': this.lineClass(style),
             x1: X, y1: this.fixed(dt - d), x2: X, y2: this.fixed(h - dt)
         }));
     }
@@ -264,14 +276,14 @@ CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVG
      * @param {number} y       The y location of the line
      * @param {string} style   The border style for the line
      * @param {number} t       The line thickness
-     * @return {N}             The SVG element for the line
+     * @returns {N}            The SVG element for the line
      */
     protected makeHLine(y: number, style: string, t: number) {
         const w = this.getBBox().w;
         const dt = (style === 'dotted' ? t / 2 : 0);
         const Y = this.fixed(y - t / 2);
         return this.svg('line', this.setLineThickness(t, style, {
-            'data-line': 'h', 'class': 'mjx-' + style,
+            'data-line': 'h', 'class': this.lineClass(style),
             x1: this.fixed(dt), y1: Y, x2: this.fixed(w - dt), y2: Y
         }));
     }

--- a/mathjax3-ts/output/svg/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtd.ts
@@ -21,7 +21,8 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {SVGWrapper} from '../Wrapper.js';
+import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
+import {CommonMtd, CommonMtdMixin} from '../../common/Wrappers/mtd.js';
 import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
 
 /*****************************************************************/
@@ -32,7 +33,7 @@ import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmtd<N, T, D> extends SVGWrapper<N, T, D> {
+export class SVGmtd<N, T, D> extends CommonMtdMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
 
     public static kind = MmlMtd.prototype.kind;
 
@@ -50,7 +51,7 @@ export class SVGmtd<N, T, D> extends SVGWrapper<N, T, D> {
         const d = Math.max(bbox.d, .25);
         const calign = this.node.attributes.get('columnalign') as string;
         const ralign = this.node.attributes.get('rowalign') as string;
-        const alignX = this.getAlignX(W, bbox.w, calign);
+        const alignX = this.getAlignX(W, bbox, calign);
         const alignY = this.getAlignY(H, D, h, d, ralign);
         this.place(x + alignX, y + alignY);
         return [alignX, alignY];
@@ -72,4 +73,5 @@ export class SVGmtd<N, T, D> extends SVGWrapper<N, T, D> {
             adaptor.setAttribute(child, 'height', this.fixed(H));
         }
     }
+
 }

--- a/mathjax3-ts/output/svg/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtr.ts
@@ -55,6 +55,8 @@ export class SVGmtr<N, T, D> extends CommonMtrMixin<SVGmtd<N, T, D>, SVGConstruc
 
     public static kind = MmlMtr.prototype.kind;
 
+    public parent: SVGmtable<N, T, D>;
+
     public H: number;       // height of row
     public D: number;       // depth of row
     public tSpace: number;  // space above row

--- a/mathjax3-ts/output/svg/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtr.ts
@@ -122,7 +122,7 @@ export class SVGmtr<N, T, D> extends CommonMtrMixin<SVGmtd<N, T, D>, SVGConstruc
             const [TS, BS] = [this.tSpace, this.bSpace];
             const [H, D] = [this.H, this.D];
             adaptor.setAttribute(child, 'y', this.fixed(-(D + BS + BL)));
-            adaptor.setAttribute(child, 'width', this.fixed(this.parent.getBBox().w));
+            adaptor.setAttribute(child, 'width', this.fixed(this.parent.getWidth()));
             adaptor.setAttribute(child, 'height', this.fixed(TL + TS + H + D + BS + BL));
         }
     }

--- a/mathjax3-ts/util/lengths.ts
+++ b/mathjax3-ts/util/lengths.ts
@@ -82,6 +82,7 @@ export const MATHSPACE: {[name: string]: number} = {
  * @param {string|number} length  A dimension (giving number and units) to be converted to ems
  * @param {number} size           The default size of the dimension (for percentage values)
  * @param {number} scale          The current scaling factor (to handle absolute units)
+ * @param {number} ex             The size of an ex in pixels
  * @return {number}               The dimension converted to ems
  */
 export function length2em(length: string | number, size: number = 0, scale: number = 1, em: number = 16) {

--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -67,7 +67,7 @@ export function unicodeChars(text: string) {
  * @return {boolean}   True if the string ends with a percent sign
  */
 export function isPercent(x: string) {
-    return x.match(/%\s*$/);
+    return !!x.match(/%\s*$/);
 }
 
 /**

--- a/samples/tables/lib/dual-tables.css
+++ b/samples/tables/lib/dual-tables.css
@@ -1,0 +1,40 @@
+mjx-samples {
+    position: relative;
+    display: block;
+    margin-bottom: 1em;
+}
+mjx-description {
+    display: block;
+    position: absolute;
+    right: 0; top: 0; bottom: 0;
+    width: 24%;
+    border: 1px solid black;
+    padding: .5em;
+}
+mjx-tables {
+    display: block;
+    width: 72%;
+    border: 1px solid black;
+    font-size: 150%;
+}
+mjx-tempalte {
+    white-space: pre;
+    padding: 5em;
+    border: 2px solid black;
+}
+#navigation {
+    position: fixed;
+    top: 1em;
+    right: 1em;
+    background-color: white;
+    padding: .5em;
+    border: 1px solid black;
+}
+#navigation a {
+    text-decoration: none;
+    font-family: 'Times New Roman';
+}
+#navigation a[disabled] {
+    pointer-events: none;
+    color: #CCC;
+}

--- a/samples/tables/lib/dual-tables.js
+++ b/samples/tables/lib/dual-tables.js
@@ -34,7 +34,7 @@ const samples = [
 const div = document.createElement('div');
 const template = document.getElementsByTagName('mjx-template')[0];
 
-function  CreateMathML() {
+function CreateMathML() {
     const mathml = template.innerHTML;
     template.innerHTML = mathml.replace(/\&/g, '&amp;')
                                .replace(/</g, '&lt;')
@@ -47,14 +47,14 @@ function  CreateMathML() {
 function Substitute(mml, data, descr) {
   if (data.length === 0) {
     addMathML(mml, descr);
-  } else {
-    const n = data.length - 1;
-    const [name, values] = data[n];
-    const rest = data.slice(0, n);
-    const re = new RegExp('\\{'+name+'\\}', 'g');
-    for (const value of values) {
-      Substitute(mml.replace(re, value), rest, name + ': <b>' + value + '</b><br/>' + descr);
-    }
+    return;
+  }
+  const n = data.length - 1;
+  const [name, values] = data[n];
+  const rest = data.slice(0, n);
+  const re = new RegExp('\\{'+name+'\\}', 'g');
+  for (const value of values) {
+    Substitute(mml.replace(re, value), rest, name + ': <b>' + value + '</b><br/>' + descr);
   }
 }
 
@@ -92,6 +92,7 @@ docs.CHTML
   .getMetrics()
   .typeset()
   .updateDocument();
+
 docs.SVG
   .findMath({elements: ['mjx-svg-table']})
   .compile()

--- a/samples/tables/lib/dual-tables.js
+++ b/samples/tables/lib/dual-tables.js
@@ -1,0 +1,100 @@
+import {MathML} from "../../../mathjax3/input/mathml.js";
+import {CHTML} from "../../../mathjax3/output/chtml.js";
+import {SVG} from "../../../mathjax3/output/svg.js";
+import {HTMLMathItem} from "../../../mathjax3/handlers/html/HTMLMathItem.js";
+import {HTMLDocument} from "../../../mathjax3/handlers/html/HTMLDocument.js";
+import {handleRetriesFor} from "../../../mathjax3/util/Retries.js";
+import {browserAdaptor} from "../../../mathjax3/adaptors/browserAdaptor.js";
+
+let mml = new MathML({forceReparse: true});
+let chtml = new CHTML({fontURL: '../../mathjax2/css/'});
+let svg = new SVG();
+
+let docs = {
+  CHTML: new HTMLDocument(document, browserAdaptor(), {InputJax: mml, OutputJax: chtml}),
+  SVG:   new HTMLDocument(document, browserAdaptor(), {InputJax: mml, OutputJax: svg})
+};
+
+const samples = [
+  '<mjx-samples>',
+  '<mjx-description>',
+  '',
+  '</mjx-description>',
+  '<mjx-tables>',
+  '<mjx-chtml-table>',
+  '',
+  '</mjx-chtml-table>',
+  '<mjx-svg-table>',
+  '',
+  '</mjx-svg-table>',
+  '</mjx-tables>',
+  '</mjx-samples>'
+];
+
+const div = document.createElement('div');
+const template = document.getElementsByTagName('mjx-template')[0];
+
+function  CreateMathML() {
+    const mathml = template.innerHTML;
+    template.innerHTML = mathml.replace(/\&/g, '&amp;')
+                               .replace(/</g, '&lt;')
+                               .replace(/>/g, '&gt;')
+                               .replace(/\n/g, '<br/>')
+                               .replace(/\s/g, '\u00A0');
+    Substitute(mathml, window.variables, '');
+}
+
+function Substitute(mml, data, descr) {
+  if (data.length === 0) {
+    addMathML(mml, descr);
+  } else {
+    const n = data.length - 1;
+    const [name, values] = data[n];
+    const rest = data.slice(0, n);
+    const re = new RegExp('\\{'+name+'\\}', 'g');
+    for (const value of values) {
+      Substitute(mml.replace(re, value), rest, name + ': <b>' + value + '</b><br/>' + descr);
+    }
+  }
+}
+
+function addMathML(mml, descr) {
+  samples[2] = descr;
+  samples[6] = samples[9] = mml;
+  div.innerHTML = samples.join('\n');
+  template.parentNode.insertBefore(div.firstChild, template);
+}
+
+CreateMathML();
+
+function linkTables(n, m, arrow) {
+    let N = String(n);
+    if (N.length == 1) {
+        N = '0' + N;
+    }
+    return '<a href="tables-' + N + '.html"' + (n === m ? ' disabled="true"' : '') + '>&#x' + arrow + ';</a>';
+}
+
+const testNo = parseInt(this.location.pathname.match(/-(\d+)\.html$/)[1]);
+const maxTest = 60;
+
+const nav = document.body.appendChild(document.createElement('div'));
+nav.id = "navigation";
+nav.innerHTML = [
+    linkTables(testNo - 1, 0, '25C4'),
+    linkTables(testNo + 1, maxTest + 1, '25BA')
+].join(' ');
+
+
+docs.CHTML
+  .findMath({elements: ['mjx-chtml-table']})
+  .compile()
+  .getMetrics()
+  .typeset()
+  .updateDocument();
+docs.SVG
+  .findMath({elements: ['mjx-svg-table']})
+  .compile()
+  .getMetrics()
+  .typeset()
+  .updateDocument();

--- a/samples/tables/tables-01.html
+++ b/samples/tables/tables-01.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 01</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 01</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="{width}" mathbackground="yellow">
+      <mtr>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-02.html
+++ b/samples/tables/tables-02.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 02</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 02</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="{width}" mathbackground="yellow" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(1)</mtext></mtd>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-03.html
+++ b/samples/tables/tables-03.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 03</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 03</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="{width}" mathbackground="yellow" equalcolumns="true">
+      <mtr>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-04.html
+++ b/samples/tables/tables-04.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 04</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 04</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="{width}" mathbackground="yellow" side="{side}" equalcolumns="true">
+      <mlabeledtr>
+        <mtd><mtext>(1)</mtext></mtd>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-05.html
+++ b/samples/tables/tables-05.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 05</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 05</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="{width}" mathbackground="yellow" side="{side}"
+                         minlabelspacing="{minlabelspacing}">
+      <mlabeledtr>
+        <mtd><mtext>(1)</mtext></mtd>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['minlabelspacing', ['1em', '0']],
+  ['width', ['100%', '25em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-06.html
+++ b/samples/tables/tables-06.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 06</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+  margin-left: 2em;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 06</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}" indentshift="{indentshift}">
+    <mtable mathbackground="yellow">
+      <mtr>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['indentshift', ['0em', '1em', '3em', '-1em', '-3em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-07.html
+++ b/samples/tables/tables-07.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 07</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+  margin-left: 2em;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 07</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}" indentshift="{indentshift}">
+    <mtable width="10em" mathbackground="yellow" side="{side}" minlabelspacing="0">
+      <mlabeledtr>
+        <mtd><mspace width="2em" height=".75em" depth=".25em" background="blue"/></mtd>
+        <mtd mathbackground="green"><mi>a</mi></mtd>
+        <mtd mathbackground="red"><mi>bbb</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['indentshift', ['0em', '1em', '3em', '-1em', '-3em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-08.html
+++ b/samples/tables/tables-08.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 08</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 08</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-09.html
+++ b/samples/tables/tables-09.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 09</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 09</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-10.html
+++ b/samples/tables/tables-10.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 10</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 10</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-11.html
+++ b/samples/tables/tables-11.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 11</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 11</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-12.html
+++ b/samples/tables/tables-12.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 12</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 12</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-13.html
+++ b/samples/tables/tables-13.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 13</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 13</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-14.html
+++ b/samples/tables/tables-14.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 14</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 14</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-15.html
+++ b/samples/tables/tables-15.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 15</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 15</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="15em fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-16.html
+++ b/samples/tables/tables-16.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 16</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 16</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-17.html
+++ b/samples/tables/tables-17.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 17</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 17</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-18.html
+++ b/samples/tables/tables-18.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 18</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 18</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-19.html
+++ b/samples/tables/tables-19.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 19</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 19</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-20.html
+++ b/samples/tables/tables-20.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 20</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 20</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-21.html
+++ b/samples/tables/tables-21.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 21</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 21</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-22.html
+++ b/samples/tables/tables-22.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 22</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 22</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-23.html
+++ b/samples/tables/tables-23.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 23</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 23</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow" columnspacing="0" columnwidth="75% fit">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-24.html
+++ b/samples/tables/tables-24.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 24</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 24</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeldtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-25.html
+++ b/samples/tables/tables-25.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 25</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 25</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-26.html
+++ b/samples/tables/tables-26.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 26</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 26</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-27.html
+++ b/samples/tables/tables-27.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 27</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 27</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-28.html
+++ b/samples/tables/tables-28.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 28</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 28</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-29.html
+++ b/samples/tables/tables-29.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 29</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 29</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-30.html
+++ b/samples/tables/tables-30.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 30</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 30</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-31.html
+++ b/samples/tables/tables-31.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 31</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 31</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-32.html
+++ b/samples/tables/tables-32.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 32</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 32</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-33.html
+++ b/samples/tables/tables-33.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 33</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 33</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeldtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-34.html
+++ b/samples/tables/tables-34.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 34</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 34</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeldtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-35.html
+++ b/samples/tables/tables-35.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 35</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 35</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-36.html
+++ b/samples/tables/tables-36.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 36</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 36</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-37.html
+++ b/samples/tables/tables-37.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 37</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 37</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="5em" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-38.html
+++ b/samples/tables/tables-38.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 38</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 38</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="20em" mathbackground="yellow"
+            columnspacing="0" columnwidth="15em fit" side="{side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink">
+            <mtr>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-39.html
+++ b/samples/tables/tables-39.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 39</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 39</h1>
+
+<mjx-template>
+  <math display="block" indentalign="{indentalign}">
+    <mtable width="80%" mathbackground="yellow"
+            columnspacing="0" columnwidth="75% fit" side="{o-side}">
+      <mlabeledtr>
+        <mtd><mtext>(2)</mtext></mtd>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mi>xyz</mi></mtd>
+      </mlabeledtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['indentalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['o-side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-40.html
+++ b/samples/tables/tables-40.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 40</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 40</h1>
+
+<mjx-template>
+  <math display="block">
+    <mtable width="{width}" mathbackground="yellow"
+            columnspacing="0" equalcolumns="true">
+      <mtr>
+        <mtd columnalign="{columnalign}">
+          <mtable width="50%" mathbackground="pink" side="{side}" minlabelspacing="0">
+            <mlabeledtr>
+              <mtd><mtext>(1)</mtext></mtd>
+              <mtd mathbackground="green"><mi>a</mi></mtd>
+              <mtd mathbackground="red"><mi>bbb</mi></mtd>
+            </mlabeledtr>
+          </mtable>
+        </mtd>
+        <mtd mathbackground="orange"><mpadded width="10em" data-align="center"><mi>xyz</mi></mpadded></mtd>
+      </mtr>
+    </mtable>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['columnalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['width', ['auto', '20em', '80%']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-41.html
+++ b/samples/tables/tables-41.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 41</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 41</h1>
+
+<mjx-template>
+  <math display="block">
+    <mpadded width="20em" mathbackground="yellow" data-align="{data-align}">
+      <mtable width="{width}">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+    </mpadded>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['data-align', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-42.html
+++ b/samples/tables/tables-42.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 42</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 42</h1>
+
+<mjx-template>
+  <math display="block">
+    <mpadded width="20em" mathbackground="yellow" data-align="{data-align}">
+      <mtable width="{width}" side="{side}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+    </mpadded>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['data-align', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-43.html
+++ b/samples/tables/tables-43.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 43</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 43</h1>
+
+<mjx-template>
+  <math display="block">
+    <mpadded width="20em" mathbackground="yellow" data-align="{data-align}">
+      <mtable width="{width}" equalcolumns="true">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+    </mpadded>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['data-align', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-44.html
+++ b/samples/tables/tables-44.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 44</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 44</h1>
+
+<mjx-template>
+  <math display="block">
+    <mpadded width="20em" mathbackground="yellow" data-align="{data-align}">
+      <mtable width="{width}" side="{side}" equalcolumns="true">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+    </mpadded>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['data-align', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '10em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-45.html
+++ b/samples/tables/tables-45.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 45</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 45</h1>
+
+<mjx-template>
+  <math display="block">
+    <mpadded width="20em" mathbackground="yellow" data-align="{data-align}">
+      <mtable width="{width}" side="{side}" minlabelspacing="{minlabelspacing}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+    </mpadded>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['data-align', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['minlabelspacing', ['1em', '0']],
+  ['width', ['100%', '25em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-46.html
+++ b/samples/tables/tables-46.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 46</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 46</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}">
+      <mtable width="{width}">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-47.html
+++ b/samples/tables/tables-47.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 47</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 47</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}">
+      <mtable width="{width}" side="{side}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-48.html
+++ b/samples/tables/tables-48.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 48</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 48</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}">
+      <mtable width="{width}" equalcolumns="true">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-49.html
+++ b/samples/tables/tables-49.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 49</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 49</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}">
+      <mtable width="{width}" side="{side}" equalcolumns="true">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-50.html
+++ b/samples/tables/tables-50.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 50</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 50</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}">
+      <mtable width="{width}" side="{side}" minlabelspacing="{minlabelspacing}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['minlabelspacing', ['1em', '0']],
+  ['width', ['100%', '25em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-51.html
+++ b/samples/tables/tables-51.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 51</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 51</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" linethickness="0">
+      <mtable width="{width}">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-52.html
+++ b/samples/tables/tables-52.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 52</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 52</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" linethickness="0">
+      <mtable width="{width}" side="{side}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-53.html
+++ b/samples/tables/tables-53.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 53</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 53</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" linethickness="0">
+      <mtable width="{width}" equalcolumns="true">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-54.html
+++ b/samples/tables/tables-54.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 54</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 54</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" linethickness="0">
+      <mtable width="{width}" side="{side}" equalcolumns="true">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-55.html
+++ b/samples/tables/tables-55.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 55</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 55</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" linethickness="0">
+      <mtable width="{width}" side="{side}" minlabelspacing="{minlabelspacing}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['minlabelspacing', ['1em', '0']],
+  ['width', ['100%', '25em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-56.html
+++ b/samples/tables/tables-56.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 56</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 56</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" bevelled="true">
+      <mtable width="{width}">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-57.html
+++ b/samples/tables/tables-57.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 57</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 57</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" bevelled="true">
+      <mtable width="{width}" side="{side}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-58.html
+++ b/samples/tables/tables-58.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 58</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 58</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" bevelled="true">
+      <mtable width="{width}" equalcolumns="true">
+        <mtr>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-59.html
+++ b/samples/tables/tables-59.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 59</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 59</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" bevelled="true">
+      <mtable width="{width}" side="{side}" equalcolumns="true">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['width', ['auto', '50%', '5em', '15em']],
+  ['side', ['left', 'right']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+

--- a/samples/tables/tables-60.html
+++ b/samples/tables/tables-60.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MathJax v3 Tables Sample 60</title>
+<link rel="stylesheet" type="text/css" href="lib/dual-tables.css">
+<script src="../../lib/traceur.min.js"></script>
+<script src="../../lib/system.js"></script>
+<style>
+mjx-tables {
+  width: 50%;
+}
+svg {
+  overflow: visible;
+}
+</style>
+</head>
+<body>
+
+<h1>MathJax v3 Tables Sample 60</h1>
+
+<mjx-template>
+  <math display="block">
+    <mfrac mathbackground="yellow" numalign="{numalign}" bevelled="true">
+      <mtable width="{width}" side="{side}" minlabelspacing="{minlabelspacing}">
+        <mlabeledtr>
+          <mtd><mtext>(1)</mtext></mtd>
+          <mtd mathbackground="green"><mi>a</mi></mtd>
+          <mtd mathbackground="red"><mi>bbb</mi></mtd>
+        </mlabeledtr>
+      </mtable>
+      <mi>xxxxxxxxxxyyyyyyyyyy</mi>
+    </mfrac>
+  </math>
+</mjx-template>
+
+<script>
+var variables = [
+  ['numalign', ['left', 'center', 'right']],
+  ['side', ['left', 'right']],
+  ['minlabelspacing', ['1em', '0']],
+  ['width', ['100%', '25em']]
+];
+</script>
+
+<script>
+System.import('./lib/dual-tables.js').catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>
+
+


### PR DESCRIPTION
This PR adds better support for nested tables, and in particular, nested tables with labels and with percentage widths.  The percentage-width tables are taken to be a percentage of the containing table cell (the line-wrap context, according to the MathML spec).  Nesting is also considered for fractions and `mpadded` elements.  An extra `data-align` attribute can be used to control the alignment in `mpadded` elements; the `columnalign` attribute controls alignment in tables nested inside tables, and `numalign`/`denomalign` control it in tables nested in fractions.

This PR also adds 60 test files (so more than half the files are just those tests).

Among other things, this resolves #154, #163, #164, #183, #184, and #185.