### PR TITLE
Fix values set by inheritAttributesFrom()

### DIFF
--- a/mathjax3-ts/core/MmlTree/MmlNode.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNode.ts
@@ -605,11 +605,11 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
      */
     public inheritAttributesFrom(node: MmlNode) {
         const attributes = node.attributes;
-        const display = attributes.get('display') as boolean;
+        const display = attributes.get('displaystyle') as boolean;
         const scriptlevel = attributes.get('scriptlevel') as number;
-        const defaults: AttributeList = {
+        const defaults: AttributeList = (!attributes.isSet('mathsize') ? {} : {
             mathsize: ['math', attributes.get('mathsize')]
-        };
+        });
         const prime = node.getProperty('texprimestyle') as boolean || false
         this.setInheritedAttributes(defaults, display, scriptlevel, prime);
     }


### PR DESCRIPTION
Use proper `displaystyle` for `inheritAttributeFrom()`, and don't set `mathsize` unless it is actually needed.  This is in response to a report from Volker.