### PR TITLE
Update a11y and add explorer

### DIFF
--- a/mathjax3-ts/a11y/Explorer.ts
+++ b/mathjax3-ts/a11y/Explorer.ts
@@ -1,8 +1,4 @@
-// import {MathDocument} from '../core/MathDocument.js';
-import {HTMLAdaptor} from '../adaptors/HTMLAdaptor.js';
-import {OptionList} from '../util/Options.js';
 import {A11yDocument, HoverRegion, Region, ToolTip} from './Region.js';
-
 import {sreReady} from './sre.js';
 
 
@@ -65,7 +61,9 @@ export class AbstractExplorer implements Explorer {
     } else {
       event.returnValue = false;
     }
-    if (event.stopPropagation) {
+    if (event.stopImmediatePropagation) {
+      event.stopImmediatePropagation();
+    } else if (event.stopPropagation) {
       event.stopPropagation();
     }
     event.cancelBubble = true;

--- a/mathjax3-ts/a11y/complexity.ts
+++ b/mathjax3-ts/a11y/complexity.ts
@@ -214,6 +214,10 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EnrichedDocumentC
  * @param {Handler} handler   The Handler instance to enhance
  * @param {MathML} MmlJax     The MathML input jax to use for reading the enriched MathML
  * @return {Handler}          The handler that was modified (for purposes of chainging extensions)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
  */
 export function ComplexityHandler<N, T, D>(handler: Handler<N, T, D>, MmlJax: MathML<N, T, D>) {
     handler = EnrichHandler(handler, MmlJax);

--- a/mathjax3-ts/a11y/complexity.ts
+++ b/mathjax3-ts/a11y/complexity.ts
@@ -98,9 +98,16 @@ export function ComplexityMathItemMixin<N, T, D, B extends Constructor<EnrichedM
         /**
          * @override
          */
-        public rerender(document: ComplexityMathDocument<N, T, D>) {
-            super.rerender(document);
-            this.complexity(document);
+        public rerender(document: ComplexityMathDocument<N, T, D>,
+                        start: number = STATE.TYPESET, end: number = STATE.LAST) {
+            const state = STATE.COMPLEXITY;
+            if (start <= state && state <= end) {
+                super.rerender(document, start, STATE.ENRICHED - 1);
+                this.complexity(document);
+                super.rerender(document, state + 1, end);
+            } else {
+                super.rerender(document, start, end);
+            }
         }
 
     };

--- a/mathjax3-ts/a11y/complexity.ts
+++ b/mathjax3-ts/a11y/complexity.ts
@@ -22,7 +22,7 @@
  */
 
 import {Handler} from '../core/Handler.js';
-import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../core/MathDocument.js';
+import {MathDocumentConstructor} from '../core/MathDocument.js';
 import {MathItem, STATE, newState} from '../core/MathItem.js';
 import {MathML} from '../input/mathml.js';
 import {MmlNode, AbstractMmlTokenNode} from '../core/MmlTree/MmlNode.js';
@@ -57,9 +57,9 @@ newState('COMPLEXITY', 40);
 export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
 
     /**
-     * @param {MathDocument} docuemnt   The MathDocument for the MathItem
+     * @param {ComplexityMathDocument} docuemnt   The MathDocument for the MathItem
      */
-    complexity(document: MathDocument<N, T, D>): void;
+    complexity(document: ComplexityMathDocument<N, T, D>): void;
 
 }
 
@@ -82,9 +82,9 @@ export function ComplexityMathItemMixin<N, T, D, B extends Constructor<EnrichedM
     return class extends BaseMathItem {
 
         /**
-         * @param {MathDocument} docuemnt   The MathDocument for the MathItem
+         * @param {ComplexityMathDocument} docuemnt   The MathDocument for the MathItem
          */
-        public complexity(document: MathDocument<N, T, D>) {
+        public complexity(document: ComplexityMathDocument<N, T, D>) {
             if (this.state() < STATE.COMPLEXITY) {
                 this.enrich(document);
                 computeComplexity(this.root);
@@ -109,9 +109,9 @@ export interface ComplexityMathDocument<N, T, D> extends EnrichedMathDocument<N,
     /**
      * Perform complexity computations on the MathItems in the MathDocument
      *
-     * @return {MathDocument}   The MathDocument (so calls can be chained)
+     * @return {ComplexityMathDocument}   The MathDocument (so calls can be chained)
      */
-    complexity(): MathDocument<N, T, D>;
+    complexity(): ComplexityMathDocument<N, T, D>;
 }
 
 /**
@@ -158,7 +158,7 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EnrichedDocumentC
          */
         constructor(...args: any[]) {
             super(...args);
-            const ProcessBits = (this.constructor as typeof AbstractMathDocument).ProcessBits;
+            const ProcessBits = (this.constructor as typeof BaseDocument).ProcessBits;
             if (!ProcessBits.has('complexity')) {
                 ProcessBits.allocate('complexity');
             }
@@ -212,8 +212,10 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EnrichedDocumentC
  * @template T  The Text node class
  * @template D  The Document class
  */
-export function ComplexityHandler<N, T, D>(handler: Handler<N, T, D>, MmlJax: MathML<N, T, D>) {
-    handler = EnrichHandler(handler, MmlJax);
+export function ComplexityHandler<N, T, D>(handler: Handler<N, T, D>, MmlJax: MathML<N, T, D> = null) {
+    if (!handler.documentClass.prototype.enrich && MmlJax) {
+        handler = EnrichHandler(handler, MmlJax);
+    }
     handler.documentClass =
         ComplexityMathDocumentMixin<N, T, D, EnrichedDocumentConstructor<N, T, D>>(handler.documentClass as any);
     return handler;

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -195,7 +195,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
 
         /**
          * Extend the MathItem class used for this MathDocument
-         *   and create the visitor and exporer objects needed for the explorer
+         *   and create the visitor and explorer objects needed for the explorer
          *
          * @override
          * @constructor
@@ -220,6 +220,8 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
 
         /**
          * Add the Explorer to the MathItems in this MathDocument
+         *
+         * @return {ExplorerMathDocument}   The MathDocument (so calls can be chained)
          */
         public explorable() {
             if (!this.processed.isSet('explorer')) {
@@ -252,6 +254,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
  * Add Explorer functions to a Handler instance
  *
  * @param {Handler} handler   The Handler instance to enhance
+ * @param {MathML} MmlJax     A MathML input jax to be used for the semantic enrichment
  * @returns {Handler}         The handler that was modified (for purposes of chainging extensions)
  */
 export function ExplorerHandler(handler: HANDLER, MmlJax: MATHML = null) {

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -1,0 +1,203 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Mixin that implements the Explorer
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {MathJax} from '../mathjax.js';
+import {Handler} from '../core/Handler.js';
+import {MmlNode} from '../core/MmlTree/MmlNode.js';
+import {HTMLDocument} from '../handlers/html/HTMLDocument.js';
+import {HTMLMathItem} from '../handlers/html/HTMLMathItem.js';
+import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
+
+import {SpeechExplorer, Magnifier} from './explorer/Explorer.js';
+import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
+import {sreReady} from './sre.js';
+
+/**
+ * Generic constructor for Mixins
+ */
+export type Constructor<T> = new(...args: any[]) => T;
+
+export type HANDLER = Handler<HTMLElement, Text, Document>;
+export type HTMLDOCUMENT = HTMLDocument<HTMLElement, Text, Document>;
+export type HTMLMATHITEM = HTMLMathItem<HTMLElement, Text, Document>;
+
+/*==========================================================================*/
+
+/**
+ * The properties added to MathItem for the Explorer
+ */
+export interface ExplorerMathItem extends HTMLMATHITEM {
+
+    /**
+     * True when this MathItem has already had the Explorer added to it
+     */
+    hasExplorer: boolean;
+
+    /**
+     * @param {HTMLDocument} document  The document where the Explorer is being added
+     */
+    explorable(document: HTMLDOCUMENT): void;
+}
+
+/**
+ * The mixin for adding the Explorer to MathItems
+ *
+ * @param {B} BaseMathItem      The MathItem class to be extended
+ * @param {Function} toMathML   The function to serialize the internal MathML
+ * @returns {ExplorerMathItem}  The Explorer MathItem class
+ *
+ * @template B  The MathItem class to extend
+ */
+export function ExplorerMathItemMixin(
+    BaseMathItem: Constructor<HTMLMATHITEM>,
+    toMathML: (node: MmlNode) => string
+): Constructor<ExplorerMathItem> {
+
+    return class extends BaseMathItem {
+
+        /**
+         * True when this MathItem has already had the Explorer added to it
+         */
+        public hasExplorer: boolean = false;
+
+        /**
+         * Add the explorer to the output for this math item
+         *
+         * @param {HTMLDocument} docuemnt   The MathDocument for the MathItem
+         */
+        public explorable(document: ExplorerMathDocument) {
+            if (this.hasExplorer) return;
+            if (!(sre && sre.Engine.isReady())) {
+                MathJax.retryAfter(sreReady);
+            }
+            const node = this.typesetRoot;
+            const mml = toMathML(this.root);
+            SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
+            this.hasExplorer = true;
+        }
+
+    };
+
+}
+
+/*==========================================================================*/
+
+/**
+ * The objects needed for the explorer
+ */
+export type ExplorerObjects = {
+    region?: LiveRegion,
+    tooltip?: ToolTip,
+    tooltip2?: ToolTip,
+    tooltip3?: ToolTip,
+    magnifier?: HoverRegion
+}
+
+/**
+ * The funtions added to MathDocument for the Explorer
+ */
+export interface ExplorerMathDocument extends HTMLDOCUMENT {
+
+    /**
+     * The objects needed for the explorer
+     */
+    explorerObjects: ExplorerObjects;
+
+    /**
+     * Add the Explorer to the MathItems in the MathDocument
+     *
+     * @returns {MathDocument}   The MathDocument (so calls can be chained)
+     */
+    explorable(): HTMLDOCUMENT;
+
+}
+
+/**
+ * The mixin for adding the Explorer to MathDocuments
+ *
+ * @param {B} BaseMathDocument      The MathDocument class to be extended
+ * @returns {ExplorerMathDocument}  The extended MathDocument class
+ */
+export function ExplorerMathDocumentMixin(BaseDocument: Constructor<HTMLDOCUMENT>): Constructor<ExplorerMathDocument> {
+
+    return class extends BaseDocument {
+
+        /**
+         * The objects needed for the explorer
+         */
+        public explorerObjects: ExplorerObjects;
+
+        /**
+         * Extend the MathItem class used for this MathDocument
+         *   and create the visitor and exporer objects needed for the explorer
+         *
+         * @override
+         * @constructor
+         */
+        constructor(...args: any[]) {
+            super(...args);
+            const ProcessBits = (this.constructor as typeof HTMLDocument).ProcessBits;
+            if (!ProcessBits.has('explorer')) {
+                ProcessBits.allocate('explorer');
+            }
+            const visitor = new SerializedMmlVisitor(this.mmlFactory);
+            const toMathML = ((node: MmlNode) => visitor.visitTree(node));
+            this.options.MathItem = ExplorerMathItemMixin(this.options.MathItem, toMathML);
+            this.explorerObjects = {
+                region: new LiveRegion(this),
+                tooltip: new ToolTip(this),
+                tooltip2: new ToolTip(this),
+                tooltip3: new ToolTip(this),
+                magnifier: new HoverRegion(this)
+            };
+        }
+
+        /**
+         * Add the Explorer to the MathItems in this MathDocument
+         */
+        public explorable() {
+            if (!this.processed.isSet('explorer')) {
+                for (const math of this.math) {
+                    (math as ExplorerMathItem).explorable(this);
+                }
+                this.processed.set('explorer');
+            }
+            return this;
+        }
+
+    };
+
+}
+
+/*==========================================================================*/
+
+/**
+ * Add Explorer functions to a Handler instance
+ *
+ * @param {Handler} handler   The Handler instance to enhance
+ * @returns {Handler}         The handler that was modified (for purposes of chainging extensions)
+ */
+export function ExplorerHandler(handler: Handler<HTMLElement, Text, Document>) {
+    handler.documentClass = ExplorerMathDocumentMixin(handler.documentClass as any);
+    return handler;
+}

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -222,9 +222,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
   }
 
   private initWalker() {
+    const jax = this.document.outputJax.name;
     this.highlighter = sre.HighlighterFactory.highlighter(
       this.background, this.foreground,
-      {renderer: this.document.outputJax.name}
+      {renderer: jax === 'CHTML' ? 'CommonHTML' : jax}
     );
     // Add speech
     this.speechGenerator = new sre.TreeSpeechGenerator();

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -1,5 +1,5 @@
 import {A11yDocument, HoverRegion, Region, ToolTip} from './Region.js';
-import {sreReady} from './sre.js';
+import {sreReady} from '../sre.js';
 
 
 export interface Explorer {

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -23,10 +23,10 @@
  */
 
 
-import {HTMLDocument} from '../handlers/html/HTMLDocument.js';
-import {CssStyles, StyleList} from '../output/common/CssStyles.js';
+import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
+import {CssStyles, StyleList} from '../../output/common/CssStyles.js';
 
-import './sre.js';
+import '../sre.js';
 
 export type A11yDocument = HTMLDocument<HTMLElement, Text, Document>;
 

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -23,12 +23,12 @@
  */
 
 
-import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
+import {MathDocument} from '../../core/MathDocument.js';
 import {CssStyles, StyleList} from '../../output/common/CssStyles.js';
 
 import '../sre.js';
 
-export type A11yDocument = HTMLDocument<HTMLElement, Text, Document>;
+export type A11yDocument = MathDocument<HTMLElement, Text, Document>;
 
 export interface Region {
 

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -105,6 +105,20 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
             this.state(STATE.ENRICHED);
         }
 
+        /**
+         * @override
+         */
+        public rerender(document: MathDocument<N, T, D>, start: number = STATE.TYPESET, end: number = STATE.LAST) {
+            const state = STATE.ENRICHED;
+            if (start <= state && state <= end) {
+                super.rerender(document, start, state);
+                this.enrich(document);
+                super.rerender(document, state + 1, end);
+            } else {
+                super.rerender(document, start, end);
+            }
+        }
+
     };
 
 }

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -206,6 +206,10 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends Constructor<Abstrac
  * @param {Handler} handler   The Handler instance to enhance
  * @param {MathML} MmlJax     The MathML input jax to use for reading the enriched MathML
  * @return {Handler}          The handler that was modified (for purposes of chainging extensions)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
  */
 export function EnrichHandler<N, T, D>(handler: Handler<N, T, D>, MmlJax: MathML<N, T, D>) {
     MmlJax.setAdaptor(handler.adaptor);

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -67,7 +67,8 @@ export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
  * The mixin for adding enrichment to MathItems
  *
  * @param {B} BaseMathItem     The MathItem class to be extended
- * @param {MathML} MmlJax          The MathML input jax used to convert the enriched MathML
+ * @param {MathML} MmlJax      The MathML input jax used to convert the enriched MathML
+ * @param {Function} toMathML  The function serialize the internal MathML
  * @return {EnrichedMathItem}  The enriched MathItem class
  *
  * @template N  The HTMLElement node class

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -72,7 +72,7 @@ export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
  *
  * @param {B} BaseMathItem     The MathItem class to be extended
  * @param {MathML} MmlJax      The MathML input jax used to convert the enriched MathML
- * @param {Function} toMathML  The function serialize the internal MathML
+ * @param {Function} toMathML  The function to serialize the internal MathML
  * @return {EnrichedMathItem}  The enriched MathItem class
  *
  * @template N  The HTMLElement node class

--- a/mathjax3-ts/a11y/sre.ts
+++ b/mathjax3-ts/a11y/sre.ts
@@ -24,8 +24,6 @@
 
 import {asyncLoad} from '../util/AsyncLoad.js';
 
-declare const window: Window;
-
 /**
  * The name of the modiule to load, if necessary
  */


### PR DESCRIPTION
This PR adds an explorer extension that uses the proper mechanism for extending the handler, document, and math item classes.  It also updates the existing extensions to register themselves with the new render-action list, and hook into the `STATE` values properly.