### PR TITLE
Update components

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -212,9 +212,8 @@ function makeFile(file, lines) {
 function processGlobal() {
     console.log('  ' + COMPONENT + '.ts');
     const lines = [
-        '"use strict";',
-        `Object.defineProperty(exports, '__esModule', {value: true});`,
-        `require('${GLOBAL}').combineWithMathJax({_: {`
+        `import {combineWithMathJax} from '${GLOBAL}';`,
+        '',
     ];
     const packages = [];
     PACKAGE = PACKAGE.sort(sortDir);
@@ -222,6 +221,7 @@ function processGlobal() {
         const dir = path.dirname(PACKAGE[0]).split(path.sep)[0];
         packages.push(processPackage(lines, INDENT, dir));
     }
+    lines.push('', `combineWithMathJax({_: {`);
     lines.push(INDENT + packages.join(',\n' + INDENT));
     lines.push('}});');
     fs.writeFileSync(path.join(LIB, COMPONENT + '.js'), lines.join('\n') + '\n');
@@ -236,6 +236,7 @@ function sortDir(a, b) {
     return (A === B ? 0 : A < B ? -1 : 1);
  }
 
+let importCount = 0;
 /**
  * Recursively process packages, collecting them into groups by subdirectory, properly indented
  *
@@ -263,7 +264,8 @@ function processPackage(lines, space, dir) {
             const file = PACKAGE.shift();
             const name = path.basename(file);
             const relativefile = path.join('..', MATHJAX3, dir, name).replace(/\.ts$/, '.js');
-            const component = `require('${relativefile}')`;
+            const component = 'module' + (++importCount);
+            lines.push(`import * as ${component} from '${relativefile}';`);
             let property = name.replace(/\.ts$/, '');
             if (property !== name && exists(path.resolve(MATHJAX3, file.replace(/\.ts$/, '')))) {
                 property += '_ts';

--- a/components/samples/context-menu/config-live.js
+++ b/components/samples/context-menu/config-live.js
@@ -1,0 +1,26 @@
+import {source} from '../../src/source.js';
+
+window.MathJax = {
+    loader: {
+        load: ["tex-input", "chtml-output", "context-menu"],
+        paths: {
+            mathjax: '../../dist',
+            node: '../../../node_modules',
+            sre: '[node]/speech-rule-engine/lib'
+        },
+        source: Object.assign(source, {
+            sre: '[sre]/sre_browser.js'
+        }),
+        require: (url) => System.import(url),
+        failed: (error) => {
+            console.log(`MathJax(${error.package || '?'}): ${error.message}`);
+            if (error.stack) console.log(error.stack);
+        }
+    },
+    chtml: {
+        fontURL: 'https://cdn.rawgit.com/mathjax/mathjax-v3/3.0.0-beta.3/mathjax2/css'
+    },
+    tex: {
+        inlineMath: [['$','$']]
+    }
+};

--- a/components/samples/context-menu/config-live.js
+++ b/components/samples/context-menu/config-live.js
@@ -4,13 +4,9 @@ window.MathJax = {
     loader: {
         load: ["tex-input", "chtml-output", "context-menu"],
         paths: {
-            mathjax: '../../dist',
-            node: '../../../node_modules',
-            sre: '[node]/speech-rule-engine/lib'
+            mathjax: '../../dist'
         },
-        source: Object.assign(source, {
-            sre: '[sre]/sre_browser.js'
-        }),
+        source: source,
         require: (url) => System.import(url),
         failed: (error) => {
             console.log(`MathJax(${error.package || '?'}): ${error.message}`);

--- a/components/samples/context-menu/config.js
+++ b/components/samples/context-menu/config.js
@@ -1,0 +1,23 @@
+window.MathJax = {
+    loader: {
+        load: ["tex-input", "chtml-output", "context-menu"],
+        paths: {
+            mathjax: '../../dist',
+            node: '../../../node_modules',
+            sre: '[node]/speech-rule-engine/lib'
+        },
+        source: {
+            sre: '[sre]/sre_browser.js'
+        },
+        failed: (error) => {
+            console.log(`MathJax(${error.package || '?'}): ${error.message}`);
+            if (error.stack) console.log(error.stack);
+        }
+    },
+    chtml: {
+        fontURL: 'https://cdn.rawgit.com/mathjax/mathjax-v3/3.0.0-beta.3/mathjax2/css'
+    },
+    tex: {
+        inlineMath: [['$','$']]
+    }
+};

--- a/components/samples/context-menu/config.js
+++ b/components/samples/context-menu/config.js
@@ -2,12 +2,7 @@ window.MathJax = {
     loader: {
         load: ["tex-input", "chtml-output", "context-menu"],
         paths: {
-            mathjax: '../../dist',
-            node: '../../../node_modules',
-            sre: '[node]/speech-rule-engine/lib'
-        },
-        source: {
-            sre: '[sre]/sre_browser.js'
+            mathjax: '../../dist'
         },
         failed: (error) => {
             console.log(`MathJax(${error.package || '?'}): ${error.message}`);

--- a/components/samples/context-menu/test-live.html
+++ b/components/samples/context-menu/test-live.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>Test of MathJax3 loader</title>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+<script src="../../../lib/traceur.min.js"></script>
+<script src="../../../lib/system.js"></script>
+</head>
+<body>
+
+Display math:
+$$x+1\over x-1$$
+
+In-line math: $\sqrt{x+1}$ and $\frac{1}{x^2+1}$ are expressions.
+
+<script>
+System.import('./config-live.js')
+  .then(() => System.import('../../src/startup/startup.js'))
+  .catch(function (error) {console.log(error.message)});
+</script>
+</body>
+</html>

--- a/components/samples/context-menu/test.html
+++ b/components/samples/context-menu/test.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>Test of MathJax3 loader</title>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+<script src="config.js"></script>
+<script src="../../dist/startup.js" id="MathJax-script"></script>
+</head>
+<body>
+
+Display math:
+$$x+1\over x-1$$
+
+In-line math: $\sqrt{x+1}$ and $\frac{1}{x^2+1}$ are expressions.
+
+</body>
+</html>

--- a/components/samples/context-menu/test.js
+++ b/components/samples/context-menu/test.js
@@ -1,0 +1,2 @@
+require('./config.js');
+require('../../src/startup/startup.js');

--- a/components/src/a11y/complexity/complexity.js
+++ b/components/src/a11y/complexity/complexity.js
@@ -1,14 +1,15 @@
-require('./lib/complexity.js');
-const combineDefaults = require('../../../../mathjax3/components/global.js').combineDefaults;
+import './lib/complexity.js';
+
+import {combineDefaults} from '../../../../mathjax3/components/global.js';
+import {sreReady} from '../../../../mathjax3/a11y/sre.js';
+import {ComplexityHandler} from '../../../../mathjax3/a11y/complexity.js';
+import {MathML} from '../../../../mathjax3/input/mathml.js';
 
 if (MathJax.loader) {
-    const sreReady = require('./lib/a11y/sre.js').sreReady;
     combineDefaults(MathJax.config.loader, 'a11y/complexity', {checkReady: () => sreReady});
 }
 
 if (MathJax.startup) {
-    const ComplexityHandler = require('./lib/a11y/complexity.js').ComplexityHandler;
-    const MathML = require('../../../../mathjax3/input/mathml.js').MathML;
     MathJax.startup.extendHandler(handler => ComplexityHandler(handler, new MathML()));
     MathJax.startup.typesetCall('complexity', 30);
     MathJax.startup.convertCall('complexity', 30);

--- a/components/src/a11y/complexity/complexity.js
+++ b/components/src/a11y/complexity/complexity.js
@@ -1,15 +1,9 @@
 import './lib/complexity.js';
 
 import {combineDefaults} from '../../../../mathjax3/components/global.js';
-import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ComplexityHandler} from '../../../../mathjax3/a11y/complexity.js';
-import {MathML} from '../../../../mathjax3/input/mathml.js';
-
-if (MathJax.loader) {
-    combineDefaults(MathJax.config.loader, 'a11y/complexity', {checkReady: () => sreReady});
-}
 
 if (MathJax.startup) {
-    MathJax.startup.extendHandler(handler => ComplexityHandler(handler, new MathML()));
+    MathJax.startup.extendHandler(handler => ComplexityHandler(handler));
     combineDefaults(MathJax.config, 'options', MathJax.config['a11y/complexity'] || {});
 }

--- a/components/src/a11y/complexity/complexity.js
+++ b/components/src/a11y/complexity/complexity.js
@@ -4,6 +4,7 @@ import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ComplexityHandler} from '../../../../mathjax3/a11y/complexity.js';
 import {MathML} from '../../../../mathjax3/input/mathml.js';
+import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/complexity', {checkReady: () => sreReady});
@@ -11,7 +12,7 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => ComplexityHandler(handler, new MathML()));
-    MathJax.startup.typesetCall('complexity', 30);
-    MathJax.startup.convertCall('complexity', 30);
+    MathJax.startup.typesetCall('complexity', STATE.COMPLEXITY);
+    MathJax.startup.convertCall('complexity', STATE.COMPLEXITY);
     combineDefaults(MathJax.config, 'options', MathJax.config['a11y/complexity'] || {});
 }

--- a/components/src/a11y/complexity/complexity.js
+++ b/components/src/a11y/complexity/complexity.js
@@ -4,7 +4,6 @@ import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ComplexityHandler} from '../../../../mathjax3/a11y/complexity.js';
 import {MathML} from '../../../../mathjax3/input/mathml.js';
-import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/complexity', {checkReady: () => sreReady});
@@ -12,7 +11,5 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => ComplexityHandler(handler, new MathML()));
-    MathJax.startup.typesetCall('complexity', STATE.COMPLEXITY);
-    MathJax.startup.convertCall('complexity', STATE.COMPLEXITY);
     combineDefaults(MathJax.config, 'options', MathJax.config['a11y/complexity'] || {});
 }

--- a/components/src/a11y/complexity/webpack.config.js
+++ b/components/src/a11y/complexity/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = PACKAGE(
     'complexity',                       // the package to build
     '../../../../mathjax3',             // location of the mathjax3 library
     [                                   // packages to link to
+        'components/src/a11y/semantic-enrich/lib',
         'components/src/mml-input/lib',
         'components/src/core/lib'
     ],

--- a/components/src/a11y/explorer/build.json
+++ b/components/src/a11y/explorer/build.json
@@ -1,0 +1,6 @@
+{
+    "component": "explorer",
+    "targets": ["a11y/explorer.ts", "a11y/sre.ts"],
+    "mathjax3": "../../../../mathjax3"
+}
+

--- a/components/src/a11y/explorer/build.json
+++ b/components/src/a11y/explorer/build.json
@@ -1,6 +1,6 @@
 {
     "component": "explorer",
-    "targets": ["a11y/explorer.ts", "a11y/sre.ts"],
+    "targets": ["a11y/explorer.ts", "a11y/sre.ts", "a11y/explorer"],
     "mathjax3": "../../../../mathjax3"
 }
 

--- a/components/src/a11y/explorer/explorer.js
+++ b/components/src/a11y/explorer/explorer.js
@@ -1,0 +1,15 @@
+import './lib/explorer.js';
+
+import {combineDefaults} from '../../../../mathjax3/components/global.js';
+import {sreReady} from '../../../../mathjax3/a11y/sre.js';
+import {ExplorerHandler} from '../../../../mathjax3/a11y/explorer.js';
+
+if (MathJax.loader) {
+    combineDefaults(MathJax.config.loader, 'a11y/explorer', {checkReady: () => sreReady});
+}
+
+if (MathJax.startup) {
+    MathJax.startup.extendHandler(handler => ExplorerHandler(handler));
+    MathJax.startup.typesetCall('explorable', 160);
+    MathJax.startup.convertCall('explorable', 160);
+}

--- a/components/src/a11y/explorer/explorer.js
+++ b/components/src/a11y/explorer/explorer.js
@@ -1,12 +1,7 @@
 import './lib/explorer.js';
 
 import {combineDefaults} from '../../../../mathjax3/components/global.js';
-import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ExplorerHandler} from '../../../../mathjax3/a11y/explorer.js';
-
-if (MathJax.loader) {
-    combineDefaults(MathJax.config.loader, 'a11y/explorer', {checkReady: () => sreReady});
-}
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => ExplorerHandler(handler));

--- a/components/src/a11y/explorer/explorer.js
+++ b/components/src/a11y/explorer/explorer.js
@@ -3,6 +3,7 @@ import './lib/explorer.js';
 import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ExplorerHandler} from '../../../../mathjax3/a11y/explorer.js';
+import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/explorer', {checkReady: () => sreReady});
@@ -10,6 +11,6 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => ExplorerHandler(handler));
-    MathJax.startup.typesetCall('explorable', 160);
-    MathJax.startup.convertCall('explorable', 160);
+    MathJax.startup.typesetCall('explorable', STATE.EXPLORER);
+    MathJax.startup.convertCall('explorable', STATE.EXPLORER);
 }

--- a/components/src/a11y/explorer/explorer.js
+++ b/components/src/a11y/explorer/explorer.js
@@ -3,7 +3,6 @@ import './lib/explorer.js';
 import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {ExplorerHandler} from '../../../../mathjax3/a11y/explorer.js';
-import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/explorer', {checkReady: () => sreReady});
@@ -11,6 +10,4 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => ExplorerHandler(handler));
-    MathJax.startup.typesetCall('explorable', STATE.EXPLORER);
-    MathJax.startup.convertCall('explorable', STATE.EXPLORER);
 }

--- a/components/src/a11y/explorer/webpack.config.js
+++ b/components/src/a11y/explorer/webpack.config.js
@@ -4,6 +4,8 @@ module.exports = PACKAGE(
     'explorer',                        // the package to build
     '../../../../mathjax3',             // location of the mathjax3 library
     [                                   // packages to link to
+        'components/src/a11y/semantic-enrich/lib',
+        'components/src/mml-input/lib',
         'components/src/core/lib'
     ],
     __dirname,                          // our directory

--- a/components/src/a11y/explorer/webpack.config.js
+++ b/components/src/a11y/explorer/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'explorer',                        // the package to build
+    '../../../../mathjax3',             // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/core/lib'
+    ],
+    __dirname,                          // our directory
+    '../../../dist/a11y'                // dist directory
+);

--- a/components/src/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/src/a11y/semantic-enrich/semantic-enrich.js
@@ -1,14 +1,15 @@
-require('./lib/semantic-enrich.js');
+import './lib/semantic-enrich.js';
+
+import {combineDefaults} from '../../../../mathjax3/components/global.js';
+import {sreReady} from '../../../../mathjax3/a11y/sre.js';
+import {EnrichHandler} from '../../../../mathjax3/a11y/semantic-enrich.js';
+import {MathML} from '../../../../mathjax3/input/mathml.js';
 
 if (MathJax.loader) {
-    const sreReady = require('./lib/a11y/sre.js').sreReady;
-    const combineDefaults = require('../../../../mathjax3/components/global.js').combineDefaults;
     combineDefaults(MathJax.config.loader, 'a11y/semantic-enrich', {checkReady: () => sreReady});
 }
 
 if (MathJax.startup) {
-    const EnrichHandler = require('./lib/a11y/semantic-enrich.js').EnrichHandler;
-    const MathML = require('../../../../mathjax3/input/mathml.js').MathML;
     MathJax.startup.extendHandler(handler => EnrichHandler(handler, new MathML()));
     MathJax.startup.typesetCall('enrich', 30);
     MathJax.startup.convertCall('enrich', 30);

--- a/components/src/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/src/a11y/semantic-enrich/semantic-enrich.js
@@ -4,6 +4,7 @@ import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {EnrichHandler} from '../../../../mathjax3/a11y/semantic-enrich.js';
 import {MathML} from '../../../../mathjax3/input/mathml.js';
+import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/semantic-enrich', {checkReady: () => sreReady});
@@ -11,6 +12,6 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => EnrichHandler(handler, new MathML()));
-    MathJax.startup.typesetCall('enrich', 30);
-    MathJax.startup.convertCall('enrich', 30);
+    MathJax.startup.typesetCall('enrich', STATE.ENRICHED);
+    MathJax.startup.convertCall('enrich', STATE.ENRICHED);
 }

--- a/components/src/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/src/a11y/semantic-enrich/semantic-enrich.js
@@ -4,7 +4,6 @@ import {combineDefaults} from '../../../../mathjax3/components/global.js';
 import {sreReady} from '../../../../mathjax3/a11y/sre.js';
 import {EnrichHandler} from '../../../../mathjax3/a11y/semantic-enrich.js';
 import {MathML} from '../../../../mathjax3/input/mathml.js';
-import {STATE} from '../../../../mathjax3/core/MathItem.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'a11y/semantic-enrich', {checkReady: () => sreReady});
@@ -12,6 +11,4 @@ if (MathJax.loader) {
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => EnrichHandler(handler, new MathML()));
-    MathJax.startup.typesetCall('enrich', STATE.ENRICHED);
-    MathJax.startup.convertCall('enrich', STATE.ENRICHED);
 }

--- a/components/src/chtml-output/chtml-output.js
+++ b/components/src/chtml-output/chtml-output.js
@@ -1,7 +1,9 @@
-require('./lib/chtml-output.js');
+import './lib/chtml-output.js';
+
+import {combineDefaults} from '../../../mathjax3/components/global.js';
+import {CHTML} from '../../../mathjax3/output/chtml.js';
 
 if (MathJax.loader) {
-    const combineDefaults = require('../../../mathjax3/components/global.js').combineDefaults;
     combineDefaults(MathJax.config.loader, 'chtml-output', {
         checkReady() {
             return MathJax.loader.load("chtml-fonts/tex");
@@ -10,6 +12,6 @@ if (MathJax.loader) {
 }
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('chtml', MathJax._.output.chtml_ts.CHTML);
+    MathJax.startup.registerConstructor('chtml', CHTML);
     MathJax.startup.useOutput('chtml');
 }

--- a/components/src/chtml-output/fonts/tex/tex.js
+++ b/components/src/chtml-output/fonts/tex/tex.js
@@ -1,9 +1,10 @@
-require('./lib/tex.js');
-const combineDefaults = require('../../../../../mathjax3/components/global.js').combineDefaults;
-const selectOptionsFromKeys = require('../../../../../mathjax3/util/Options.js').selectOptionsFromKeys;
+import './lib/tex.js';
+
+import {combineDefaults} from '../../../../../mathjax3/components/global.js';
+import {selectOptionsFromKeys} from '../../../../../mathjax3/util/Options.js';
+import {TeXFont} from '../../../../../mathjax3/output/chtml/fonts/tex.js';
 
 if (MathJax.startup) {
-    const TeXFont = MathJax._.output.chtml.fonts.tex_ts.TeXFont;
     const options = selectOptionsFromKeys(MathJax.config.chtml || {}, TeXFont.OPTIONS);
     combineDefaults(MathJax.config, 'chtml', {font: new TeXFont(options)});
 }

--- a/components/src/context-menu/build.json
+++ b/components/src/context-menu/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "context-menu",
+    "targets": ["ui/menu"]
+}
+

--- a/components/src/context-menu/context-menu.js
+++ b/components/src/context-menu/context-menu.js
@@ -1,0 +1,12 @@
+import './lib/context-menu.js';
+
+import {MenuHandler} from '../../../mathjax3/ui/menu/MenuHandler.js';
+import {STATE} from '../../../mathjax3/core/MathItem.js';
+
+
+if (MathJax.startup) {
+    MathJax.startup.extendHandler(handler => MenuHandler(handler), 20);
+    MathJax.startup.typesetCall('addMenu', STATE.CONTEXT_MENU);
+    MathJax.startup.convertCall('addMenu', STATE.CONTEXT_MENU);
+}
+

--- a/components/src/context-menu/context-menu.js
+++ b/components/src/context-menu/context-menu.js
@@ -1,12 +1,8 @@
 import './lib/context-menu.js';
 
 import {MenuHandler} from '../../../mathjax3/ui/menu/MenuHandler.js';
-import {STATE} from '../../../mathjax3/core/MathItem.js';
-
 
 if (MathJax.startup) {
     MathJax.startup.extendHandler(handler => MenuHandler(handler), 20);
-    MathJax.startup.typesetCall('addMenu', STATE.CONTEXT_MENU);
-    MathJax.startup.convertCall('addMenu', STATE.CONTEXT_MENU);
 }
 

--- a/components/src/context-menu/webpack.config.js
+++ b/components/src/context-menu/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'context-menu',                     // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/core/lib',
+        'components/src/mml-input/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/core/core.js
+++ b/components/src/core/core.js
@@ -1,8 +1,11 @@
-require('./lib/core.js');
+import './lib/core.js';
+
+import {HTMLHandler} from '../../../mathjax3/handlers/html/HTMLHandler.js';
+import {browserAdaptor} from '../../../mathjax3/adaptors/browserAdaptor.js';
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('HTMLHandler', MathJax._.handlers.html.HTMLHandler.HTMLHandler);
-    MathJax.startup.registerConstructor('browserAdaptor', MathJax._.adaptors.browserAdaptor.browserAdaptor);
+    MathJax.startup.registerConstructor('HTMLHandler', HTMLHandler);
+    MathJax.startup.registerConstructor('browserAdaptor', browserAdaptor);
     MathJax.startup.useHandler('HTMLHandler');
     MathJax.startup.useAdaptor('browserAdaptor');
 }

--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -2,6 +2,6 @@
 Object.defineProperty(exports, '__esModule', {value: true});
 exports.dependencies = {
     'a11y/semantic-enrich': ['core', 'sre', 'mml-input'],
-    'a11y/complexity': ['core', 'sre', 'mml-input'],
-    'a11y/explorer': ['core', 'sre']
+    'a11y/complexity': ['a11y/semantic-enrich'],
+    'a11y/explorer': ['a11y/semantic-enrich']
 };

--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, '__esModule', {value: true});
+exports.dependencies = {
+    'a11y/semantic-enrich': ['core', 'sre', 'mml-input'],
+    'a11y/complexity': ['core', 'sre', 'mml-input'],
+    'a11y/explorer': ['core', 'sre']
+};

--- a/components/src/entities/entities.js
+++ b/components/src/entities/entities.js
@@ -1,2 +1,2 @@
-require('../../../mathjax3/util/entities/all.js');
+import '../../../mathjax3/util/entities/all.js';
 

--- a/components/src/liteDOM/liteDOM.js
+++ b/components/src/liteDOM/liteDOM.js
@@ -1,6 +1,8 @@
-require('./lib/liteDOM.js');
+import './lib/liteDOM.js';
+
+import {liteAdaptor} from '../../../mathjax3/adaptors/liteAdaptor.js';
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('liteAdaptor', MathJax._.adaptors.liteAdaptor.liteAdaptor);
+    MathJax.startup.registerConstructor('liteAdaptor', liteAdaptor);
     MathJax.startup.useAdaptor('liteAdaptor', true);
 }

--- a/components/src/loader/loader.js
+++ b/components/src/loader/loader.js
@@ -1,6 +1,10 @@
 import './lib/loader.js';
 
 import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
+import {combineDefaults} from '../../../mathjax3/components/global.js';
+import {dependencies} from '../dependencies.js';
+
+combineDefaults(MathJax.config, 'loader', {dependencies});
 
 Loader.load(...CONFIG.load)
     .then(() => CONFIG.ready())

--- a/components/src/loader/loader.js
+++ b/components/src/loader/loader.js
@@ -4,7 +4,7 @@ import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
 import {combineDefaults} from '../../../mathjax3/components/global.js';
 import {dependencies} from '../dependencies.js';
 
-combineDefaults(MathJax.config, 'loader', {dependencies});
+combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
 
 Loader.load(...CONFIG.load)
     .then(() => CONFIG.ready())

--- a/components/src/loader/loader.js
+++ b/components/src/loader/loader.js
@@ -1,4 +1,6 @@
-const {Loader, CONFIG} = require('./lib/loader.js');
+import './lib/loader.js';
+
+import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
 
 Loader.load(...CONFIG.load)
     .then(() => CONFIG.ready())

--- a/components/src/mml-input/mml-input.js
+++ b/components/src/mml-input/mml-input.js
@@ -1,6 +1,8 @@
-require('./lib/mml-input.js');
+import './lib/mml-input.js';
+
+import {MathML} from '../../../mathjax3/input/mathml.js';
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('mml', MathJax._.input.mathml_ts.MathML);
+    MathJax.startup.registerConstructor('mml', MathML);
     MathJax.startup.useInput('mml');
 }

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -13,6 +13,7 @@ exports.source = {
     'a11y/complexity': `${src}/a11y/complexity/complexity.js`,
     'a11y/explorer': `${src}/a11y/explorer/explorer.js`,
     'sre': `../../mathjax3/a11y/sre-node.js`,
+    'context-menu': `${src}/context-menu/context-menu.js`,
     'loader': `${src}/loader/loader.js`,
     'startup': `${src}/startup/startup.js`
 };

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -11,6 +11,7 @@ exports.source = {
     'svg-output': `${src}/svg-output/svg-output.js`,
     'a11y/semantic-enrich': `${src}/a11y/semantic-enrich/semantic-enrich.js`,
     'a11y/complexity': `${src}/a11y/complexity/complexity.js`,
+    'a11y/explorer': `${src}/a11y/explorer/explorer.js`,
     'sre': `../../mathjax3/a11y/sre-node.js`,
     'loader': `${src}/loader/loader.js`,
     'startup': `${src}/startup/startup.js`

--- a/components/src/startup/startup.js
+++ b/components/src/startup/startup.js
@@ -1,5 +1,6 @@
-require('./lib/startup.js');
-const {Loader, CONFIG} = require('../../../mathjax3/components/loader.js');
+import './lib/startup.js';
+
+import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
 
 Loader.preLoad('loader');
 

--- a/components/src/startup/startup.js
+++ b/components/src/startup/startup.js
@@ -1,6 +1,10 @@
 import './lib/startup.js';
 
 import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
+import {combineDefaults} from '../../../mathjax3/components/global.js';
+import {dependencies} from '../dependencies.js';
+
+combineDefaults(MathJax.config, 'loader', {dependencies});
 
 Loader.preLoad('loader');
 

--- a/components/src/startup/startup.js
+++ b/components/src/startup/startup.js
@@ -4,7 +4,7 @@ import {Loader, CONFIG} from '../../../mathjax3/components/loader.js';
 import {combineDefaults} from '../../../mathjax3/components/global.js';
 import {dependencies} from '../dependencies.js';
 
-combineDefaults(MathJax.config, 'loader', {dependencies});
+combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
 
 Loader.preLoad('loader');
 

--- a/components/src/svg-output/fonts/tex/tex.js
+++ b/components/src/svg-output/fonts/tex/tex.js
@@ -1,9 +1,10 @@
-require('./lib/tex.js');
+import './lib/tex.js';
+
+import {TeXFont} from '../../../../../mathjax3/output/svg/fonts/tex.js';
+import {combineDefaults} from '../../../../../mathjax3/components/global.js';
+import {selectOptionsFromKeys} from '../../../../../mathjax3/util/Options.js';
 
 if (MathJax.startup) {
-    const TeXFont = MathJax._.output.svg.fonts.tex_ts.TeXFont;
-    const combineDefaults = require('../../../../../mathjax3/components/global.js').combineDefaults;
-    const selectOptionsFromKeys = require('../../../../../mathjax3/util/Options.js').selectOptionsFromKeys;
     const options = selectOptionsFromKeys(MathJax.config.svg || {}, TeXFont.OPTIONS);
     combineDefaults(MathJax.config, 'svg', {font: new TeXFont(options)});
 }

--- a/components/src/svg-output/svg-output.js
+++ b/components/src/svg-output/svg-output.js
@@ -1,5 +1,7 @@
-const combineDefaults = require('../../../mathjax3/components/global.js').combineDefaults;
-require('./lib/svg-output.js');
+import './lib/svg-output.js';
+
+import {combineDefaults} from '../../../mathjax3/components/global.js';
+import {SVG} from '../../../mathjax3/output/svg.js';
 
 if (MathJax.loader) {
     combineDefaults(MathJax.config.loader, 'svg-output', {
@@ -10,6 +12,6 @@ if (MathJax.loader) {
 }
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('svg', MathJax._.output.svg_ts.SVG);
+    MathJax.startup.registerConstructor('svg', SVG);
     MathJax.startup.useOutput('svg');
 }

--- a/components/src/tex-input/tex-input.js
+++ b/components/src/tex-input/tex-input.js
@@ -1,6 +1,8 @@
-require('./lib/tex-input.js');
+import './lib/tex-input.js';
+
+import {TeX} from '../../../mathjax3/input/tex.js';
 
 if (MathJax.startup) {
-    MathJax.startup.registerConstructor('tex', MathJax._.input.tex_ts.TeX);
+    MathJax.startup.registerConstructor('tex', TeX);
     MathJax.startup.useInput('tex');
 }

--- a/mathjax3-ts/components/global.ts
+++ b/mathjax3-ts/components/global.ts
@@ -55,6 +55,7 @@ declare const global: {MathJax: MathJaxObject | MathJaxConfig};
  */
 export function combineConfig(dst: any, src: any) {
     for (const id of Object.keys(src)) {
+        if (id === '__esModule') continue;
         if (typeof dst[id] === 'object' && typeof src[id] === 'object') {
             combineConfig(dst[id], src[id]);
         } else if (src[id] !== null && src[id] !== undefined) {

--- a/mathjax3-ts/components/package.ts
+++ b/mathjax3-ts/components/package.ts
@@ -254,8 +254,13 @@ export class Package {
      */
     protected loadCustom(url: string) {
         try {
-            CONFIG.require(url);
-            this.checkLoad();
+            const result = CONFIG.require(url);
+            if (result instanceof Promise) {
+                result.then(() => this.checkLoad())
+                      .catch(() => this.failed('Can\'t load "' + url + '"'));
+            } else {
+                this.checkLoad();
+            }
         } catch (err) {
             this.failed(err.message);
         }

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -35,6 +35,7 @@ import {InputJax, AbstractInputJax} from '../core/InputJax.js';
 import {OutputJax, AbstractOutputJax} from '../core/OutputJax.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {PrioritizedList} from '../util/PrioritizedList.js';
+import {OptionList} from '../util/Options.js';
 
 import {TeX} from '../input/tex.js';
 
@@ -74,12 +75,6 @@ export type TEX = TeX<any, any, any>;
 export type HandlerExtension = (handler: HANDLER) => HANDLER;
 
 /**
- * Functions to be called in typeset and conversion methods created for the registered packages
- */
-export type TypesetCall = (document: MATHDOCUMENT) => void;
-export type ConvertCall = (math: MATHITEM, document: MATHDOCUMENT) => void;
-
-/**
  * Update the MathJax object to inclide the startup information
  */
 export interface MathJaxObject extends MJObject {
@@ -101,10 +96,6 @@ export interface MathJaxObject extends MJObject {
         useInput(name:string, force?: boolean): void;
         extendHandler(extend: HandlerExtension): void;
         toMML(node: MmlNode): string;
-        typesetCall(fn: string | TypesetCall, priority: number): void;
-        clearTypesetCalls(): void;
-        convertCall(fn: string | ConvertCall, priority: number): void;
-        clearConvertCalls(): void;
         defaultReady(): void;
         getComponents(): void;
         makeMethods(): void;
@@ -112,8 +103,6 @@ export interface MathJaxObject extends MJObject {
         makeOutputMethods(iname: string, oname: string, input: INPUTJAX): void;
         makeMmlMethods(name: string, input: INPUTJAX): void;
         makeResetMethod(name: string, input: INPUTJAX): void;
-        convertMath(mitem: MATHITEM, document: MATHDOCUMENT, maxPriority?: number): void;
-        typesetMath(document: MATHDOCUMENT, minPriority?: number): void;
         getInputJax(): INPUTJAX[];
         getOutputJax(): OUTPUTJAX;
         getAdaptor(): DOMADAPTOR;
@@ -136,12 +125,6 @@ export namespace Startup {
      * The array of handler extensions
      */
     const extensions = new PrioritizedList<HandlerExtension>();
-
-    /**
-     * The prioritized list of functions to call duing typesetting and conversion
-     */
-    let typesetCalls = new PrioritizedList<TypesetCall>();
-    let convertCalls = new PrioritizedList<ConvertCall>();
 
     let visitor: any;  // the visitor for toMML();
     let mathjax: any;  // variable for the MathJax variable from mathjax.js
@@ -266,45 +249,6 @@ export namespace Startup {
     };
 
     /**
-     * @param {string | TypesetCall} fn    The name of a Handler method or a function to call during typesetting
-     * @param {number} priority            The priority of the call (so extensions can add calls at the right place)
-     */
-    export function typesetCall(fn: string | TypesetCall, priority: number) {
-        if (typeof fn === 'string') {
-            typesetCalls.add((doc: any) => doc[fn](), priority);
-        } else {
-            typesetCalls.add(fn, priority);
-        }
-    };
-
-    /**
-     * Clear the typeset calls (in case you need to remove the default ones)
-     */
-    export function clearTypesetCalls() {
-        typesetCalls = new PrioritizedList<TypesetCall>();
-    };
-
-    /**
-     * @param {string | TypesetCall} fn    The name of a Handler method or a function to call during typesetting
-     * @param {number} priority            The priority of the call (so extensions can add calls at the right place)
-     *                                        priorities of 100 or higher aren't performed for the *2mml() methods
-     */
-    export function convertCall(fn: string | ConvertCall, priority: number) {
-        if (typeof fn === 'string') {
-            convertCalls.add((math: any, doc: any) => math[fn](doc), priority);
-        } else {
-            convertCalls.add(fn, priority);
-        }
-    };
-
-    /**
-     * Clear the convert calls (in case you need to remove the default ones)
-     */
-    export function clearConvertCalls() {
-        convertCalls = new PrioritizedList<ConvertCall>();
-    }
-
-    /**
      * The default ready() function called when all the packages have been loaded
      *   (setting MathJax.startup.ready in the configuration will override this,
      *    but you can call MathJax.startup.defaultReady() within your own ready function
@@ -349,9 +293,9 @@ export namespace Startup {
         if (input && output) {
             makeTypesetMethods();
         }
-        const oname = (output ? (output.constructor as typeof AbstractOutputJax).NAME.toLowerCase() : '');
+        const oname = (output ? output.name.toLowerCase() : '');
         for (const jax of input) {
-            const iname = (jax.constructor as typeof AbstractInputJax).NAME.toLowerCase();
+            const iname = jax.name.toLowerCase();
             makeMmlMethods(iname, jax);
             makeResetMethod(iname, jax);
             if (output) {
@@ -363,38 +307,31 @@ export namespace Startup {
     /**
      * Create the Typeset(elements?), TypesetPromise(elements?), and TypesetClear() methods.
      *
-     * The first two call the registered typesetCalls in prioritized order, with the latter
+     * The first two call the document's render() function, the latter
      *   wrapped in handleRetriesFor() and returning the resulting promise.
      *
      * TypeseClear() clears all the MathItems from the document.
      */
     export function makeTypesetMethods() {
-        MathJax.Typeset = (which: any = null) => {
-            elements = which;
-            for (const fn of typesetCalls) {
-                fn.item(document);
-            }
+        MathJax.Typeset = (elements: any = null) => {
+            document.options.elements = elements;
+            document.render();
         };
-        MathJax.TypesetPromise = (which: any = null) => {
-            elements = which;
+        MathJax.TypesetPromise = (elements: any = null) => {
+            document.options.elements = elements;
             return mathjax.handleRetriesFor(() => {
-                for (const fn of typesetCalls) {
-                    fn.item(document);
-                }
+                document.render();
             })
         };
-        MathJax.Clear = () => document.clear();
+        MathJax.TypesetClear = () => document.clear();
     };
 
     /**
-     * Make the input2output(math, display?, em?, ex?, cwidth?)
-     *   and input2outuputPromise(math, display? , em?, ex?, cwidth?) methods,
+     * Make the input2output(math, options?) and input2outuputPromise(math, options?) methods,
      *   and outputStylesheet() method, where "input" and "output" are replaced by the
      *   jax names (e.g., tex2chtml() and chtmlStyleSheet()).
      *
-     * The first two create a MathItem for the given math string (in display mode if display is true),
-     *   with the given em and ex metrics, with the specified container width, and then
-     *   performs the registered convertCalls on it, with the Promise version wrapped in
+     * The first two perform the document's convert() call, with the Promise version wrapped in
      *   handlerRetriesFor() and returning the resulting promise.  The return value is the
      *   DOM object for the converted math.  Use MathJax.startup.adaptor.outerHTML(result)
      *   to get the serialized string version of the output.
@@ -410,43 +347,41 @@ export namespace Startup {
     export function makeOutputMethods(iname: string, oname: string, input: INPUTJAX) {
         const name = iname + '2' + oname;
         MathJax[name] =
-            (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new document.options.MathItem(math, input, display);
-                mitem.setMetrics(em, ex, cwidth, 1000000, 1);
-                return convertMath(mitem, document);
+            (math: string, options: OptionList = {}) => {
+                options.format = input.name;
+                return document.convert(math, options);
             };
         MathJax[name + 'Promise'] =
-            (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new document.options.MathItem(math, input, display);
-                mitem.setMetrics(em, ex, cwidth, 1000000, 1);
-                return mathjax.handleRetriesFor(() => convertMath(mitem, document));
+            (math: string, options: OptionList = {}) => {
+                options.format = input.name;
+                return mathjax.handleRetriesFor(() => document.convert(math, options));
             };
         MathJax[oname + 'Stylesheet'] = () => output.styleSheet(document);
     };
 
     /**
-     * Make the input2mml(math, display?, em? , ex?, cwidth?) and
-     *   input2mmlPromise(math, display?, em? , ex?, cwidth?) methods, where "input" is
-     *   replaced by the name of the input jax (e.g., "tex2mml").
+     * Make the input2mml(math, options?) and input2mmlPromise(math, options?) methods,
+     *   where "input" is replaced by the name of the input jax (e.g., "tex2mml").
      *
-     * These convert the math to its serialized MathML representation.  The second wraps the conversion
-     *   in handleRetriesFor() and returns the resulting promise.
+     * These convert the math to its serialized MathML representation.
+     *   The second wraps the conversion in handleRetriesFor() and
+     *   returns the resulting promise.
      *
      * @param {string} name     The name of the input jax
      * @param {input} INPUTJAX  The input jax itself
      */
     export function makeMmlMethods(name: string, input: INPUTJAX) {
         MathJax[name + '2mml'] =
-            (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new document.options.MathItem(math, input, display);
-                mitem.setMetrics(em, ex, cwidth, 1000000, 1);
-                return convertMath(mitem, document, 100);
+            (math: string, options: OptionList = {}) => {
+                options.end = STATE.CONVERT;
+                options.format = input.name;
+                return toMML(document.convert(math, options));
             };
         MathJax[name + '2mmlPromise'] =
-            (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new document.options.MathItem(math, input, display);
-                mitem.setMetrics(em, ex, cwidth, 1000000, 1);
-                return mathjax.handleRetriesFor(() => convertMath(mitem, document, 100));
+            (math: string, options: OptionList = {}) => {
+                options.end = STATE.CONVERT;
+                options.format = input.name;
+                return mathjax.handleRetriesFor(() => toMML(document.convert(math, options)));
             };
     };
 
@@ -463,39 +398,6 @@ export namespace Startup {
             MathJax.texReset = () => (input as TEX).parseOptions.tags.reset();
         }
     };
-
-    /**
-     * Called by input2output() and input2mml() methods to perform the conversions
-     *
-     * @param {MATHITEM} mitem      The MathItem whose math is to be converted
-     * @param {DOCUMENT} document   The MathDocument in which the conversion takes palce
-     * @param {number} maxPriority  The priority where processing should stop (for input2mml())
-     * @return {any}                The serialized MathML or the DOM node for the converted result
-     */
-    export function convertMath(mitem: MATHITEM, document: MATHDOCUMENT, maxPriority: number = 0) {
-        for (const {item, priority} of convertCalls) {
-            if (maxPriority === 0 || priority < maxPriority) {
-                item(mitem, document);
-            }
-        }
-        return (maxPriority ? toMML(mitem.root) : mitem.typesetRoot);
-    };
-
-    /**
-     * Perform the typesetting calls from a particular priority onward.
-     * Default is to do typeset() and beyond, so this is a rerender command.
-     *
-     * @param {DOCUMENT} document   The MathDocument in which the conversion takes palce
-     * @param {number} minPriority  The priority where processing should begin (default = 110, which is typeset)
-     * @return {any}                The serialized MathML or the DOM node for the converted result
-     */
-    export function typesetMath(document: MATHDOCUMENT, minPriority: number = 110) {
-        for (const {item, priority} of typesetCalls) {
-            if (priority > minPriority) {
-                item(document);
-            }
-        }
-    }
 
     /**
      * @return {INPUTJAX[]}  The array of instances of the registered input jax
@@ -595,20 +497,6 @@ if (typeof MathJax._.startup === 'undefined') {
         options: {}
     });
 
-    const findMath = (document: MATHDOCUMENT) => {
-        const elements = Startup.elements;
-        return document.findMath(elements ? {elements} : {});
-    }
-
-    Startup.typesetCall(findMath, 10);
-    Startup.typesetCall('compile', STATE.COMPILED);
-    Startup.typesetCall('getMetrics', STATE.METRICS);
-    Startup.typesetCall('typeset', STATE.TYPESET);
-    Startup.typesetCall('updateDocument', STATE.INSERTED);
-    Startup.typesetCall('reset', 500);
-
-    Startup.convertCall('compile', STATE.COMPILED);
-    Startup.convertCall('typeset', STATE.TYPESET);
 }
 
 /**

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -409,13 +409,13 @@ export namespace Startup {
         const name = iname + '2' + oname;
         MathJax[name] =
             (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new MathJax._.core.MathItem.AbstractMathItem(math, input, display);
+                const mitem = new document.options.MathItem(math, input, display);
                 mitem.setMetrics(em, ex, cwidth, 1000000, 1);
                 return convertMath(mitem, document);
             };
         MathJax[name + 'Promise'] =
             (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new MathJax._.core.MathItem.AbstractMathItem(math, input, display);
+                const mitem = new document.options.MathItem(math, input, display);
                 mitem.setMetrics(em, ex, cwidth, 1000000, 1);
                 return mathjax.handleRetriesFor(() => convertMath(mitem, document));
             };
@@ -436,13 +436,13 @@ export namespace Startup {
     export function makeMmlMethods(name: string, input: INPUTJAX) {
         MathJax[name + '2mml'] =
             (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new MathJax._.core.MathItem.AbstractMathItem(math, input, display);
+                const mitem = new document.options.MathItem(math, input, display);
                 mitem.setMetrics(em, ex, cwidth, 1000000, 1);
                 return convertMath(mitem, document, 100);
             };
         MathJax[name + '2mmlPromise'] =
             (math: string, display: boolean = true, em: number = 16, ex: number = 8, cwidth:number = 80 * 16) => {
-                const mitem = new MathJax._.core.MathItem.AbstractMathItem(math, input, display);
+                const mitem = new document.options.MathItem(math, input, display);
                 mitem.setMetrics(em, ex, cwidth, 1000000, 1);
                 return mathjax.handleRetriesFor(() => convertMath(mitem, document, 100));
             };

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -28,7 +28,7 @@ import {MathJax as MJGlobal, MathJaxObject as MJObject,
         MathJaxConfig as MJConfig, combineWithMathJax, combineDefaults} from './global.js';
 
 import {MathDocument} from '../core/MathDocument.js';
-import {MathItem} from '../core/MathItem.js';
+import {MathItem, STATE} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {Handler} from '../core/Handler.js';
 import {InputJax, AbstractInputJax} from '../core/InputJax.js';
@@ -601,14 +601,14 @@ if (typeof MathJax._.startup === 'undefined') {
     }
 
     Startup.typesetCall(findMath, 10);
-    Startup.typesetCall('compile', 20);
-    Startup.typesetCall('getMetrics', 110);
-    Startup.typesetCall('typeset', 150);
-    Startup.typesetCall('updateDocument', 200);
+    Startup.typesetCall('compile', STATE.COMPILED);
+    Startup.typesetCall('getMetrics', STATE.METRICS);
+    Startup.typesetCall('typeset', STATE.TYPESET);
+    Startup.typesetCall('updateDocument', STATE.INSERTED);
     Startup.typesetCall('reset', 500);
 
-    Startup.convertCall('compile', 20);
-    Startup.convertCall('typeset', 150);
+    Startup.convertCall('compile', STATE.COMPILED);
+    Startup.convertCall('typeset', STATE.TYPESET);
 }
 
 /**

--- a/mathjax3-ts/core/Handler.ts
+++ b/mathjax3-ts/core/Handler.ts
@@ -54,7 +54,7 @@ export interface Handler<N, T, D> {
      * The class implementing the MathDocument for this handler
      *   (so it can be subclassed by extensions as needed)
      */
-    documentClass: MathDocumentConstructor<N, T, D>;
+    documentClass: MathDocumentConstructor<AbstractMathDocument<N, T, D>>;
 
     /**
      * Checks to see if the handler can process a given document
@@ -113,7 +113,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
      * The class implementing the MathDocument for this handler
      *   (so it can be subclassed by extensions as needed)
      */
-    public documentClass: MathDocumentConstructor<N, T, D> = DefaultMathDocument;
+    public documentClass: MathDocumentConstructor<AbstractMathDocument<N, T, D>> = DefaultMathDocument;
 
     /**
      * @param {number} priority  The priority to use for this handler

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -25,7 +25,7 @@ import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
 import {InputJax, AbstractInputJax} from './InputJax.js';
 import {OutputJax, AbstractOutputJax} from './OutputJax.js';
 import {MathList, AbstractMathList} from './MathList.js';
-import {MathItem, AbstractMathItem} from './MathItem.js';
+import {MathItem, AbstractMathItem, STATE} from './MathItem.js';
 import {MmlNode, TextNode} from './MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
@@ -159,6 +159,13 @@ export interface MathDocument<N, T, D> {
     state(state: number, restore?: boolean): MathDocument<N, T, D>;
 
     /**
+     * Rerender the MathItems on the page
+     *
+     * @return {MathDocument}    The math document instance
+     */
+    rerender(): MathDocument<N, T, D>;
+
+    /**
      * Clear the processed values so that the document can be reprocessed
      *
      * @return {MathDocument}  The math document instance
@@ -259,7 +266,6 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
             doc.typesetError(math, err);
         }
     };
-    public static STATE = AbstractMathItem.STATE;
 
     /**
      * A bit-field for the actions that heve been processed
@@ -454,6 +460,18 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     /**
      * @override
      */
+    public rerender() {
+        this.state(STATE.PRE_TYPESET);  // reset to just before typesetting
+        for (const math of this.math) {
+            math.rerender(this);
+        }
+        this.updateDocument();
+        return this;
+    }
+
+    /**
+     * @override
+     */
     public reset() {
         this.processed.reset();
         return this;
@@ -477,8 +495,6 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     }
 
 }
-
-let STATE = AbstractMathDocument.STATE;
 
 /**
  * The constructor type for a MathDocument

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
+import {userOptions, defaultOptions, OptionList, expandable} from '../util/Options.js';
 import {InputJax, AbstractInputJax} from './InputJax.js';
 import {OutputJax, AbstractOutputJax} from './OutputJax.js';
 import {MathList, AbstractMathList} from './MathList.js';
@@ -30,6 +30,205 @@ import {MmlNode, TextNode} from './MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {BitField, BitFieldClass} from '../util/BitField.js';
+
+import {PrioritizedList, PrioritizedListItem} from '../util/PrioritizedList.js';
+
+/*****************************************************************/
+
+/**
+ * A function to call while rendering a document (usually calls a MathDocument method)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type RenderDoc<N, T, D> = (document: MathDocument<N, T, D>) => boolean;
+
+/**
+ * A function to call while rendering a MathItem (usually calls one of its methods)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type RenderMath<N, T, D> = (math: MathItem<N, T, D>, document: MathDocument<N, T, D>) => boolean;
+
+/**
+ * The data for an action to perform during rendering or conversion
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type RenderData<N, T, D> = {
+    id: string,                           //  The name for the action
+    renderDoc: RenderDoc<N, T, D>,        //  The action to take during a render() call
+    renderMath: RenderMath<N, T, D>,      //  The action to take during a rerender() or convert() call
+    convert: boolean                      //  Whether the action is to be used during convert()
+};
+
+/**
+ * The data used to define a render action in configurations and options objects
+ *   (the key is used as the id, the number in the data below is the priority, and
+ *    the remainind data is as described below; if no boolean is given, convert = true
+ *    by default)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type RenderAction<N, T, D> =
+    [number] |                                                     // id (i.e., key) is method name to use
+    [number, string] |                                             // string is method to call
+    [number, string, string] |                                     // the strings are methods names for doc and math
+    [number, RenderDoc<N, T, D>, RenderMath<N, T, D>] |            // explicit functions for doc and math
+    [number, boolean] |                                            // same as first above, with boolean for convert
+    [number, string, boolean] |                                    // same as second above, with boolean for convert
+    [number, string, string, boolean] |                            // same as third above, with boolean for convert
+    [number, RenderDoc<N, T, D>, RenderMath<N, T, D>, boolean];    // same as forth above, with boolean for convert
+
+/**
+ * An object representing a collection of rendering actions (id's tied to priority-and-method data)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type RenderActions<N, T, D> = {[id: string]: RenderAction<N, T, D>};
+
+/**
+ * Implements a prioritized list of render actions.  Extensions can add actions to the list
+ *   to make it easy to extend the normal typesetting and conversion operations.
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
+
+    /**
+     * Creates a new RenderList from an initial list of rendering actions
+     *
+     * @param {RenderActions}   The list of actions to take during render(), rerender(), and convert() calls
+     * @returns {RenderList}    The newly created prioritied list
+     */
+    public static create<N, T, D>(actions: RenderActions<N, T, D>) {
+        const list = new this<N, T, D>();
+        for (const id of Object.keys(actions)) {
+            const [action, priority] = this.action<N, T, D>(id, actions[id]);
+            if (priority) {
+                list.add(action, priority);
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Parses a RenderAction to produce the correspinding RenderData item
+     *  (e.g., turn method names into actual functions that call the method)
+     *
+     * @param {string} id             The id of the action
+     * @param {RenderAction} action   The RenderAction defining the action
+     * @returns {RenderData}          The corresponding RenderData definition for the action
+     */
+    public static action<N, T, D>(id: string, action: RenderAction<N, T, D>) {
+        let renderDoc, renderMath;
+        let convert = true;
+        let priority = action[0];
+        if (action.length === 1 || typeof action[1] === 'boolean') {
+            action.length === 2 && (convert = action[1] as boolean);
+            [renderDoc, renderMath] = this.methodActions(id);
+        } else if (typeof action[1] === 'string') {
+            if (typeof action[2] === 'string') {
+                action.length === 4 && (convert = action[3] as boolean);
+                const [method1, method2] = action.slice(1) as [string, string];
+                [renderDoc, renderMath] = this.methodActions(method1, method2);
+            } else {
+                action.length === 3 && (convert = action[2] as boolean);
+                [renderDoc, renderMath] = this.methodActions(action[1] as string);
+            }
+        } else {
+            action.length === 4 && (convert = action[3] as boolean);
+            [renderDoc, renderMath] = action.slice(1) as [RenderDoc<N, T, D>, RenderMath<N, T, D>];
+        }
+        return [{id, renderDoc, renderMath, convert}, priority] as [RenderData<N, T, D>, number];
+    }
+
+    /**
+     * Produces the doc and math actions for the given method name(s)
+     *   (a blank name is a no-op)
+     *
+     * @param {string} method1    The method to use for the render() call
+     * @param {string} method1    The method to use for the rerender() and convert() calls
+     */
+    protected static methodActions(method1: string, method2: string = method1) {
+        return [
+            (document: any) => {method1 && document[method1](); return false},
+            (math: any, document: any) => {method2 && math[method2](document); return false}
+        ];
+    }
+
+    /**
+     * Perform the document-level rendering functions
+     *
+     * @param {MathDocument} document   The MathDocument whose methods are to be called
+     * @param {number=} start           The state at which to start rendering (default is UNPROCESSED)
+     */
+    public renderDoc(document: MathDocument<N, T, D>, start: number = STATE.UNPROCESSED) {
+        for (const item of this.items) {
+            if (item.priority >= start) {
+                if (item.item.renderDoc(document)) return;
+            }
+        }
+    }
+
+    /**
+     * Perform the MathItem-level rendering functions
+     *
+     * @param {MathItem} math           The MathItem whose methods are to be called
+     * @param {MathDocument} document   The MathDocument to pass to the MathItem methods
+     * @param {number=} start           The state at which to start rendering (default is UNPROCESSED)
+     */
+    public renderMath(math: MathItem<N, T, D>, document: MathDocument<N, T, D>, start: number = STATE.UNPROCESSED) {
+        for (const item of this.items) {
+            if (item.priority >= start) {
+                if (item.item.renderMath(math, document)) return;
+            }
+        }
+    }
+
+    /**
+     * Perform the MathItem-level conversion functions
+     *
+     * @param {MathItem} math           The MathItem whose methods are to be called
+     * @param {MathDocument} document   The MathDocument to pass to the MathItem methods
+     * @param {number=} end             The state at which to end rendering (default is LAST)
+     */
+    public renderConvert(math: MathItem<N, T, D>, document: MathDocument<N, T, D>, end = STATE.LAST) {
+        for (const item of this.items) {
+            if (item.priority >= end) return;
+            if (item.item.convert) {
+                if (item.item.renderMath(math, document)) return;
+            }
+        }
+    }
+
+    /**
+     * Find an entry in the list with a given ID
+     *
+     * @param {string} id            The id to search for
+     * @returns {RenderData|null}   The data for the given id, if found, or null
+     */
+    public findID(id: string) {
+        for (const item of this.items) {
+            if (item.item.id === id) {
+                return item.item;
+            }
+        }
+        return null;
+    }
+
+}
 
 /*****************************************************************/
 /**
@@ -76,6 +275,11 @@ export interface MathDocument<N, T, D> {
     math: MathList<N, T, D>;
 
     /**
+     * The list of actions to take durring a render() or convert() call
+     */
+    renderActions: RenderList<N, T, D>;
+
+    /**
      * This object tracks what operations have been performed, so that (when
      *  asynchronous operations are used), the ones that have already been
      *  completed won't be performed again.
@@ -101,6 +305,32 @@ export interface MathDocument<N, T, D> {
      * The MmlFactory to be used for input jax and error processing
      */
     mmlFactory: MmlFactory;
+
+    /**
+     * @param {string} id      The id of the action to add
+     * @param {any[]} action   The RenderAction to take
+     */
+    addRenderAction(id: string, ...action: any[]): void;
+
+    /**
+     * @param {string} id   The id of the action to remove
+     */
+    removeRenderAction(id: string): void;
+
+    /**
+     * Perform the renderActions on the document
+     */
+    render(): MathDocument<N, T, D>;
+
+    /**
+     * Rerender the MathItems on the page
+     *
+     * @param {number=} start    The state to start rerendering at
+     * @return {MathDocument}    The math document instance
+     */
+    rerender(start?: number): MathDocument<N, T, D>;
+
+    convert(math: string, options?: OptionList): MmlNode;
 
     /**
      * Locates the math in the document and constructs the MathList
@@ -209,6 +439,7 @@ class DefaultInputJax<N, T, D> extends AbstractInputJax<N, T, D> {
         return null as MmlNode;
     }
 }
+
 /**
  * Defaults used when ouput jax isn't specified
  *
@@ -227,6 +458,7 @@ class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
         return null as N;
     }
 }
+
 /**
  * Default for the MathList when one isn't specified
  *
@@ -235,6 +467,7 @@ class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
  * @template D  The Document class
  */
 class DefaultMathList<N, T, D> extends AbstractMathList<N, T, D> {}
+
 /**
  * Default for the Mathitem when one isn't specified
  *
@@ -255,6 +488,7 @@ class DefaultMathItem<N, T, D> extends AbstractMathItem<N, T, D> {}
 export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T, D> {
 
     public static KIND: string = 'MathDocument';
+
     public static OPTIONS: OptionList = {
         OutputJax: null,           // instance of an OutputJax for the document
         InputJax: null,            // instance of an InputJax or an array of them
@@ -266,7 +500,18 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         },
         typesetError: (doc: AbstractMathDocument<any, any, any>, math: MathItem<any, any, any>, err: Error) => {
             doc.typesetError(math, err);
-        }
+        },
+        renderActions: expandable({
+            find:    [STATE.FINDMATH, (document: MathDocument<any, any, any>) => {
+                const elements = document.options.elements;
+                document.findMath(elements ? {elements} : {});
+            }, () => {}, false],
+            compile: [STATE.COMPILED],
+            metrics: [STATE.METRICS, 'getMetrics', '', false],
+            typeset: [STATE.TYPESET],
+            update:  [STATE.INSERTED, 'updateDocument', false],
+            reset:   [STATE.RESET, 'reset', '', false]
+        }) as RenderActions<any, any, any>
     };
 
     /**
@@ -277,6 +522,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     public document: D;
     public options: OptionList;
     public math: MathList<N, T, D>;
+    public renderActions: RenderList<N, T, D>;
     public processed: BitField;
     public inputJax: InputJax<N, T, D>[];
     public outputJax: OutputJax<N, T, D>;
@@ -290,11 +536,12 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
      * @param {OptionList} options     The options for this document
      * @constructor
      */
-    constructor (document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
+    constructor (document: D, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
         let CLASS = this.constructor as typeof AbstractMathDocument;
         this.document = document;
         this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
         this.math = new (this.options['MathList'] || DefaultMathList)();
+        this.renderActions = RenderList.create<N, T, D>(this.options['renderActions']);
         this.processed = new AbstractMathDocument.ProcessBits();
         this.outputJax = this.options['OutputJax'] || new DefaultOutputJax<N, T, D>();
         let inputJax = this.options['InputJax'] || [new DefaultInputJax<N, T, D>()];
@@ -325,6 +572,56 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
      */
     public get kind() {
         return (this.constructor as typeof AbstractMathDocument).KIND;
+    }
+
+    /**
+     * @override
+     */
+    public addRenderAction(id: string, ...action: any[]) {
+        const [fn, p] = RenderList.action<N, T, D>(id, action as RenderAction<N, T, D>);
+        this.renderActions.add(fn, p);
+    }
+
+    /**
+     * @override
+     */
+    public removeRenderAction(id: string) {
+        const action = this.renderActions.findID(id);
+        if (action) {
+            this.renderActions.remove(action);
+        }
+    }
+
+    /**
+     * @override
+     */
+    public render() {
+        this.renderActions.renderDoc(this);
+        return this;
+    }
+
+    /**
+     * @override
+     */
+    public rerender(start: number = STATE.RERENDER) {
+        this.state(start - 1);
+        this.render();
+        return this;
+    }
+
+    /**
+     * @override
+     */
+    public convert(math: string, options: OptionList = {}) {
+        const {format, display, end, ex, em, cwidth, lwidth, scale} = userOptions({
+            format: this.inputJax[0].name, display: true, end: STATE.LAST,
+            em: 16, ex: 8, cwidth: 1000000, lwidth: 1000000, scale: 1
+        }, options);
+        const jax = this.inputJax.reduce((jax, ijax) => (ijax.name === format ? ijax : jax), null);
+        const mitem = new this.options.MathItem(math, jax, display);
+        mitem.setMetrics(em, ex, cwidth, lwidth, scale);
+        mitem.convert(this, end);
+        return (mitem.typesetRoot || mitem.root);
     }
 
     /**
@@ -500,7 +797,12 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
 
 /**
  * The constructor type for a MathDocument
+ *
+ * @template D    The MathDocument type this constructor is for
  */
-export type MathDocumentConstructor<N, T, D> = {
-    new (document: any, adaptor: DOMAdaptor<N, T, D>, options: OptionList): AbstractMathDocument<N, T, D>;
+export interface MathDocumentConstructor<D extends MathDocument<any, any, any>> {
+    KIND: string;
+    OPTIONS: OptionList;
+    ProcessBits: typeof BitField;
+    new (...args: any[]): D;
 };

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -161,9 +161,11 @@ export interface MathDocument<N, T, D> {
     /**
      * Rerender the MathItems on the page
      *
+     * @param {number=} start    The state to start rerendering at
+     * @param {number=} end      The state to end rerendering at
      * @return {MathDocument}    The math document instance
      */
-    rerender(): MathDocument<N, T, D>;
+    rerender(start?: number, end?: number): MathDocument<N, T, D>;
 
     /**
      * Clear the processed values so that the document can be reprocessed
@@ -460,10 +462,10 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     /**
      * @override
      */
-    public rerender() {
-        this.state(STATE.PRE_TYPESET);  // reset to just before typesetting
+    public rerender(start: number = STATE.TYPESET, end: number = STATE.LAST) {
+        if (start > end) return;
         for (const math of this.math) {
-            math.rerender(this);
+            math.rerender(this, start, end);
         }
         this.updateDocument();
         return this;

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -330,7 +330,14 @@ export interface MathDocument<N, T, D> {
      */
     rerender(start?: number): MathDocument<N, T, D>;
 
-    convert(math: string, options?: OptionList): MmlNode;
+    /**
+     * Convert a math string to the document's output format
+     *
+     * @param {string} math           The math string to convert
+     * @params {OptionList} optoins   The options for the conversion (e.g., format, ex, em, etc.)
+     * @return {MmlNode|N}            The MmlNode or N node for the converted content
+     */
+    convert(math: string, options?: OptionList): MmlNode | N;
 
     /**
      * Locates the math in the document and constructs the MathList
@@ -753,18 +760,6 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         if (state < STATE.COMPILED) {
             this.processed.clear('compile');
         }
-        return this;
-    }
-
-    /**
-     * @override
-     */
-    public rerender(start: number = STATE.TYPESET, end: number = STATE.LAST) {
-        if (start > end) return;
-        for (const math of this.math) {
-            math.rerender(this, start, end);
-        }
-        this.updateDocument();
         return this;
     }
 

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -154,7 +154,7 @@ export interface MathItem<N, T, D> {
     compile(document: MathDocument<N, T, D>): void;
 
     /**
-     * Converts the internal format to the typeset version by caling the output jax
+     * Converts the internal format to the typeset version by calling the output jax
      *
      * @param {MathDocument} document  The MathDocument in which the math resides
      */
@@ -387,7 +387,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
 /*****************************************************************/
 /**
  * The various states that a MathItem (or MathDocument) can be in
- *   (open-ended to so that extensions can add to it)
+ *   (open-ended so that extensions can add to it)
  */
 export const STATE: {[state: string]: number} = {
     UNPROCESSED: 0,

--- a/mathjax3-ts/core/MathItem.ts
+++ b/mathjax3-ts/core/MathItem.ts
@@ -193,11 +193,18 @@ export interface MathItem<N, T, D> {
      *
      * @param {number} state    The state to set for the expression
      * @param {number} restore  True if the original form should be restored
-     *                           when rolling back a typeset version
+     *                           to the document when rolling back a typeset version
      * @returns {number}        The current state
      */
     state(state?: number, restore?: boolean): number;
 
+    /**
+     * Reset the item to its unprocessed state
+     *
+     * @param {number} restore  True if the original form should be restored
+     *                           to the document when rolling back a typeset version
+     */
+    reset(restore?: boolean): void;
 }
 
 /*****************************************************************/
@@ -368,7 +375,10 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
         return this._state;
     }
 
-    public reset() {
+    /**
+     * @override
+     */
+    public reset(restore: boolean = false) {
         this.state(STATE.UNPROCESSED);
     }
 

--- a/mathjax3-ts/handlers/html/HTMLDocument.ts
+++ b/mathjax3-ts/handlers/html/HTMLDocument.ts
@@ -28,7 +28,7 @@ import {HTMLMathList} from './HTMLMathList.js';
 import {HTMLDomStrings} from './HTMLDomStrings.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 import {InputJax} from '../../core/InputJax.js';
-import {MathItem, ProtoItem, Location} from '../../core/MathItem.js';
+import {MathItem, STATE, ProtoItem, Location} from '../../core/MathItem.js';
 
 /*****************************************************************/
 /**
@@ -60,7 +60,6 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         MathItem: HTMLMathItem,           // Use the HTMLMathItem for MathItem
         DomStrings: null                  // Use the default DomString parser
     };
-    public static STATE = AbstractMathDocument.STATE;
 
     /**
      * The DomString parser for locating the text in DOM trees
@@ -265,5 +264,3 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
 }
 
 AbstractMathDocument.ProcessBits.allocate('TestMath');  // Temporary
-
-let STATE = HTMLDocument.STATE;

--- a/mathjax3-ts/handlers/html/HTMLMathItem.ts
+++ b/mathjax3-ts/handlers/html/HTMLMathItem.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {AbstractMathItem, Location} from '../../core/MathItem.js';
+import {AbstractMathItem, Location, STATE} from '../../core/MathItem.js';
 import {InputJax} from '../../core/InputJax.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 import {HTMLDocument} from './HTMLDocument.js';
@@ -35,8 +35,6 @@ import {HTMLDocument} from './HTMLDocument.js';
  * @template D  The Document class
  */
 export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
-
-    public static STATE = AbstractMathItem.STATE;
 
     /**
      * Easy access to DOM adaptor
@@ -130,5 +128,3 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
     }
 
 }
-
-let STATE = HTMLMathItem.STATE;

--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -107,6 +107,7 @@ CommonMactionMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrappe
                 }
                 mml.nextToggleSelection();
                 math.rerender(document);
+                math.updateDocument(document);
                 event.stopPropagation();
             });
         }, {}]],

--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -107,7 +107,6 @@ CommonMactionMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrappe
                 }
                 mml.nextToggleSelection();
                 math.rerender(document);
-                math.updateDocument(document);
                 event.stopPropagation();
             });
         }, {}]],

--- a/mathjax3-ts/output/svg/Wrappers/maction.ts
+++ b/mathjax3-ts/output/svg/Wrappers/maction.ts
@@ -107,6 +107,7 @@ CommonMactionMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
                 }
                 mml.nextToggleSelection();
                 math.rerender(document);
+                math.updateDocument(document);
                 event.stopPropagation();
             });
         }, {}]],

--- a/mathjax3-ts/output/svg/Wrappers/maction.ts
+++ b/mathjax3-ts/output/svg/Wrappers/maction.ts
@@ -107,7 +107,6 @@ CommonMactionMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
                 }
                 mml.nextToggleSelection();
                 math.rerender(document);
-                math.updateDocument(document);
                 event.stopPropagation();
             });
         }, {}]],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,37 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
-      "dev": true
-    },
-    "@samverschueren/stream-to-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-      "dev": true,
-      "requires": {
-        "any-observable": "^0.3.0"
-      }
-    },
-    "@sindresorhus/is": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-      "dev": true
-    },
     "@webassemblyjs/ast": {
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.6.tgz",
@@ -271,12 +240,6 @@
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -287,12 +250,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
     },
     "anymatch": {
@@ -329,37 +286,10 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1.js": {
@@ -403,18 +333,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "ast-types": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
-      "dev": true
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
@@ -483,24 +401,6 @@
         "trim-right": "^1.0.1"
       }
     },
-    "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
@@ -542,18 +442,6 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "dev": true,
-      "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
         "babel-runtime": "^6.22.0",
         "babel-traverse": "^6.24.1",
         "babel-types": "^6.24.1"
@@ -685,58 +573,10 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-      "dev": true
-    },
-    "babel-plugin-syntax-class-constructor-call": {
-      "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
-      "dev": true
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-      "dev": true
-    },
-    "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-      "dev": true
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
-    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-export-extensions": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
-      "dev": true
-    },
-    "babel-plugin-syntax-flow": {
-      "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -744,17 +584,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
-    },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
-      }
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
@@ -765,42 +594,6 @@
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
         "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-class-constructor-call": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1048,36 +841,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-transform-export-extensions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-flow-strip-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
-      }
-    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1133,74 +896,6 @@
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
-      }
-    },
-    "babel-preset-stage-1": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
-      }
-    },
-    "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
-      }
-    },
-    "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1354,12 +1049,6 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
-    "binaryextensions": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
-      "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==",
-      "dev": true
-    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -1508,28 +1197,6 @@
         "isarray": "^1.0.0"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1540,12 +1207,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtin-status-codes": {
@@ -1592,39 +1253,10 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cacheable-request": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-      "dev": true,
-      "requires": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      },
-      "dependencies": {
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-          "dev": true
-        }
-      }
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
-    },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
       "dev": true
     },
     "caniuse-lite": {
@@ -1645,12 +1277,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
     },
     "chokidar": {
       "version": "2.0.4",
@@ -1721,70 +1347,6 @@
         }
       }
     },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
-      }
-    },
-    "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -1802,15 +1364,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1819,83 +1372,7 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
         }
-      }
-    },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
-    },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-      "dev": true
-    },
-    "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
       }
     },
     "code-point-at": {
@@ -2100,28 +1577,10 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
-    "dargs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
-      "dev": true
-    },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
     "debug": {
@@ -2145,25 +1604,10 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "define-properties": {
@@ -2233,10 +1677,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "detect-conflict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-      "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24=",
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-indent": {
@@ -2265,26 +1709,10 @@
         "randombytes": "^2.0.0"
       }
     },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
-      }
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "duplexify": {
@@ -2299,32 +1727,10 @@
         "stream-shift": "^1.0.0"
       }
     },
-    "editions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
-      "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
-      "dev": true,
-      "requires": {
-        "errlop": "^1.0.3",
-        "semver": "^5.6.0"
-      }
-    },
-    "ejs": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.3.96",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
       "integrity": "sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q==",
-      "dev": true
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "elliptic": {
@@ -2368,29 +1774,6 @@
         "tapable": "^1.0.0"
       }
     },
-    "envinfo": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.12.1.tgz",
-      "integrity": "sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w==",
-      "dev": true
-    },
-    "errlop": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.0.3.tgz",
-      "integrity": "sha512-5VTnt0yikY4LlQEfCXVSqfE6oLj1HVM4zVSvAKMnoYjL/zrb6nqiLowZS4XlG7xENfyj7lpYWvT+wfSCr6dtlA==",
-      "dev": true,
-      "requires": {
-        "editions": "^1.3.4"
-      },
-      "dependencies": {
-        "editions": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-          "dev": true
-        }
-      }
-    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -2398,25 +1781,6 @@
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
-      }
-    },
-    "error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-      "dev": true,
-      "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -2464,12 +1828,6 @@
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.34.tgz",
       "integrity": "sha512-napl1sk7uu4ULhGVWVGIleN2G1TpURvfq5+ALLSc1V4jXcbftCtV8RIOkHw46UnLtzw3xIZgMES39f6N75JhtA=="
     },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
@@ -2508,31 +1866,18 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "expand-brackets": {
@@ -2570,57 +1915,6 @@
         }
       }
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2649,17 +1943,6 @@
             "is-plain-object": "^2.0.4"
           }
         }
-      }
-    },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2733,39 +2016,10 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
-    "fast-glob": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-      "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
-      "dev": true,
-      "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
-      }
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
@@ -2835,21 +2089,6 @@
         }
       }
     },
-    "first-chunk-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "flow-parser": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.88.0.tgz",
-      "integrity": "sha512-wJInZp8NEh9g1MktCH0JzfbKlqgmC7nXwsOlg+bbAEqLlz9fo1EtOaNAKtZAMdZ/FSpxD7cPgbYT8vBGJGjxBQ==",
-      "dev": true
-    },
     "flush-write-stream": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
@@ -2874,15 +2113,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -3554,89 +2784,31 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
     },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
-    },
-    "gh-got": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-      "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-      "dev": true,
-      "requires": {
-        "got": "^7.0.0",
-        "is-plain-obj": "^1.1.0"
-      },
-      "dependencies": {
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "dev": true,
-          "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true
-        },
-        "p-timeout": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-          "dev": true,
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        }
-      }
-    },
-    "github-username": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-      "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-      "dev": true,
-      "requires": {
-        "gh-got": "^6.0.0"
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -3650,69 +2822,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-all": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
-      "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5",
-        "yargs": "~1.2.6"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.1.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "1.2.6",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
-          "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-          "dev": true,
-          "requires": {
-            "minimist": "^0.1.0"
-          }
-        }
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -3735,12 +2844,6 @@
           }
         }
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
     },
     "global-modules": {
       "version": "1.0.0",
@@ -3772,60 +2875,11 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      }
-    },
-    "got": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
-      }
-    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
-    },
-    "grouped-queue": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
-      "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.2"
-      }
     },
     "has": {
       "version": "1.0.1",
@@ -3845,32 +2899,11 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "dev": true,
-      "requires": {
-        "has-symbol-support-x": "^1.4.1"
-      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -3946,40 +2979,19 @@
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
-    },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
-    "http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-      "dev": true
     },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
     },
     "ieee754": {
       "version": "1.1.12",
@@ -3993,32 +3005,74 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
-    "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "dev": true
-    },
     "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
       }
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "indexof": {
@@ -4047,88 +3101,11 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inquirer": {
-      "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
-    },
-    "into-stream": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-      "dev": true,
-      "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
-      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -4140,9 +3117,9 @@
       }
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -4165,12 +3142,6 @@
         }
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -4185,15 +3156,6 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -4244,21 +3206,6 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
-      }
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4323,35 +3270,6 @@
         }
       }
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "^1.1.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "dev": true
-        }
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -4361,24 +3279,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -4386,21 +3286,6 @@
       "dev": true,
       "requires": {
         "has": "^1.0.1"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
-    "is-scoped": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
-      "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-      "dev": true,
-      "requires": {
-        "scoped-regex": "^1.0.0"
       }
     },
     "is-stream": {
@@ -4415,12 +3300,6 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -4432,15 +3311,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "isbinaryfile": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc": "^1.2.0"
-      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -4454,163 +3324,16 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "istextorbinary": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.3.0.tgz",
-      "integrity": "sha512-xs+IFjzw1/5n45nMYUh2ipLWGarmE0bDVR85WAiYUXzawc8NYn1WW0qaq2rSEFIR3NoNkaAvOr3FVMojFz5uUg==",
-      "dev": true,
-      "requires": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.0.2",
-        "textextensions": "^2.4.0"
-      }
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "dev": true,
-      "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
-      }
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "jscodeshift": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
-      "integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-preset-es2015": "^6.9.0",
-        "babel-preset-stage-1": "^6.5.0",
-        "babel-register": "^6.9.0",
-        "babylon": "^7.0.0-beta.47",
-        "colors": "^1.1.2",
-        "flow-parser": "^0.*",
-        "lodash": "^4.13.1",
-        "micromatch": "^2.3.7",
-        "neo-async": "^2.5.0",
-        "node-dir": "0.1.8",
-        "nomnom": "^1.8.1",
-        "recast": "^0.15.0",
-        "temp": "^0.8.1",
-        "write-file-atomic": "^1.2.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        }
-      }
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -4631,15 +3354,6 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
-    "keyv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4647,146 +3361,12 @@
       "dev": true
     },
     "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
-    "listr": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-      "dev": true,
-      "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-          "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-      "dev": true
-    },
-    "listr-update-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.0.0"
-          }
-        }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
+        "invert-kv": "^2.0.0"
       }
     },
     "loader-runner": {
@@ -4828,57 +3408,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "log-update": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
-      }
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4887,12 +3416,6 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -4919,6 +3442,15 @@
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4934,12 +3466,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -4952,90 +3478,14 @@
       }
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "mem-fs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
-      "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.0",
-        "vinyl": "^1.1.0",
-        "vinyl-file": "^2.0.0"
-      }
-    },
-    "mem-fs-editor": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
-      "integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "deep-extend": "^0.6.0",
-        "ejs": "^2.5.9",
-        "glob": "^7.0.3",
-        "globby": "^7.1.1",
-        "isbinaryfile": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "multimatch": "^2.0.0",
-        "rimraf": "^2.2.8",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.1"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "dev": true,
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^1.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "memory-fs": {
@@ -5047,12 +3497,6 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
-    },
-    "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
-      "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
@@ -5089,12 +3533,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -5199,24 +3637,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      }
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
@@ -5253,12 +3673,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-dir": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-      "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
       "dev": true
     },
     "node-libs-browser": {
@@ -5300,53 +3714,6 @@
         }
       }
     },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -5354,17 +3721,6 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
       }
     },
     "npm-run-path": {
@@ -5380,12 +3736,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
@@ -5440,16 +3790,6 @@
         "isobject": "^3.0.0"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -5465,15 +3805,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -5507,14 +3838,14 @@
       "dev": true
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
       }
     },
     "os-tmpdir": {
@@ -5523,20 +3854,11 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "p-cancelable": {
-      "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-      "dev": true
-    },
-    "p-each-series": {
+    "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-      "dev": true,
-      "requires": {
-        "p-reduce": "^1.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5545,15 +3867,9 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-      "dev": true
-    },
-    "p-lazy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
-      "integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
       "dev": true
     },
     "p-limit": {
@@ -5572,27 +3888,6 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
-      }
-    },
-    "p-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-      "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
-      "dev": true
-    },
-    "p-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-      "dev": true
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -5629,45 +3924,6 @@
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-passwd": {
@@ -5717,15 +3973,6 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -5745,21 +3992,6 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -5773,30 +4005,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
-      "dev": true
-    },
-    "pretty-bytes": {
-      "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "private": {
@@ -5888,17 +4096,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -5910,25 +4107,6 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
     },
     "randombytes": {
       "version": "2.0.6",
@@ -5947,37 +4125,6 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "read-chunk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -6006,35 +4153,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "recast": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.15.5.tgz",
-      "integrity": "sha512-nkAYNqarh73cMWRKFiPQ8I9dOLFvFk6SnG8u/LUlOYfArDOD/EjsVRAs860TlBLrpxqAXHGET/AUAVjdEymL5w==",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.11.5",
-        "esprima": "~4.0.0",
-        "private": "~0.1.5",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -6056,15 +4174,6 @@
         "babel-runtime": "^6.18.0",
         "babel-types": "^6.19.0",
         "private": "^0.1.6"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -6138,12 +4247,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6196,25 +4299,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
@@ -6249,15 +4333,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -6265,15 +4340,6 @@
       "dev": true,
       "requires": {
         "aproba": "^1.1.1"
-      }
-    },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -6291,12 +4357,6 @@
         "ret": "~0.1.10"
       }
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
     "sax": {
       "version": "0.4.2",
       "resolved": "http://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
@@ -6311,12 +4371,6 @@
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0"
       }
-    },
-    "scoped-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
-      "dev": true
     },
     "semver": {
       "version": "5.6.0",
@@ -6390,17 +4444,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -6411,18 +4454,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "snapdragon": {
@@ -6532,15 +4563,6 @@
         }
       }
     },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -6579,38 +4601,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
-    },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
     "speech-rule-engine": {
@@ -6708,18 +4698,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6776,25 +4754,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-bom-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
-      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-      "dev": true,
-      "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      }
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -6805,12 +4764,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
     },
     "tapable": {
@@ -6848,36 +4801,6 @@
         }
       }
     },
-    "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "textextensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
-      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6894,12 +4817,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
-    },
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
@@ -6907,15 +4824,6 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -7089,12 +4997,6 @@
         }
       }
     },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-      "dev": true
-    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -7198,12 +5100,6 @@
         }
       }
     },
-    "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
-      "dev": true
-    },
     "upath": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
@@ -7243,21 +5139,6 @@
         }
       }
     },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0"
-      }
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -7284,49 +5165,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
       "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
       "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "vinyl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-      "dev": true,
-      "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
-        "replace-ext": "0.0.1"
-      }
-    },
-    "vinyl-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
-      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -7380,186 +5218,23 @@
         "webpack-sources": "^1.2.0"
       }
     },
-    "webpack-addons": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
-      "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
-      "dev": true,
-      "requires": {
-        "jscodeshift": "^0.4.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "ast-types": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "jscodeshift": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
-          "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
-          "dev": true,
-          "requires": {
-            "async": "^1.5.0",
-            "babel-plugin-transform-flow-strip-types": "^6.8.0",
-            "babel-preset-es2015": "^6.9.0",
-            "babel-preset-stage-1": "^6.5.0",
-            "babel-register": "^6.9.0",
-            "babylon": "^6.17.3",
-            "colors": "^1.1.2",
-            "flow-parser": "^0.*",
-            "lodash": "^4.13.1",
-            "micromatch": "^2.3.7",
-            "node-dir": "0.1.8",
-            "nomnom": "^1.8.1",
-            "recast": "^0.12.5",
-            "temp": "^0.8.1",
-            "write-file-atomic": "^1.2.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "recast": {
-          "version": "0.12.9",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-          "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.10.1",
-            "core-js": "^2.4.1",
-            "esprima": "~4.0.0",
-            "private": "~0.1.5",
-            "source-map": "~0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "webpack-cli": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
-      "integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.2.3.tgz",
+      "integrity": "sha512-Ik3SjV6uJtWIAN5jp5ZuBMWEAaP5E4V78XJ2nI+paFPh8v4HPSwo/myN0r29Xc/6ZKnd2IdrAlpSgNOu2CDQ6Q==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "cross-spawn": "^6.0.5",
-        "diff": "^3.5.0",
-        "enhanced-resolve": "^4.0.0",
-        "envinfo": "^5.7.0",
-        "glob-all": "^3.1.0",
+        "enhanced-resolve": "^4.1.0",
+        "findup-sync": "^2.0.0",
         "global-modules": "^1.0.0",
-        "got": "^8.3.1",
-        "import-local": "^1.0.0",
-        "inquirer": "^5.2.0",
+        "import-local": "^2.0.0",
         "interpret": "^1.1.0",
-        "jscodeshift": "^0.5.0",
-        "listr": "^0.14.1",
         "loader-utils": "^1.1.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "p-each-series": "^1.0.0",
-        "p-lazy": "^1.0.0",
-        "prettier": "^1.12.1",
-        "supports-color": "^5.4.0",
-        "v8-compile-cache": "^2.0.0",
-        "webpack-addons": "^1.1.5",
-        "yargs": "^11.1.0",
-        "yeoman-environment": "^2.1.1",
-        "yeoman-generator": "^2.0.5"
+        "supports-color": "^5.5.0",
+        "v8-compile-cache": "^2.0.2",
+        "yargs": "^12.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7582,11 +5257,26 @@
             "supports-color": "^5.3.0"
           }
         },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
         },
         "supports-color": {
           "version": "5.5.0",
@@ -7647,28 +5337,33 @@
       }
     },
     "wrap-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -7677,17 +5372,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
     },
     "xml-mapping": {
       "version": "1.7.1",
@@ -7727,296 +5411,78 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
         "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
+        "os-locale": "^3.0.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
-      }
-    },
-    "yeoman-environment": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
-      "integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "diff": "^3.5.0",
-        "escape-string-regexp": "^1.0.2",
-        "globby": "^8.0.1",
-        "grouped-queue": "^0.3.3",
-        "inquirer": "^6.0.0",
-        "is-scoped": "^1.0.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.2.0",
-        "mem-fs": "^1.1.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "untildify": "^3.0.3"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-          "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.11",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-              "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.0.0"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            }
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "yeoman-generator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
-      "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.0",
-        "chalk": "^2.3.0",
-        "cli-table": "^0.3.1",
-        "cross-spawn": "^6.0.5",
-        "dargs": "^5.1.0",
-        "dateformat": "^3.0.3",
-        "debug": "^3.1.0",
-        "detect-conflict": "^1.0.0",
-        "error": "^7.0.2",
-        "find-up": "^2.1.0",
-        "github-username": "^4.0.0",
-        "istextorbinary": "^2.2.1",
-        "lodash": "^4.17.10",
-        "make-dir": "^1.1.0",
-        "mem-fs-editor": "^4.0.0",
-        "minimist": "^1.2.0",
-        "pretty-bytes": "^4.0.2",
-        "read-chunk": "^2.1.0",
-        "read-pkg-up": "^3.0.0",
-        "rimraf": "^2.6.2",
-        "run-async": "^2.0.0",
-        "shelljs": "^0.8.0",
-        "text-table": "^0.2.0",
-        "through2": "^2.0.0",
-        "yeoman-environment": "^2.0.5"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
     "webpack": "4.19.0",
-    "webpack-cli": "^2.1.3"
+    "webpack-cli": "^3.2.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR does several things:

1.  It switches from `require()` to `import` in the component control files so that they can be loaded into a browser using System.js (for testing purposes) without having to webpack them first.  So now they can be loaded into node or a browser in either their webpacked or un-webpacked versions.

2.  It adds a number of new components (e.g., explorer and context-menu extensions) and samples.

3.  It moves the code that handled the calls to make for `Typeset()` and the conversion functions from `startup.ts` to `MathItem.ts` and `MathDocument.ts` to make them part of the core code.  There is a new `RenderList` class to manage the actions to take, and these are controlled through the document options (or through direct calls to the list to add and remove items).

    There are several new methods the take advantage of this list, although one can continue to call the rendering methods directly by hand, as before.  There are new `render()` and `convert()` methods, and `rerender()` has been updated to use the render actions list rather than having her-coded calls.  The `render()` method calls the render actions for typesetting (which include measuring the metrics and updating the document), while the `convert()` method takes a math string (in the proper format, TeX or MathML) and converts it to the document's output jax format (HTML or SVG) using the render actions for conversion.

4.  The components no longer need to register typeset and convert calls with the startup module because that is now handled by the extensions themselves.