### PR TITLE
Make sure ALL quotes are escaped

### DIFF
--- a/mathjax3-ts/adaptors/lite/Parser.ts
+++ b/mathjax3-ts/adaptors/lite/Parser.ts
@@ -359,7 +359,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
         if (typeof text !== 'string') {
             text = String(text);
         }
-        return text.replace(/"/, '&quot;');
+        return text.replace(/"/g, '&quot;');
     }
 
     /**


### PR DESCRIPTION
This is a trivial fix to makes sure that all quotes are escapes in serialized HTML produced from the lite parser.