### PR TITLE
Add ability to make blocks of options that are open-ended

### DIFF
--- a/mathjax3-ts/util/Options.ts
+++ b/mathjax3-ts/util/Options.ts
@@ -44,14 +44,43 @@ export type OptionList = {[name: string]: any};
  *  E.g., an option of the form
  *
  *    {
- *      name: {APPEND: [1, 2, 3]}
+ *      name: {[APPEND]: [1, 2, 3]}
  *    }
  *
  *  where 'name' is an array in the default options would end up with name having its
  *  original value with 1, 2, and 3 appended.
  */
-export const APPEND = Symbol('Append to option array');
+export const APPEND = '[+]';
 
+/**
+ * A Class to use for options that should not produce warnings if an undefined key is used
+ */
+export class Expandable {};
+
+/**
+ * Produces an instance of Expandable with the given values (to be used in defining options
+ * that can use keys that don't have default values).  E.g., default options of the form:
+ *
+ *  OPTIONS = {
+ *     types: expandable({
+ *       a: 1,
+ *       b: 2
+ *     })
+ *  }
+ *
+ *  would allow user options of
+ *
+ *  {
+ *     types: {
+ *       c: 3
+ *     }
+ *  }
+ *
+ *  without reporting an error.
+ */
+export function expandable(def: OptionList) {
+    return Object.assign(Object.create(Expandable.prototype), def);
+}
 
 /*****************************************************************/
 /**
@@ -111,7 +140,7 @@ export function copy(def: OptionList): OptionList {
  */
 export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
     for (let key of keys(src)) {
-        if (warn && dst[key] === undefined) {
+        if (warn && dst[key] === undefined && !(dst instanceof Expandable)) {
             if (typeof key === 'symbol') {
                 key = key.toString();
             }


### PR DESCRIPTION
Add ability to make blocks of options that are open-ended (expandable).  You need these for things like the `Macros` configuration for TeX input, for example.

Also, make the APPEND variable a string so that it can be included in the user configuration object without having to load MathJax modules to get access to this variable.

