### PR TITLE
Add displayAlign/displayIndent configuration as in v2.  #186

### DIFF
--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -65,6 +65,8 @@ AbstractOutputJax<N, T, D> {
         mathmlSpacing: false,          // true for MathML spacing rules, false for TeX rules
         skipAttributes: {},            // RFDa and other attributes NOT to copy to the output
         exFactor: .5,                  // default size of ex in em units
+        displayAlign: 'center',        // default for indentalign when set to 'auto'
+        displayIndent: '0',            // default for indentshift when set to 'auto'
         wrapperFactory: null,          // The wrapper factory to use
         font: null,                    // The FontData object to use
         cssStyles: null                // The CssStyles object to use

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -559,7 +559,7 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
         if (indentshift === 'auto') {
             indentshift = this.jax.options.displayIndent;
             if (indentalign === 'right' && !indentshift.match(/^\s*0[a-z]*\s*$/)) {
-                indentshift = ('-' + indentshift.replace(/^\s+/, '')).replace(/^--/, '');
+                indentshift = ('-' + indentshift.trim()).replace(/^--/, '');
             }
         }
         const shift = this.length2em(indentshift, this.metrics.containerWidth);

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -551,13 +551,16 @@ AbstractWrapper<MmlNode, CommonWrapper<J, W, C>> {
             indentalign = indentalignfirst;
         }
         if (indentalign === 'auto') {
-            indentalign = 'center';
+            indentalign = this.jax.options.displayAlign;
         }
         if (indentshiftfirst !== 'indentshift') {
             indentshift = indentshiftfirst;
         }
         if (indentshift === 'auto') {
-            indentshift = '0';
+            indentshift = this.jax.options.displayIndent;
+            if (indentalign === 'right' && !indentshift.match(/^\s*0[a-z]*\s*$/)) {
+                indentshift = ('-' + indentshift.replace(/^\s+/, '')).replace(/^--/, '');
+            }
         }
         const shift = this.length2em(indentshift, this.metrics.containerWidth);
         return [indentalign, shift] as [string, number];


### PR DESCRIPTION
Add `displayAlign` and `displayIndent` parameters for CHTML and SVG output, as in version 2.

Resolves issue #186.