### PR TITLE
Context menu

### DIFF
--- a/mathjax3-ts/ui/menu/MJContextMenu.ts
+++ b/mathjax3-ts/ui/menu/MJContextMenu.ts
@@ -1,13 +1,60 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements a subclass of ContextMenu specific to MathJax
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
 import {MathItem} from '../../core/MathItem.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import '../../../../context-menu/scripts/js/context_menu.js';
 import {SelectableInfo} from './SelectableInfo.js';
 
+/*==========================================================================*/
+
+/**
+ * The data needed to define a menu
+ */
 export type MenuJSON = {menu: {pool: Array<Object>, items: Array<Object>, id: string}};
+
+/**
+ * The data for a variable in the variable pool
+ */
 export type PoolItem = {name: string, getter: () => string | boolean, setter: (x: (string | boolean)) => void};
 
+/*==========================================================================*/
+
+/**
+ * The subclass of ContextMenu that handles the needs of the MathJax
+ *   contextual menu (in particular, tying it to a MathItem).
+ */
 export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
 
+    /**
+     * @param {MenuJSON} menu     Create a menu object from a menu definition
+     * @returns {MJContextMenu}   The MJContextMenu created from the definition
+     *
+     * @override
+     *
+     * NOTE:  If the original used "new this()" rather than "new ContextMenu()",
+     *        we would not have to override it.
+     */
     public static parse({menu}: MenuJSON): ContextMenu.ContextMenu {
         if (!menu) {
             ContextMenu.MenuUtil.error(null, 'Wrong JSON format for menu.');
@@ -23,15 +70,41 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         return ctxtMenu;
     }
 
+    /*======================================================================*/
+
+    /**
+     * The MathItem that has posted the menu
+     */
     public mathItem: MathItem<N, T, D> = null;
 
+    /**
+     * The annotation selected in the Annotation submenu (neede for the info box to be able to show it)
+     */
     public annotation: string = '';
 
+    /**
+     * The info box for showing annotations (created by the Menu object that contains this MJContextMenu)
+     */
     public showAnnotation: SelectableInfo;
+
+    /**
+     * The function to copy the selected annotation (set by the containing Menu item)
+     */
     public copyAnnotation: () => void;
 
+    /**
+     * The annotation types to look for in a MathItem
+     */
     public annotationTypes: {[type: string]: string[]} = {};
 
+    /*======================================================================*/
+
+    /**
+     * Before posting the menu, set the name for the ShowAs and CopyToClipboard menus,
+     *   enable/disable the semantics check item, and get the annotations for the MathItem
+     *
+     * @override
+     */
     public post(x?:any, y?: number) {
         if (this.mathItem) {
             if (y !== undefined) {
@@ -49,11 +122,24 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         }
     }
 
+    /**
+     * Clear the stored MathItem when the menu is removed
+     *
+     * @override
+     */
     public unpost() {
         super.unpost();
         this.mathItem = null;
     }
 
+    /*======================================================================*/
+
+    /**
+     * Find an item in the menu (recursively descending into submenus, if needed)
+     *
+     * @param {string[]} names   The menu IDs to look for
+     * @returns {string}         The menu item (or null if not found)
+     */
     public findID(...names: string[]) {
         let menu = this as ContextMenu.Menu;
         let item = null as ContextMenu.Item;
@@ -68,12 +154,22 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         return item;
     }
 
+    /*======================================================================*/
+
+    /**
+     * Look up the annotations in the MathItem and set the ShowAs and CopyToClipboard menus
+     */
     protected getAnnotationMenu() {
         const annotations = this.getAnnotations(this.getSemanticNode());
         this.createAnnotationMenu('Show', annotations, () => this.showAnnotation.post());
         this.createAnnotationMenu('Copy', annotations, () => this.copyAnnotation());
     }
 
+    /**
+     * Find the top-most semantics element that encloses the contents of the expression (if any)
+     *
+     * @returns {MmlNode}   The semantics node that was found
+     */
     protected getSemanticNode() {
         let node: MmlNode = this.mathItem.root;
         while (node && !node.isKind('semantics'))  {
@@ -83,6 +179,11 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         return node;
     }
 
+    /**
+     * @param {MmlNode} node           The semantics node whose annotations are to be obtained
+     * @returns {[string, string][]}   Array of [type, text] where the type is the annotation type
+     *                                   and text is the content of the annotation of that type
+     */
     protected getAnnotations(node: MmlNode) {
         const annotations = [] as [string, string][];
         if (!node) return annotations;
@@ -98,6 +199,10 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         return annotations;
     }
 
+    /**
+     * @param {MmlNode} child    The annotation node to check if its encoding is one of the displayable ones
+     * @returns {string}         The annotation type if it does, or null iof it doesn't
+     */
     protected annotationMatch(child: MmlNode) {
         const encoding = child.attributes.get('encoding') as string;
         for (const type of Object.keys(this.annotationTypes)) {
@@ -108,6 +213,13 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
         return null;
     }
 
+    /**
+     * Create a submenu from the available annotations and attach it to the proper menu item
+     *
+     * @param {string} id                        The id of the menu to attach to (Show or Copy)
+     * @param {[string, string][]} annotations   The annotations to use for the submenu
+     * @param {() => void} action                The action to perform when the annotation is selected
+     */
     protected createAnnotationMenu(id: string, annotations: [string, string][], action: () => void) {
         const menu = this.findID(id, 'Annotation') as ContextMenu.Submenu;
         menu.setSubmenu(ContextMenu.SubMenu.parse({
@@ -130,6 +242,8 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
             menu.disable();
         }
     }
+
+    /*======================================================================*/
 
 }
 

--- a/mathjax3-ts/ui/menu/MJContextMenu.ts
+++ b/mathjax3-ts/ui/menu/MJContextMenu.ts
@@ -29,48 +29,10 @@ import {SelectableInfo} from './SelectableInfo.js';
 /*==========================================================================*/
 
 /**
- * The data needed to define a menu
- */
-export type MenuJSON = {menu: {pool: Array<Object>, items: Array<Object>, id: string}};
-
-/**
- * The data for a variable in the variable pool
- */
-export type PoolItem = {name: string, getter: () => string | boolean, setter: (x: (string | boolean)) => void};
-
-/*==========================================================================*/
-
-/**
  * The subclass of ContextMenu that handles the needs of the MathJax
  *   contextual menu (in particular, tying it to a MathItem).
  */
 export class MJContextMenu extends ContextMenu.ContextMenu {
-
-    /**
-     * @param {MenuJSON} menu     Create a menu object from a menu definition
-     * @returns {MJContextMenu}   The MJContextMenu created from the definition
-     *
-     * @override
-     *
-     * NOTE:  If the original used "new this()" rather than "new ContextMenu()",
-     *        we would not have to override it.
-     */
-    public static parse({menu}: MenuJSON): ContextMenu.ContextMenu {
-        if (!menu) {
-            ContextMenu.MenuUtil.error(null, 'Wrong JSON format for menu.');
-            return;
-        }
-        const {pool, items, id} = menu;
-        const ctxtMenu = new this();
-        const menuPool = ctxtMenu.getPool();
-        pool.forEach(({name, getter, setter}: PoolItem) => {
-            menuPool.insert(new ContextMenu.Variable(name, getter, setter));
-        });
-        ctxtMenu.parseItems(items);
-        return ctxtMenu;
-    }
-
-    /*======================================================================*/
 
     /**
      * The MathItem that has posted the menu
@@ -201,7 +163,7 @@ export class MJContextMenu extends ContextMenu.ContextMenu {
 
     /**
      * @param {MmlNode} child    The annotation node to check if its encoding is one of the displayable ones
-     * @returns {string}         The annotation type if it does, or null iof it doesn't
+     * @returns {string}         The annotation type if it does, or null if it doesn't
      */
     protected annotationMatch(child: MmlNode) {
         const encoding = child.attributes.get('encoding') as string;

--- a/mathjax3-ts/ui/menu/MJContextMenu.ts
+++ b/mathjax3-ts/ui/menu/MJContextMenu.ts
@@ -1,5 +1,7 @@
 import {MathItem} from '../../core/MathItem.js';
+import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import '../../../../context-menu/scripts/js/context_menu.js';
+import {SelectableInfo} from './SelectableInfo.js';
 
 export type MenuJSON = {menu: {pool: Array<Object>, items: Array<Object>, id: string}};
 export type PoolItem = {name: string, getter: () => string | boolean, setter: (x: (string | boolean)) => void};
@@ -23,17 +25,26 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
 
     public mathItem: MathItem<N, T, D> = null;
 
+    public annotation: string = '';
+
+    public showAnnotation: SelectableInfo;
+    public copyAnnotation: () => void;
+
+    public annotationTypes: {[type: string]: string[]} = {};
+
     public post(x?:any, y?: number) {
         if (this.mathItem) {
-            // FIXME:  look for annotations
-            // FIXME:  handle error output jax
-            const input = this.mathItem.inputJax.name;
-            const original = this.findID('Show', 'Original');
-            original.content = (input === 'MathML' ? 'Original MathML' : input + ' Commands');
-            const clipboard = this.findID('Copy', 'Original');
-            clipboard.content = original.content;
-            const semantics = this.findID('Settings', 'semantics');
-            input === 'MathML' ? semantics.disable() : semantics.enable();
+            if (y !== undefined) {
+                // FIXME:  handle error output jax
+                const input = this.mathItem.inputJax.name;
+                const original = this.findID('Show', 'Original');
+                original.content = (input === 'MathML' ? 'Original MathML' : input + ' Commands');
+                const clipboard = this.findID('Copy', 'Original');
+                clipboard.content = original.content;
+                const semantics = this.findID('Settings', 'semantics');
+                input === 'MathML' ? semantics.disable() : semantics.enable();
+                this.getAnnotationMenu();
+            }
             super.post(x, y);
         }
     }
@@ -55,6 +66,69 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
             }
         }
         return item;
+    }
+
+    protected getAnnotationMenu() {
+        const annotations = this.getAnnotations(this.getSemanticNode());
+        this.createAnnotationMenu('Show', annotations, () => this.showAnnotation.post());
+        this.createAnnotationMenu('Copy', annotations, () => this.copyAnnotation());
+    }
+
+    protected getSemanticNode() {
+        let node: MmlNode = this.mathItem.root;
+        while (node && !node.isKind('semantics'))  {
+            if (node.isToken || node.childNodes.length !== 1) return;
+            node = node.childNodes[0] as MmlNode;
+        }
+        return node;
+    }
+
+    protected getAnnotations(node: MmlNode) {
+        const annotations = [] as [string, string][];
+        if (!node) return annotations;
+        for (const child of node.childNodes as MmlNode[]) {
+            if (child.isKind('annotation')) {
+                const match = this.annotationMatch(child);
+                if (match) {
+                    const value = child.childNodes.reduce((text, chars) => text + chars.toString(), '');
+                    annotations.push([match, value]);
+                }
+            }
+        }
+        return annotations;
+    }
+
+    protected annotationMatch(child: MmlNode) {
+        const encoding = child.attributes.get('encoding') as string;
+        for (const type of Object.keys(this.annotationTypes)) {
+            if (this.annotationTypes[type].indexOf(encoding) >= 0) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    protected createAnnotationMenu(id: string, annotations: [string, string][], action: () => void) {
+        const menu = this.findID(id, 'Annotation') as ContextMenu.Submenu;
+        menu.setSubmenu(ContextMenu.SubMenu.parse({
+            items: annotations.map(([type, value]) => {
+                return {
+                    type: 'command',
+                    id: type,
+                    content: type,
+                    action: () => {
+                        this.annotation = value;
+                        action();
+                    }
+                };
+            }),
+            id: 'annotations'
+        }, menu));
+        if (annotations.length) {
+            menu.enable();
+        } else {
+            menu.disable();
+        }
     }
 
 }

--- a/mathjax3-ts/ui/menu/MJContextMenu.ts
+++ b/mathjax3-ts/ui/menu/MJContextMenu.ts
@@ -1,0 +1,61 @@
+import {MathItem} from '../../core/MathItem.js';
+import '../../../../context-menu/scripts/js/context_menu.js';
+
+export type MenuJSON = {menu: {pool: Array<Object>, items: Array<Object>, id: string}};
+export type PoolItem = {name: string, getter: () => string | boolean, setter: (x: (string | boolean)) => void};
+
+export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
+
+    public static parse({menu}: MenuJSON): ContextMenu.ContextMenu {
+        if (!menu) {
+            ContextMenu.MenuUtil.error(null, 'Wrong JSON format for menu.');
+            return;
+        }
+        const {pool, items, id} = menu;
+        const ctxtMenu = new this();
+        const menuPool = ctxtMenu.getPool();
+        pool.forEach(({name, getter, setter}: PoolItem) => {
+            menuPool.insert(new ContextMenu.Variable(name, getter, setter));
+        });
+        ctxtMenu.parseItems(items);
+        return ctxtMenu;
+    }
+
+    public mathItem: MathItem<N, T, D> = null;
+
+    public post(x?:any, y?: number) {
+        if (this.mathItem) {
+            // FIXME:  look for annotations
+            // FIXME:  handle error output jax
+            const input = this.mathItem.inputJax.name;
+            const original = this.findID('Show', 'Original');
+            original.content = (input === 'MathML' ? 'Original MathML' : input + ' Commands');
+            const clipboard = this.findID('Copy', 'Original');
+            clipboard.content = original.content;
+            const semantics = this.findID('Settings', 'semantics');
+            input === 'MathML' ? semantics.disable() : semantics.enable();
+            super.post(x, y);
+        }
+    }
+
+    public unpost() {
+        super.unpost();
+        this.mathItem = null;
+    }
+
+    public findID(...names: string[]) {
+        let menu = this as ContextMenu.Menu;
+        let item = null as ContextMenu.Item;
+        for (const name of names) {
+            if (menu) {
+                item = menu.find(name);
+                menu = (item instanceof ContextMenu.Submenu ? item.getSubmenu() : null);
+            } else {
+                item = null;
+            }
+        }
+        return item;
+    }
+
+}
+

--- a/mathjax3-ts/ui/menu/MJContextMenu.ts
+++ b/mathjax3-ts/ui/menu/MJContextMenu.ts
@@ -44,7 +44,7 @@ export type PoolItem = {name: string, getter: () => string | boolean, setter: (x
  * The subclass of ContextMenu that handles the needs of the MathJax
  *   contextual menu (in particular, tying it to a MathItem).
  */
-export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
+export class MJContextMenu extends ContextMenu.ContextMenu {
 
     /**
      * @param {MenuJSON} menu     Create a menu object from a menu definition
@@ -75,7 +75,7 @@ export class MJContextMenu<N, T, D> extends ContextMenu.ContextMenu {
     /**
      * The MathItem that has posted the menu
      */
-    public mathItem: MathItem<N, T, D> = null;
+    public mathItem: MathItem<HTMLElement, Text, Document> = null;
 
     /**
      * The annotation selected in the Annotation submenu (neede for the info box to be able to show it)

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -622,7 +622,7 @@ export class Menu {
     protected setExplorer(explore: boolean) {
         this.enableExplorerItems(explore);
         if (!explore || (window.MathJax._.a11y && window.MathJax._.a11y.explorer)) {
-            this.rerender();
+            this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED);
         } else {
             this.loadA11y('explorer');
         }

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -610,7 +610,7 @@ export class Menu {
     }
 
     /**
-     * @param {boolean} tab   True for including math in the tab other, false for not
+     * @param {boolean} tab   True for including math in the tab order, false for not
      */
     protected setTabOrder(tab: boolean) {
         this.menu.getStore().inTaborder(tab);

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -1,0 +1,428 @@
+import {MathJax} from '../../mathjax.js';
+
+import {MathItem} from '../../core/MathItem.js';
+import {OutputJax} from '../../core/OutputJax.js';
+import {MathJaxObject as StartupObject} from '../../components/startup.js';
+import {MathJaxObject as LoaderObject} from '../../components/loader.js';
+import {OptionList, userOptions, defaultOptions} from '../../util/Options.js';
+
+import {MJContextMenu} from './MJContextMenu.js';
+import {MmlVisitor} from './MmlVisitor.js';
+import {SelectableInfo} from './SelectableInfo.js';
+import {MenuMathDocument} from './MenuHandler.js';
+
+const isMac = false;
+
+declare namespace window {
+    const MathJax: StartupObject & LoaderObject;
+}
+
+export interface MenuSettings {
+    texHints: boolean;
+    semantics: boolean;
+    zoom: string;
+    zscale: string;
+    renderer: string;
+    alt: boolean;
+    cmd: boolean;
+    ctrl: boolean;
+    shift: boolean;
+    scale: number;
+    explorer: boolean;
+    autocollapse: boolean;
+    collapsible: boolean;
+    inTabOrder: boolean;
+}
+
+export class Menu<N, T, D> {
+
+    public static OPTIONS: OptionList = {
+        settings: {
+            texHints: true,
+            semantics: false,
+            zoom: 'NoZoom',
+            zscale: '200%',
+            renderer: 'CHTML',
+            alt: false,
+            cmd: false,
+            ctrl: false,
+            shift: false,
+            scale: 1,
+            explorer: false,
+            autocollapse: false,
+            collapsible: false,
+            inTabOrder: true,
+        },
+        jax: {
+            CHTML: null,
+            SVG: null
+        }
+    };
+
+    public options: OptionList;
+
+    public settings: MenuSettings = null;
+
+    public zscale: number = 1.25 * 200;
+
+    public menu: MJContextMenu<N, T, D> = null;
+
+    public MmlVisitor = new MmlVisitor<N, T, D>();
+
+    protected document: MenuMathDocument<N, T, D>;
+
+    protected jax: {[name: string]: OutputJax<N, T, D>} = {
+        CHTML: null,
+        SVG: null
+    };
+
+    protected about = new ContextMenu.Info(
+        '<b style="font-size:120%;">MathJax</b> v' + MathJax.version,
+        () => {
+            const lines = [] as string[];
+            lines.push('Input Jax: ' + this.document.inputJax.map(jax => jax.name).join(', '));
+            lines.push('Output Jax: ' + this.document.outputJax.name);
+            lines.push('Document Type: ' + this.document.kind);
+            return lines.join('<br/>');
+        },
+        '<a href="https://www.mathjax.org">www.mathjax.org</a>'
+    );
+
+    protected help = new ContextMenu.Info(
+        '<b>MathJax Help</b>',
+        () => {
+            return [
+                '<p><b>MathJax</b> is a JavaScript library that allows page',
+                ' authors to include mathematics within their web pages.',
+                ' As a reader, you don\'t need to do anything to make that happen.</p>',
+                '<p><b>Browsers</b>: MathJax works with all modern browsers including',
+                ' Edge, Firefox, Chrome, Safari, Opera, and most mobile browsers.</p>',
+                '<p><b>Math Menu</b>: MathJax adds a contextual menu to equations.',
+                ' Right-click or CTRL-click on any mathematics to access the menu.</p>',
+                '<div style="margin-left: 1em;">',
+                '<p><b>Show Math As</b> allows you to view the formula\'s source markup',
+                ' for copy &amp; paste (as MathML or in its original format).</p>',
+                '<p><b>Math Settings</b> gives you control over features of MathJax, such as',
+                ' the size of the mathematics, and the mechanism used',
+                ' to display equations.</p>',
+                '<p><b>Accessibility</b>: MathJax can work with screen',
+                ' readers to make mathematics accessible to the visually impaired.',
+                ' Turn on the explorer to enable generation of speech strings',
+                ' and the ability to investigate expressions interactively.</p>',
+                '<p><b>Language</b> lets you select the language used by MathJax for',
+                ' its menus and warning messages. (Not yet implemented.)</p>',
+                '</div>',
+                '<p><b>Math Zoom</b>: If you are having difficulty reading an',
+                ' equation, MathJax can enlarge it to help you see it better, or',
+                ' you can scall all the math on the page to make it larger.',
+                ' Turn these features on in the <b>Math Settings</b> menu.</p>'
+            ]. join('\n');
+        },
+        '<a href="https://www.mathjax.org">www.mathjax.org</a>'
+    );
+
+    protected mathmlCode = new SelectableInfo(
+        'MathJax MathML Expression',
+        () => {
+            if (!this.menu.mathItem) return '';
+            const text = this.toMML(this.menu.mathItem);
+            return '<pre>' + this.formatSource(text) + '</pre>';
+        },
+        '<input type="button" value="Copy to Clipboard" />'
+    );
+
+    protected originalText = new SelectableInfo(
+        'MathJax original Source',
+        () => {
+            if (!this.menu.mathItem) return '';
+            const text = this.menu.mathItem.math;
+            return '<pre style="font-size:125%; margin:0">' + this.formatSource(text) + '</pre>';
+        },
+        '<input type="button" value="Copy to Clipboard" />'
+    );
+
+    protected zoomBox = new ContextMenu.Info(
+        'MathJax Zoomed Expression',
+        () => {
+            if (!this.menu.mathItem) return '';
+            const element = (this.menu.mathItem.typesetRoot as any).cloneNode(true) as HTMLElement;
+            element.style.margin = '0';
+            return '<div style="font-size: ' + this.zscale + '%">' + element.outerHTML + '</div>';
+        },
+        ''
+    );
+
+    constructor(document: MenuMathDocument<N, T, D>, options: OptionList = {}) {
+        this.document = document;
+        this.options = userOptions(defaultOptions({}, (this.constructor as typeof Menu).OPTIONS), options);
+        this.initSettings();
+        this.initMenu();
+    }
+
+    protected initSettings() {
+        this.settings = this.options.settings);
+        this.jax = this.options.jax;
+        const jax = this.document.outputJax;
+        this.jax[jax.name] = jax;
+        this.settings.renderer = jax.name;
+        this.settings.scale = jax.options.scale;
+    }
+
+    protected initMenu() {
+        this.menu = MJContextMenu.parse({
+            menu: {
+                id: 'MathJax_Menu',
+                pool: [
+                    this.variable<boolean>('texHints'),
+                    this.variable<boolean>('semantics'),
+                    this.variable<string> ('zoom'),
+                    this.variable<string> ('zscale', (scale: string) => this.setZScale(scale)),
+                    this.variable<string> ('renderer', (jax: string) => this.setRenderer(jax)),
+                    this.variable<boolean>('alt'),
+                    this.variable<boolean>('cmd'),
+                    this.variable<boolean>('ctrl'),
+                    this.variable<boolean>('shift'),
+                    this.variable<boolean>('explorer'),
+                    this.variable<boolean>('autocollapse'),
+                    this.variable<boolean>('collapsible'),
+                    this.variable<boolean>('inTabOrder', (tab: boolean) => this.menu.getStore().inTaborder(tab))
+                ],
+                items: [
+                    this.submenu('Show', 'Show Math As', [
+                        this.command('MathMLcode', 'MathML Code', () => this.mathmlCode.post()),
+                        this.command('Original', 'Original Form', () => this.originalText.post()),
+                        this.submenu('Annotation', 'Annotation')
+                    ]),
+                    this.submenu('Copy', 'Copy to Clipboard', [
+                        this.command('MathMLcode', 'MathML Code', () => this.copyMathML()),
+                        this.command('Original', 'Original Form', () => this.copyOriginal()),
+                        this.submenu('Annotation', 'Annotation')
+                    ]),
+                    this.rule(),
+                    this.submenu('Settings', 'Math Settings',[
+                        this.submenu('Renderer', 'Math Renderer', this.radioGroup('renderer', [['CHTML'], ['SVG']])),
+                        this.rule(),
+                        this.submenu('ZoomTrigger', 'Zoom Trigger', [
+                            this.radioGroup('zoom', [
+                                ['Click'], ['DoubleClick', 'Double-Click'], ['NoZoom', 'No Zoom']
+                            ]),
+                            this.rule(),
+                            this.label('TriggerRequires', 'Trigger Requires:'),
+                            this.checkbox((isMac ? 'Option' : 'Alt'), (isMac ? 'Option' : 'Alt'), 'alt'),
+                            this.checkbox('Command', 'Command', 'cmd', {hidden: !isMac}),
+                            this.checkbox('Control', 'Control', 'ctrl', {hiddne: isMac}),
+                            this.checkbox('Shift', 'Shift', 'shift')
+                        ]),
+                        this.submenu('ZoomFactor', 'Zoom Factor', this.radioGroup('zscale', [
+                            ['150%'], ['175%'], ['200%'], ['250%'], ['300%'], ['400%']
+                        ])),
+                        this.rule(),
+                        this.command('Scale', 'Scale All Math...', () => this.scaleAllMath()),
+                        this.rule(),
+                        this.checkbox('texHints', 'Add TeX hints to MathML', 'texHints'),
+                        this.checkbox('semantics', 'Add original as annotation', 'semantics')
+                    ]),
+                    this.submenu('Accessibility', 'Accessibility', [
+                        this.submenu('Explorer', 'Explorer', [
+                            this.checkbox('Active', 'Activate', 'explorer'),
+                            this.rule(),
+                            this.command('WhenActive', '(Options when Active)', () => {}, {disabled: true})
+                        ]),
+                        this.rule(),
+                        this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
+                        this.checkbox('AutoCollapse', 'Auto Collapse', 'autocollapse'),
+                        this.rule(),
+                        this.checkbox('InTabOrder', 'Include in Tab Order', 'inTabOrder')
+                    ]),
+                    this.submenu('Language', 'Language'),
+                    this.rule(),
+                    this.command('About', 'About MathJax', () => this.about.post()),
+                    this.command('Help', 'MathJax Help', () => this.help.post())
+                ]
+            }
+        }) as MJContextMenu<N, T, D>;
+        const menu = this.menu;
+        this.about.attachMenu(menu);
+        this.help.attachMenu(menu);
+        this.originalText.attachMenu(menu);
+        this.mathmlCode.attachMenu(menu);
+        this.zoomBox.attachMenu(menu);
+        this.disableUnloadableItems();
+        ContextMenu.CssStyles.addInfoStyles(this.document.document as any);
+        ContextMenu.CssStyles.addMenuStyles(this.document.document as any);
+    }
+
+    protected disableUnloadableItems() {
+        const MathJax = window.MathJax;
+        if (!(MathJax && MathJax._ && MathJax.loader && MathJax.startup)) {
+            const menu = this.menu;
+            for (const name of Object.keys(this.jax)) {
+                if (!this.jax[name]) {
+                    menu.findID('Settings', 'Renderer', name).disable();
+                }
+            }
+            menu.findID('Accessibility', 'Explorer').disable();
+            menu.findID('Accessibility', 'AutoCollapse').disable();
+            menu.findID('Accessibility', 'Collapsible').disable();
+        }
+    }
+
+    protected setZScale(scale: string) {
+        this.settings.zscale = scale;
+        this.zscale = 1.25 * parseFloat(scale);
+    }
+
+    protected setRenderer(jax: string) {
+        this.settings.renderer = jax;
+        if (this.jax[jax]) {
+            this.setOutputJax(this.jax[jax]);
+        } else {
+            const MathJax = window.MathJax;
+            MathJax.loader.load(name + '-output').then(() => {
+                const startup = MathJax.startup;
+                const name = jax.toLowerCase();
+                if (name in startup.constructor) {
+                    startup.useOutput(jax, true);
+                    startup.output = startup.getOutputJax();
+                    this.jax[jax] = startup.output;
+                    this.setOutputJax(this.jax[jax]);
+                }
+            }).catch((err) => {throw err});
+        }
+    }
+
+    protected setOutputJax(jax: OutputJax<N, T, D>) {
+        jax.setAdaptor(this.document.adaptor);
+        this.document.outputJax = jax;
+        this.document.rerender();
+    }
+
+    protected formatSource(text: string) {
+        return text.trim().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    protected toMML(math: MathItem<N, T, D>) {
+        return this.MmlVisitor.visitTree(math.root, math, {
+            texHints: this.settings.texHints,
+            semantics: (this.settings.semantics && math.inputJax.name !== 'MathML')
+        });
+    }
+
+    protected copyMathML() {
+        this.copyToClipboard(this.toMML(this.menu.mathItem));
+    }
+
+    protected copyOriginal() {
+        this.copyToClipboard(this.menu.mathItem.math);
+    }
+
+    protected copyToClipboard(text: string) {
+        const input = document.createElement('textarea');
+        input.value = text;
+        input.setAttribute('readonly', '');
+        input.style.cssText = 'height: 1px; width: 1px; padding: 1px; position: absolute; left: -10px';
+        document.body.appendChild(input);
+        input.select();
+        try {
+            document.execCommand('copy');
+        } catch (error) {
+            alert('Can\'t copy to clipboard: ' + error.message);
+        }
+        document.body.removeChild(input);
+    }
+
+    public addMenu(math: MathItem<N, T, D>) {
+        const element = math.typesetRoot as any as HTMLElement;
+        element.addEventListener('contextmenu', () => this.menu.mathItem = math, true);
+        element.addEventListener('keydown', () => this.menu.mathItem = math, true);
+        element.addEventListener('click', (event: MouseEvent) => this.zoom(event, 'Click', math), true);
+        element.addEventListener('dblclick', (event: MouseEvent) => this.zoom(event,'DoubleClick', math), true);
+        this.menu.getStore().insert(element);
+    }
+
+    protected scaleAllMath() {
+        const scale = (this.settings.scale * 100).toFixed(1).replace(/.0$/, '');
+        const percent = prompt('Scale all mathematics (compared to surrounding text) by', scale + '%');
+        if (percent) {
+            if (percent.match(/^\s*\d+(\.\d*)?\s*%?\s*$/)) {
+                const scale = parseFloat(percent) / 100;
+                if (scale) {
+                    if (scale !== this.settings.scale) {
+                        this.settings.scale = scale;
+                        this.document.outputJax.options.scale = scale;
+                        this.document.rerender();
+                    }
+                } else {
+                    alert('The scale should not be zero');
+                }
+            } else {
+                alert('The scale should be a percentage (e.g., 120%)');
+            }
+        }
+    }
+
+    protected zoom(event: MouseEvent, type: string, math: MathItem<N, T, D>) {
+        if (this.isZoomEvent(event, type)) {
+            this.menu.mathItem = math;
+            this.menu.post(event);
+            this.zoomBox.post();
+        }
+    }
+
+    protected isZoomEvent(event: MouseEvent, zoom: string) {
+        return (this.settings.zoom === zoom &&
+                (!this.settings.alt   || event.altKey) &&
+                (!this.settings.ctrl  || event.ctrlKey) &&
+                (!this.settings.cmd   || event.metaKey) &&
+                (!this.settings.shift || event.shiftKey));
+    }
+
+    public clear() {
+        this.menu.getStore().clear();
+    }
+
+    public variable<T extends (string | boolean)>(name: keyof MenuSettings, setter?: (value: T) => void) {
+        return {
+            name: name,
+            getter: () => this.settings[name],
+            setter: setter || ((value: T) => this.settings[name] = value as T)
+        };
+    }
+
+    public submenu(id: string, content: string, entries: any[] = []) {
+        let items = [] as Array<Object>;
+        for (const entry of entries) {
+            if (Array.isArray(entry)) {
+                items = items.concat(entry);
+            } else {
+                items.push(entry);
+            }
+        }
+        return {type: 'submenu', id, content, menu: {items}, disabled: (items.length === 0)};
+    }
+
+    public command(id: string, content: string, action: () => void, other: Object = {}) {
+        return Object.assign({type: 'command', id, content, action}, other);
+    }
+
+    public checkbox(id: string, content: string, variable: string, other: Object = {}) {
+        return Object.assign({type: 'checkbox', id, content, variable}, other);
+    }
+
+    public radioGroup(variable: string, radios: string[][]) {
+        return radios.map(def => this.radio(def[0], def[1] || def[0], variable));
+    }
+
+    public radio(id: string, content: string, variable: string, other: Object = {}) {
+        return Object.assign({type: 'radio', id, content, variable}, other);
+    }
+
+    public label(id: string, content: string) {
+        return {type: 'label', id, content};
+    }
+
+    public rule() {
+        return {type: 'rule'};
+    }
+
+}

--- a/mathjax3-ts/ui/menu/MenuHandler.ts
+++ b/mathjax3-ts/ui/menu/MenuHandler.ts
@@ -24,12 +24,12 @@
 import {MathJax} from '../../mathjax.js';
 
 import {MathItem, STATE, newState} from '../../core/MathItem.js';
-import {MathDocument, AbstractMathDocument} from '../../core/MathDocument.js';
+import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../../core/MathDocument.js';
 import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
 import {Handler} from '../../core/Handler.js';
 import {ComplexityMathDocument, ComplexityMathItem} from '../../a11y/complexity.js';
 import {ExplorerMathDocument, ExplorerMathItem} from '../../a11y/explorer.js';
-import {OptionList} from '../../util/Options.js';
+import {OptionList, expandable} from '../../util/Options.js';
 
 import {Menu} from './Menu.js';
 
@@ -50,10 +50,8 @@ export type A11yMathItemConstructor = {
 /**
  * Constructor for base document for MenuMathDocument
  */
-export type A11yDocumentConstructor = {
-    OPTIONS: OptionList;
-    new(...args: any[]): ComplexityMathDocument<HTMLElement, Text, Document> & ExplorerMathDocument;
-}
+export type A11yDocumentConstructor =
+    MathDocumentConstructor<ComplexityMathDocument<HTMLElement, Text, Document> & ExplorerMathDocument>;
 
 /*==========================================================================*/
 
@@ -94,20 +92,6 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
             if (this.state() < STATE.CONTEXT_MENU) {
                 document.menu.addMenu(this);
                 this.state(STATE.CONTEXT_MENU);
-            }
-        }
-
-        /**
-         * @override
-         */
-        public rerender(document: MenuMathDocument, start: number = STATE.TYPESET, end: number = STATE.LAST) {
-            const state = STATE.CONTEXT_MENU;
-            if (start <= state && state <= end) {
-                super.rerender(document, start, state);
-                this.addMenu(document);
-                super.rerender(document, state + 1, end);
-            } else {
-                super.rerender(document, start, end);
             }
         }
 
@@ -175,7 +159,11 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
         public static OPTIONS = {
             ...BaseDocument.OPTIONS,
             MenuClass: Menu,
-            menuOptions: Menu.OPTIONS
+            menuOptions: Menu.OPTIONS,
+            renderActions: expandable({
+                ...BaseDocument.OPTIONS.renderActions,
+                addMenu: [STATE.CONTEXT_MENU]
+            })
         }
 
         /**

--- a/mathjax3-ts/ui/menu/MenuHandler.ts
+++ b/mathjax3-ts/ui/menu/MenuHandler.ts
@@ -116,6 +116,7 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
          */
         public complexity(document: MenuMathDocument) {
             if (document.menu.settings.collapsible) {
+                document.menu.checkComponent('a11y/complexity');
                 super.complexity(document);
             }
         }
@@ -125,6 +126,7 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
          */
         public explorable(document: MenuMathDocument) {
             if (document.menu.settings.explorer) {
+                document.menu.checkComponent('a11y/explorer');
                 super.explorable(document as any);
             }
         }
@@ -237,6 +239,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
          */
         public complexity() {
             if (this.menu.settings.collapsible) {
+                this.menu.checkComponent('a11y/complexity');
                 super.complexity();
             }
             return this;
@@ -247,6 +250,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
          */
         public explorable() {
             if (this.menu.settings.explorer) {
+                this.menu.checkComponent('a11y/explorer');
                 super.explorable();
             }
             return this;

--- a/mathjax3-ts/ui/menu/MenuHandler.ts
+++ b/mathjax3-ts/ui/menu/MenuHandler.ts
@@ -23,11 +23,12 @@
 
 import {MathJax} from '../../mathjax.js';
 
-import {MathItem, AbstractMathItem, STATE, newState} from '../../core/MathItem.js';
+import {MathItem, STATE, newState} from '../../core/MathItem.js';
 import {MathDocument, AbstractMathDocument} from '../../core/MathDocument.js';
+import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
 import {Handler} from '../../core/Handler.js';
-import {ComplexityMathDocument} from '../../a11y/complexity.js';
-import {ExplorerMathDocument} from '../../a11y/explorer.js';
+import {ComplexityMathDocument, ComplexityMathItem} from '../../a11y/complexity.js';
+import {ExplorerMathDocument, ExplorerMathItem} from '../../a11y/explorer.js';
 import {OptionList} from '../../util/Options.js';
 
 import {Menu} from './Menu.js';
@@ -42,7 +43,9 @@ export type Constructor<T> = new(...args: any[]) => T;
 /**
  * Constructor for base MathItem for MenuMathItem
  */
-export type A11yMathItemConstructor = Constructor<AbstractMathItem<HTMLElement, Text, Document>>;
+export type A11yMathItemConstructor = {
+    new(...args: any[]): ComplexityMathItem<HTMLElement, Text, Document> & ExplorerMathItem;
+}
 
 /**
  * Constructor for base document for MenuMathDocument
@@ -97,9 +100,33 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
         /**
          * @override
          */
-        public rerender(document: MenuMathDocument) {
-            super.rerender(document);
-            this.addMenu(document);
+        public rerender(document: MenuMathDocument, start: number = STATE.TYPESET, end: number = STATE.LAST) {
+            const state = STATE.CONTEXT_MENU;
+            if (start <= state && state <= end) {
+                super.rerender(document, start, state);
+                this.addMenu(document);
+                super.rerender(document, state + 1, end);
+            } else {
+                super.rerender(document, start, end);
+            }
+        }
+
+        /**
+         * @override
+         */
+        public complexity(document: MenuMathDocument) {
+            if (document.menu.settings.collapsible) {
+                super.complexity(document);
+            }
+        }
+
+        /**
+         * @override
+         */
+        public explorable(document: MenuMathDocument) {
+            if (document.menu.settings.explorer) {
+                super.explorable(document as any);
+            }
         }
 
     }

--- a/mathjax3-ts/ui/menu/MenuHandler.ts
+++ b/mathjax3-ts/ui/menu/MenuHandler.ts
@@ -1,0 +1,175 @@
+import {MathJax} from '../../mathjax.js';
+
+import {MathItem, AbstractMathItem} from '../../core/MathItem.js';
+import {MathDocument, AbstractMathDocument} from '../../core/MathDocument.js';
+import {Handler} from '../../core/Handler.js';
+
+import {Menu} from './Menu.js';
+
+/**
+ * Generic constructor for Mixins
+ */
+export type Constructor<T> = new(...args: any[]) => T;
+
+/*==========================================================================*/
+
+/**
+ * The funtions added to MathItem for adding the context menu
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface MenuMathItem<N, T, D> extends MathItem<N, T, D> {
+
+    /**
+     * @param {MathDocument} document  The document where the menu is being added
+     */
+    addMenu(document: MathDocument<N, T, D>): void;
+}
+
+/**
+ * The mixin for adding context menus to MathItems
+ *
+ * @param {B} BaseMathItem   The MathItem class to be extended
+ * @return {MathMathItem}    The extended MathItem class
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ * @template B  The MathItem class to extend
+ */
+export function MenuMathItemMixin<N, T, D, B extends Constructor<AbstractMathItem<N, T, D>>>(
+    BaseMathItem: B
+): Constructor<MenuMathItem<N, T, D>> & B {
+    return class extends BaseMathItem {
+
+        public addMenu(document: MenuMathDocument<N, T, D>) {
+            document.menu.addMenu(this);
+        }
+
+    }
+}
+
+/*==========================================================================*/
+
+/**
+ * The funtions added to MathDocument for context menus
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface MenuMathDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
+
+    menu: Menu<N, T, D>;
+
+    /**
+     * Add context menus to the MathItems in the MathDocument
+     *
+     * @return {MathDocument}   The MathDocument (so calls can be chained)
+     */
+    addMenu(): MathDocument<N, T, D>;
+
+    /**
+     * Rerender the math on the page
+     *
+     * @return {MathDocument}   The MathDocument (so calls can be chained)
+     */
+    rerender(): MathDocument<N, T, D>;
+}
+
+/**
+ * The mixin for adding context menus to MathDocuments
+ *
+ * @param {B} BaseMathDocument     The MathDocument class to be extended
+ * @return {MenuMathDocument}      The extended MathDocument class
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ * @template B  The MathDocument class to extend
+ */
+export function MenuMathDocumentMixin<N, T, D, B extends Constructor<AbstractMathDocument<N, T, D>>>(
+    BaseDocument: B
+): Constructor<MenuMathDocument<N, T, D>> & B {
+
+    return class extends BaseDocument {
+
+        public static OPTIONS = {
+            ...(BaseDocument as any).OPTIONS,
+            MenuClass: Menu,
+            menuOptions: {
+                settings: {},
+                jax: {CHTML: null, SVG: null}
+            }
+        }
+
+        public menu: Menu<N, T, D>;
+
+        /**
+         * Extend the MathItem class used for this MathDocument
+         *
+         * @override
+         * @constructor
+         */
+        constructor(...args: any[]) {
+            super(...args);
+            this.menu = new this.options.MenuClass(this, this.options.menuOptions);
+            const ProcessBits = (this.constructor as typeof AbstractMathDocument).ProcessBits;
+            if (!ProcessBits.has('context-menu')) {
+                ProcessBits.allocate('context-menu');
+            }
+            this.options.MathItem =
+                MenuMathItemMixin<N, T, D, Constructor<AbstractMathItem<N, T, D>>>(this.options.MathItem);
+        }
+
+        public addMenu() {
+            if (!this.processed.isSet('context-menu')) {
+                for (const math of this.math) {
+                    (math as MenuMathItem<N, T, D>).addMenu(this);
+                }
+                this.processed.set('context-menu');
+            }
+            return this;
+        }
+
+        public state(state: number, restore: boolean = false) {
+            super.state(state, restore);
+            if (state <= AbstractMathDocument.STATE.TYPESET) {
+                this.processed.clear('context-menu');
+            }
+            return this;
+        }
+
+        public updateDocument() {
+            super.updateDocument();
+            (this.menu.menu.getStore() as any).sort();
+            return this;
+        }
+
+        public rerender() {
+            this.state(AbstractMathDocument.STATE.COMPILED);
+            this.typeset();
+            this.addMenu();
+            this.updateDocument();
+            return this;
+        }
+
+    };
+
+}
+
+/*==========================================================================*/
+
+/**
+ * Add context-menu support to a Handler instance
+ *
+ * @param {Handler} handler   The Handler instance to enhance
+ * @return {Handler}          The handler that was modified (for purposes of chaining extensions)
+ */
+export function MenuHandler<N, T, D>(handler: Handler<N, T, D>) {
+    handler.documentClass =
+        MenuMathDocumentMixin<N, T, D, Constructor<AbstractMathDocument<N, T, D>>>(handler.documentClass);
+    return handler;
+}

--- a/mathjax3-ts/ui/menu/MmlVisitor.ts
+++ b/mathjax3-ts/ui/menu/MmlVisitor.ts
@@ -1,0 +1,69 @@
+import {MathItem} from '../../core/MathItem.js';
+import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {SerializedMmlVisitor} from '../../core/MmlTree/SerializedMmlVisitor.js';
+import {OptionList, userOptions} from '../../util/Options.js';
+
+export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
+
+    public options: OptionList = {
+        texHints: true,
+        semantics: false,
+    };
+
+    public mathItem: MathItem<N, T, D> = null;
+
+    /**
+     * @override
+     */
+    public visitTree(node: MmlNode, math: MathItem<N, T, D> = null, options: OptionList = {}) {
+        this.mathItem = math;
+        userOptions(this.options, options);
+        return this.visitNode(node, '');
+    }
+
+    /**
+     * @override
+     */
+    public visitTeXAtomNode(node: MmlNode, space: string) {
+        if (this.options.texHints) {
+            return super.visitTeXAtomNode(node, space);
+        }
+        if (node.childNodes[0] && node.childNodes[0].childNodes.length === 1) {
+            return this.visitNode(node.childNodes[0], space);
+        }
+        return space + '<mrow' +  this.getAttributes(node) + '>\n'
+             + this.childNodeMml(node, space + '  ') + '\n'
+             + space + '</mrow>';
+    }
+
+    /**
+     * @param {MmlNode} node    The math node to visit
+     * @param {string} space    The number of spaces to use for indentation
+     * @return {string}         The serialzied math element
+     */
+    public visitMathNode(node: MmlNode, space: string) {
+        if (!this.options.semantics) {
+            return super.visitDefault(node, space);
+        }
+        return space + '<math' + this.getAttributes(node) + '>\n'
+             + space + '  <semantics>\n'
+             + this.childNodeMml(node, space + '    ') + '\n'
+             + space + '  <annotation encoding="application/x-tex">' + this.mathItem.math + '</annotation>\n'
+             + space + '  </semantics>\n'
+             + space + '</math>';
+    }
+
+    /**
+     * @param {MmlNode} node    The node whose children are to ne added
+     * @param {string} space    The number of spaces to use for indentation
+     * @return {string}         The serialzied children
+     */
+    public childNodeMml(node: MmlNode, space: string) {
+        let mml = '';
+        for (const child of node.childNodes) {
+            mml += this.visitNode(child, space);
+        }
+        return mml;
+    }
+
+}

--- a/mathjax3-ts/ui/menu/MmlVisitor.ts
+++ b/mathjax3-ts/ui/menu/MmlVisitor.ts
@@ -80,7 +80,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
     /**
      * @param {MmlNode} node    The math node to visit
      * @param {string} space    The number of spaces to use for indentation
-     * @returns {string}        The serializied math element
+     * @returns {string}        The serialized math element
      */
     public visitMathNode(node: MmlNode, space: string) {
         if (!this.options.semantics || this.mathItem.inputJax.name !== 'TeX') {

--- a/mathjax3-ts/ui/menu/MmlVisitor.ts
+++ b/mathjax3-ts/ui/menu/MmlVisitor.ts
@@ -32,38 +32,28 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
             return this.visitNode(node.childNodes[0], space);
         }
         return space + '<mrow' +  this.getAttributes(node) + '>\n'
-             + this.childNodeMml(node, space + '  ') + '\n'
+             + this.childNodeMml(node, space + '  ', '\n')
              + space + '</mrow>';
     }
 
     /**
      * @param {MmlNode} node    The math node to visit
      * @param {string} space    The number of spaces to use for indentation
-     * @return {string}         The serialzied math element
+     * @returns {string}        The serializied math element
      */
     public visitMathNode(node: MmlNode, space: string) {
         if (!this.options.semantics) {
             return super.visitDefault(node, space);
         }
+        const addRow = node.childNodes.length && node.childNodes[0].childNodes.length > 1;
         return space + '<math' + this.getAttributes(node) + '>\n'
              + space + '  <semantics>\n'
-             + this.childNodeMml(node, space + '    ') + '\n'
-             + space + '  <annotation encoding="application/x-tex">' + this.mathItem.math + '</annotation>\n'
+             + (addRow ? space + '    <mrow>\n' : '')
+             + this.childNodeMml(node, space + (addRow ? '      ' : '    '), '\n')
+             + (addRow ? space + '    </mrow>\n' : '')
+             + space + '    <annotation encoding="application/x-tex">' + this.mathItem.math + '</annotation>\n'
              + space + '  </semantics>\n'
              + space + '</math>';
-    }
-
-    /**
-     * @param {MmlNode} node    The node whose children are to ne added
-     * @param {string} space    The number of spaces to use for indentation
-     * @return {string}         The serialzied children
-     */
-    public childNodeMml(node: MmlNode, space: string) {
-        let mml = '';
-        for (const child of node.childNodes) {
-            mml += this.visitNode(child, space);
-        }
-        return mml;
     }
 
 }

--- a/mathjax3-ts/ui/menu/MmlVisitor.ts
+++ b/mathjax3-ts/ui/menu/MmlVisitor.ts
@@ -1,18 +1,59 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  A visitor to serialize MathML taking menu settings into account
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
 import {MathItem} from '../../core/MathItem.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import {SerializedMmlVisitor} from '../../core/MmlTree/SerializedMmlVisitor.js';
 import {OptionList, userOptions} from '../../util/Options.js';
 
+/*==========================================================================*/
+
+/**
+ * The visitor to serialize MathML
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
 export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
 
+    /**
+     * The options controlling the serialization
+     */
     public options: OptionList = {
-        texHints: true,
-        semantics: false,
+        texHints: true,           // True means include classes for TeXAtom elements
+        semantics: false,         // True means include original form as annotation in a semantics element
     };
 
+    /**
+     * The MathItem currently being processed
+     */
     public mathItem: MathItem<N, T, D> = null;
 
     /**
+     * @param {MmlNode} node         The internal MathML node to serialize
+     * @param {MathItem} math        The MathItem for this node
+     * @param {OptionList} options   The options controlling the processing
      * @override
      */
     public visitTree(node: MmlNode, math: MathItem<N, T, D> = null, options: OptionList = {}) {
@@ -42,7 +83,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
      * @returns {string}        The serializied math element
      */
     public visitMathNode(node: MmlNode, space: string) {
-        if (!this.options.semantics) {
+        if (!this.options.semantics || this.mathItem.inputJax.name !== 'TeX') {
             return super.visitDefault(node, space);
         }
         const addRow = node.childNodes.length && node.childNodes[0].childNodes.length > 1;

--- a/mathjax3-ts/ui/menu/SelectableInfo.ts
+++ b/mathjax3-ts/ui/menu/SelectableInfo.ts
@@ -1,0 +1,31 @@
+import '../../../../context-menu/scripts/js/context_menu.js';
+
+export class SelectableInfo extends ContextMenu.Info {
+
+    public addEvents(element: HTMLElement) {
+        element.addEventListener('keypress', (event: KeyboardEvent) => {
+            if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
+                this.selectAll();
+                this.stop(event);
+            }
+        });
+    }
+
+    public selectAll() {
+        const selection = document.getSelection();
+        selection.selectAllChildren(this.getHtml().querySelector('pre'));
+    }
+
+    public copyToClipboard() {
+        this.selectAll();
+        document.execCommand('copy');
+        document.getSelection().removeAllRanges();
+    }
+
+    public generateHtml() {
+        super.generateHtml();
+        const button = this.getHtml().querySelector('input');
+        button.addEventListener('click', (event: MouseEvent) => this.copyToClipboard());
+    }
+
+}

--- a/mathjax3-ts/ui/menu/SelectableInfo.ts
+++ b/mathjax3-ts/ui/menu/SelectableInfo.ts
@@ -1,7 +1,41 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  An info box that allows text selection and has copy-to-clipboard functions
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
 import '../../../../context-menu/scripts/js/context_menu.js';
 
+/*==========================================================================*/
+
+/**
+ * The SelectableInfo class definition
+ */
 export class SelectableInfo extends ContextMenu.Info {
 
+    /**
+     * Add a keypress event to handle "select all" so that only
+     * the info-box's text is selected (not the whole page)
+     *
+     * @override
+     */
     public addEvents(element: HTMLElement) {
         element.addEventListener('keypress', (event: KeyboardEvent) => {
             if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
@@ -11,20 +45,36 @@ export class SelectableInfo extends ContextMenu.Info {
         });
     }
 
+    /**
+     * Select all the main text of the info box
+     */
     public selectAll() {
         const selection = document.getSelection();
         selection.selectAllChildren(this.getHtml().querySelector('pre'));
     }
 
+    /**
+     * Implement the copy-to-clipboard action
+     */
     public copyToClipboard() {
         this.selectAll();
-        document.execCommand('copy');
+        try {
+            document.execCommand('copy');
+        } catch(err) {
+            alert('Can\'t copy to clipboard: ' + err.message);
+        }
         document.getSelection().removeAllRanges();
     }
 
+    /**
+     * Attach the cop-to-clipboard action to its button
+     */
     public generateHtml() {
         super.generateHtml();
-        const button = this.getHtml().querySelector('input');
+        const footer = this.getHtml().querySelector('span.' + ContextMenu.HtmlClasses['INFOSIGNATURE']);
+        const button = footer.appendChild(document.createElement('input'));
+        button.type = 'button';
+        button.value = 'Copy to Clipboard';
         button.addEventListener('click', (event: MouseEvent) => this.copyToClipboard());
     }
 

--- a/mathjax3-ts/ui/menu/SelectableInfo.ts
+++ b/mathjax3-ts/ui/menu/SelectableInfo.ts
@@ -67,7 +67,7 @@ export class SelectableInfo extends ContextMenu.Info {
     }
 
     /**
-     * Attach the cop-to-clipboard action to its button
+     * Attach the copy-to-clipboard action to its button
      */
     public generateHtml() {
         super.generateHtml();


### PR DESCRIPTION
This PR adds support for the contextual menu.  It uses an extension (`MenuHandler.ts`) similar to the ones in the `a11y` directory to hook itself into the rendering action list.  If the `startup` component has been loaded, it will allow the loading of the explorer and complexity extensions on the fly.

The configuration submenu for the explorer module is present, but the values are not respected, as the mechanism for changing the explorer configuration in `Explorer.ts` doesn't seem to be present yet.  There are also some issues with restarting the explorer when an `maction` is triggered, and a few other issues with the explorer.  @zorkow, if you want to work on the explorer, either use this branch, or better yet, the `v3-lab` branch as your starting point.