### PR TITLE
Fix output for \hbar and other variant forms.  #178.

### DIFF
--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -359,7 +359,7 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
             if (values.family) {
                     variant = this.explicitVariant(values.family, values.weight, values.style);
             } else {
-                if (this.node.getProperty('variantForm')) variant = '-TeX-variant';
+                if (this.node.getProperty('variantForm')) variant = '-tex-variant';
                 variant = (CommonWrapper.BOLDVARIANTS[values.weight] || {})[variant] || variant;
                 variant = (CommonWrapper.ITALICVARIANTS[values.style] || {})[variant] || variant;
             }


### PR DESCRIPTION
The problem was that when `variantForm` was set, the wrong variant name was being used.

Resolves issue #178.