### PR TITLE
Add support for svg font caching (global, local, or none)

### DIFF
--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -47,6 +47,11 @@ export class CHTML<N, T, D> extends CommonOutputJax<N, T, D, CHTMLWrapper<N, T, 
     public static OPTIONS: OptionList = {...CommonOutputJax.OPTIONS};
 
     /**
+     * The ID for the stylesheet element for the styles for the SVG output
+     */
+    public static STYLESHEETID = 'MJX-CHTML-styles';
+
+    /**
      *  Used to store the CHTMLWrapper factory,
      *  the FontData object, and the CssStyles object.
      */
@@ -73,7 +78,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<N, T, D, CHTMLWrapper<N, T, 
      */
     public styleSheet(html: MathDocument<N, T, D>) {
         const sheet = super.styleSheet(html);
-        this.adaptor.setAttribute(sheet, 'id', 'CHTML-styles');
+        this.adaptor.setAttribute(sheet, 'id', CHTML.STYLSHEETID);
         return sheet;
     }
 

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -54,10 +54,23 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     };
 
     /**
-     *  Used to store the CHTMLWrapper factory,
-     *  the FontData object, and the CssStyles object.
+     * The ID for the SVG element that stores the cached font paths
+     */
+    public static FONTCACHEID = 'MJX-SVG-global-cache';
+
+    /**
+     * The ID for the stylesheet element for the styles for the SVG output
+     */
+    public static STYLESHEETID = 'MJX-SVG-styles';
+
+    /**
+     * Stores the CHTMLWrapper factory
      */
     public factory: SVGWrapperFactory<N, T, D>;
+
+    /**
+     * Stores the information about the cached character glyphs
+     */
     public fontCache: FontCache<N, T, D>;
 
     /**
@@ -119,7 +132,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      */
     public styleSheet(html: MathDocument<N, T, D>) {
         const sheet = super.styleSheet(html);
-        this.adaptor.setAttribute(sheet, 'id', 'SVG-styles');
+        this.adaptor.setAttribute(sheet, 'id', SVG.STYLESHEETID);
         return sheet;
     }
 
@@ -135,16 +148,22 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      */
     public documentPageElements(html: MathDocument<N, T, D>) {
         if (this.options.fontCache === 'global' && !this.findCache(html)) {
-            return this.svg('svg', {id: 'SVG-global-cache', style: {display: 'none'}}, [this.fontCache.getCache()]);
+            return this.svg('svg', {id: SVG.FONTCACHEID, style: {display: 'none'}}, [this.fontCache.getCache()]);
         }
         return null as N;
     }
 
+    /**
+     * Checks if there is already a font-cache element in the page
+     *
+     * @param {MathDocument} html   The document to search
+     * @return {boolean}            True if a font cache already exists in the page
+     */
     protected findCache(html: MathDocument<N, T, D>) {
         const adaptor = this.adaptor;
         const svgs = adaptor.tags(adaptor.body(html.document), 'svg');
         for (let i = svgs.length - 1; i >= 0; i--) {
-            if (this.adaptor.getAttribute(svgs[i], 'id') === 'SVG-global-cache') {
+            if (this.adaptor.getAttribute(svgs[i], 'id') === SVG.FONTCACHEID) {
                 return true;
             }
         }
@@ -221,7 +240,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     }
 
     /**
-     * Typeset the math and add minwith (from mtables), or set the alignment and indentation
+     * Typeset the math and add minwidth (from mtables), or set the alignment and indentation
      * of the finalized expression.
      *
      * @param {SVGWrapper} wrapper   The wrapped math to typeset

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -250,7 +250,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     protected typesetSVG(wrapper: SVGWrapper<N, T, D>, svg: N, g: N) {
         const adaptor = this.adaptor;
         //
-        //  Typeset the math and add minWith (from mtables), or set the alignment and indentation
+        //  Typeset the math and add minWidth (from mtables), or set the alignment and indentation
         //    of the finalized expression
         //
         this.minwidth = this.shift = 0;

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -30,8 +30,10 @@ import {SVGWrapper} from './svg/Wrapper.js';
 import {SVGWrapperFactory} from './svg/WrapperFactory.js';
 import {SVGFontData} from './svg/FontData.js';
 import {TeXFont} from './svg/fonts/tex.js';
+import {FontCache} from './svg/FontCache.js';
 
 export const SVGNS = "http://www.w3.org/2000/svg";
+export const XLINKNS = 'http://www.w3.org/1999/xlink';
 
 /*****************************************************************/
 /**
@@ -45,18 +47,24 @@ export class SVG<N, T, D> extends
 CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFontData, typeof SVGFontData> {
 
     public static NAME: string = 'SVG';
-    public static OPTIONS: OptionList = {...CommonOutputJax.OPTIONS};
+    public static OPTIONS: OptionList = {
+        ...CommonOutputJax.OPTIONS,
+        fontCache: 'local',             // or 'global' or 'none'
+        localID: null,                  // ID to use for local font cache (for single equation processing)
+    };
 
     /**
      *  Used to store the CHTMLWrapper factory,
      *  the FontData object, and the CssStyles object.
      */
     public factory: SVGWrapperFactory<N, T, D>;
+    public fontCache: FontCache<N, T, D>;
 
     /**
      * Minimum width for tables with labels,
      * and shift and align for main equation
      */
+    public minwidth: number = 0;
     public shift: number = 0;
 
     /**
@@ -70,6 +78,23 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      */
     constructor(options: OptionList = null) {
         super(options, SVGWrapperFactory, TeXFont);
+        this.fontCache = new FontCache(this);
+    }
+
+    /**
+     * @override
+     */
+    public initialize() {
+        if (this.options.fontCache === 'global') {
+            this.fontCache.clearCache();
+        }
+    }
+
+    /**
+     * Clear the font cache (use for resetting the global font cache)
+     */
+    public clearFontCache() {
+        this.fontCache.clearCache();
     }
 
     /**
@@ -106,6 +131,27 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     }
 
     /**
+     * @override
+     */
+    public documentPageElements(html: MathDocument<N, T, D>) {
+        if (this.options.fontCache === 'global' && !this.findCache(html)) {
+            return this.svg('svg', {id: 'SVG-global-cache', style: {display: 'none'}}, [this.fontCache.getCache()]);
+        }
+        return null as N;
+    }
+
+    protected findCache(html: MathDocument<N, T, D>) {
+        const adaptor = this.adaptor;
+        const svgs = adaptor.tags(adaptor.body(html.document), 'svg');
+        for (let i = svgs.length - 1; i >= 0; i--) {
+            if (this.adaptor.getAttribute(svgs[i], 'id') === 'SVG-global-cache') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param {MmlNode} math  The MML node whose SVG is to be produced
      * @param {N} parent      The HTML node to contain the SVG
      */
@@ -116,9 +162,23 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         const container = this.container;
         this.container = parent;
         //
-        //  Get the wrapped math element and its size
+        //  Get the wrapped math element and the SVG container
+        //  Then typeset the math into the SVG
         //
         const wrapper = this.factory.wrap(math);
+        const [svg, g] = this.createRoot(wrapper);
+        this.typesetSVG(wrapper, svg, g);
+        //
+        //  Put back the original container
+        //
+        this.container = container;
+    }
+
+    /**
+     * @param {SVGWrapper} wrapper   The wrapped math to process
+     * @return {[N, N]}              The svg and g nodes for the math
+     */
+    protected createRoot(wrapper: SVGWrapper<N, T, D>) {
         const {w, h, d, pwidth} = wrapper.getBBox();
         const W = Math.max(w, .001); // make sure we are at least one unit wide (needed for e.g. \llap)
         //
@@ -132,7 +192,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         //  The svg element with its viewBox, size and alignment
         //
         const adaptor = this.adaptor;
-        const svg = adaptor.append(parent, this.svg('svg', {
+        const svg = adaptor.append(this.container, this.svg('svg', {
             xmlns: SVGNS,
             width: this.ex(W), height: this.ex(h + d),
             style: {'vertical-align': this.ex(-d)},
@@ -141,7 +201,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         if (W === .001) {
             adaptor.setAttribute(svg, 'preserveAspectRatio', 'xMidYMid slice');
             if (w < 0) {
-                adaptor.setStyle(parent, 'margin-right', this.ex(w));
+                adaptor.setStyle(this.container, 'margin-right', this.ex(w));
             }
         }
         if (pwidth) {
@@ -154,22 +214,40 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
             adaptor.setAttribute(g, 'transform', 'matrix(1 0 0 -1 0 0) scale(' +
                                  this.fixed(scale, 6) + ') translate(0, ' + this.fixed(-h * 1000, 1) + ')');
         }
+        if (this.options.fontCache !== 'none') {
+            adaptor.setAttribute(svg, 'xmlns:xlink', XLINKNS);
+        }
+        return [svg, g];
+    }
+
+    /**
+     * Typeset the math and add minwith (from mtables), or set the alignment and indentation
+     * of the finalized expression.
+     *
+     * @param {SVGWrapper} wrapper   The wrapped math to typeset
+     * @param {N} svg                The main svg element for the typeet math
+     * @param {N} g                  The group in which the math is typeset
+     */
+    protected typesetSVG(wrapper: SVGWrapper<N, T, D>, svg: N, g: N) {
+        const adaptor = this.adaptor;
         //
         //  Typeset the math and add minWith (from mtables), or set the alignment and indentation
         //    of the finalized expression
         //
-        this.shift = 0;
+        this.minwidth = this.shift = 0;
+        if (this.options.fontCache === 'local') {
+            this.fontCache.clearCache();
+            this.fontCache.useLocalID(this.options.localID);
+            adaptor.insert(this.fontCache.getCache(), g);
+        }
         wrapper.toSVG(g);
-        if (wrapper.bbox.pwidth) {
-            adaptor.setStyle(svg, 'minWidth', this.ex(wrapper.bbox.w));
+        this.fontCache.clearLocalID();
+        if (this.minwidth) {
+            adaptor.setStyle(svg, 'minWidth', this.ex(this.minwidth));
         } else if (this.shift) {
-            const align = adaptor.getAttribute(parent, 'justify') || 'center';
+            const align = adaptor.getAttribute(this.container, 'justify') || 'center';
             this.setIndent(svg, align, this.shift);
         }
-        //
-        //  Put back the original container
-        //
-        this.container = container;
     }
 
     /**

--- a/mathjax3-ts/output/svg/FontCache.ts
+++ b/mathjax3-ts/output/svg/FontCache.ts
@@ -1,0 +1,66 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the FontCache object for SVG output
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {SVG} from '../svg.js';
+
+export class FontCache<N, T, D> {
+
+    protected jax: SVG<N, T, D>;
+
+    protected cache: Map<string, string> = new Map();
+    protected defs: N = null;
+
+    protected localID: string = '';
+    protected nextID: number = 0;
+
+    constructor(jax: SVG<N, T, D>) {
+        this.jax = jax;
+    }
+
+    public cachePath(variant: string, C: string, path: string) {
+        const id = 'MJX-' + this.localID + (this.jax.font.getVariant(variant).cacheID || '') + '-' + C;
+        if (!this.cache.has(id)) {
+            this.cache.set(id, path);
+            this.jax.adaptor.append(this.defs, this.jax.svg('path', {id: id, d: path}));
+        }
+        return id;
+    }
+
+    public clearLocalID() {
+        this.localID = '';
+    }
+
+    public useLocalID(id: string = null) {
+        this.localID = (id == null ? ++this.nextID : id) + (id === '' ? '' : '-');
+    }
+
+    public clearCache() {
+        this.cache = new Map();
+        this.defs = this.jax.svg('defs');
+    }
+
+    public getCache() {
+        return this.defs;
+    }
+
+}

--- a/mathjax3-ts/output/svg/FontCache.ts
+++ b/mathjax3-ts/output/svg/FontCache.ts
@@ -25,18 +25,46 @@ import {SVG} from '../svg.js';
 
 export class FontCache<N, T, D> {
 
+    /**
+     * The SVG jax that owsn this cache
+     */
     protected jax: SVG<N, T, D>;
 
+    /**
+     * The cache of font character IDs to their paths
+     */
     protected cache: Map<string, string> = new Map();
+
+    /**
+     * The SVG <defs> element for storing the cache
+     */
     protected defs: N = null;
 
+    /**
+     * A string to use to make per-equation cache IDs unique
+     */
     protected localID: string = '';
+
+    /**
+     * A number used to make localID values to use for each equation
+     */
     protected nextID: number = 0;
 
+    /**
+     * @param {SVG} jax  The SVG jax owning this font cache
+     */
     constructor(jax: SVG<N, T, D>) {
         this.jax = jax;
     }
 
+    /**
+     * Cache a character from a particular variant and return the cache ID
+     *
+     * @param {string} variant   The variant name for the character
+     * @param {string} C         The character to be cached
+     * @param {string} path      The SVG path data for the character
+     * @return {string}          The id for the cached <path> element
+     */
     public cachePath(variant: string, C: string, path: string) {
         const id = 'MJX-' + this.localID + (this.jax.font.getVariant(variant).cacheID || '') + '-' + C;
         if (!this.cache.has(id)) {
@@ -46,19 +74,32 @@ export class FontCache<N, T, D> {
         return id;
     }
 
+    /**
+     * Clear the localID value
+     */
     public clearLocalID() {
         this.localID = '';
     }
 
+    /**
+     * Use a localID (for font-specific caching), either with a specific string,
+     * or from the nextID number.
+     */
     public useLocalID(id: string = null) {
         this.localID = (id == null ? ++this.nextID : id) + (id === '' ? '' : '-');
     }
 
+    /**
+     * Clear the cache
+     */
     public clearCache() {
         this.cache = new Map();
         this.defs = this.jax.svg('defs');
     }
 
+    /**
+     * Return the font cache <defs> element
+     */
     public getCache() {
         return this.defs;
     }

--- a/mathjax3-ts/output/svg/FontData.ts
+++ b/mathjax3-ts/output/svg/FontData.ts
@@ -16,8 +16,7 @@
  */
 
 /**
- * @fileoverview  Implements the FontData class for character bbox data
- *                and stretchy delimiters.
+ * @fileoverview  Implements the SVGFontData class for font data in SVG output.
  *
  * @author dpvc@mathjax.org (Davide Cervone)
  */
@@ -45,6 +44,7 @@ export type SVGCharData = CharData<SVGCharOptions>;
  * The extra data needed for a Variant in SVG output
  */
 export interface SVGVariantData extends VariantData<SVGCharOptions> {
+    cacheID: string;
 };
 
 /**
@@ -60,6 +60,7 @@ export interface SVGDelimiterData extends DelimiterData {
  * The SVG FontData class
  */
 export class SVGFontData extends FontData<SVGCharOptions, SVGVariantData, SVGDelimiterData> {
+
     /**
      * @override
      */

--- a/mathjax3-ts/output/svg/fonts/tex.ts
+++ b/mathjax3-ts/output/svg/fonts/tex.ts
@@ -99,5 +99,49 @@ CommonTeXFontMixin<SVGCharOptions, SVGVariantData, SVGDelimiterData, SVGFontData
         '-tex-variant': texVariant
     };
 
+    /**
+     * The cacheIDs to use for the variants in font-caching
+     */
+    protected static variantCacheIds: {[name: string]: string} = {
+        'normal': 'N',
+        'bold': 'B',
+        'italic': 'I',
+        'bold-italic': 'BI',
+        'double-struck': 'D',
+        'fraktur': 'F',
+        'bold-fraktur': 'BF',
+        'script': 'S',
+        'bold-script': 'BS',
+        'sans-serif': 'SS',
+        'bold-sans-serif': 'BSS',
+        'sans-serif-italic': 'SSI',
+        'bold-sans-serif-italic': 'BSSI',
+        'monospace': 'M',
+        '-smallop': 'SO',
+        '-largeop': 'LO',
+        '-size3': 'S3',
+        '-size4': 'S4',
+        '-tex-caligraphic': 'C',
+        '-tex-bold-caligraphic': 'BC',
+        '-tex-mathit': 'MI',
+        '-tex-oldstyle': 'OS',
+        '-tex-bold-oldstyle': 'BOS',
+        '-tex-variant': 'V'
+    };
+
+    /**
+     * @override
+     */
+    constructor() {
+        super();
+        //
+        //  Add the cacheIDs to the variants
+        //
+        const CLASS = this.constructor as typeof TeXFont;
+        for (const variant of Object.keys(CLASS.variantCacheIds)) {
+            this.variant[variant].cacheID = 'TEX-' + CLASS.variantCacheIds[variant];
+        }
+    }
+
 }
 


### PR DESCRIPTION
This PR provides a new option for the SVG output jax that lets you use a global or local font cache (global means global to all expressions on the page, local means a cache that is specific to a single expression), or no cache (all glyphs are given as SVG paths directly).

This mirrors the v2 font-caching options.