### PR TITLE
Fix horizontal stretchy characters in CHTML

### DIFF
--- a/mathjax3-ts/output/chtml/FontData.ts
+++ b/mathjax3-ts/output/chtml/FontData.ts
@@ -88,6 +88,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
      */
     protected static defaultStyles = {
         'mjx-c::before': {
+            display: 'inline-block',
             width: 0
         }
     };
@@ -293,7 +294,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
         if (!n) return 0;
         const data = this.getDelimiterData(n);
         const dw = (W - data[2]) / 2
-        const css: StyleData = {content: this.charContent(n), width: this.em0(W - dw)};
+        const css: StyleData = {content: this.charContent(n)};
         if (part !== 'ext') {
             css.padding = this.padding(data, dw);
         } else if (dw) {
@@ -335,7 +336,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
         const options = data[3] as CHTMLCharOptions;
         const css: StyleData = {content: (options && options.c ? '"' + options.c + '"' : this.charContent(n))};
         if (part !== 'ext' || force) {
-            css.padding = this.padding(data);
+            css.padding = this.padding(data, 0, -data[2]);
         }
         styles[this.cssRoot + 'mjx-stretchy-h' + c + ' mjx-' + part + ' mjx-c::before'] = css;
     }

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -45,21 +45,23 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(C
             display: 'inline-table',
             width: '100%'
         },
-        'mjx-stretchy-h > mjx-beg, mjx-stretchy-h > mjx-end': {
+        'mjx-stretchy-h > *': {
             display: 'table-cell',
             width: 0
         },
+        'mjx-stretchy-h > * > mjx-c': {
+            display: 'inline-block'
+        },
+        'mjx-stretchy-h > * > mjx-c::before': {
+            padding: '.001em 0',                  // for blink
+            width: 'initial'
+        },
         'mjx-stretchy-h > mjx-ext': {
-            display: 'table-cell',
             overflow: 'hidden',
             width: '100%'
         },
         'mjx-stretchy-h > mjx-ext > mjx-c': {
-            transform: 'scalex(500)',
-            'margin-right': '-2em'
-        },
-        'mjx-stretchy-h > mjx-ext > mjx-c::before': {
-            padding: '.001em 0'                  // for blink
+            transform: 'scalex(500)'
         },
         'mjx-stretchy-h > mjx-beg > mjx-c': {
             'margin-right': '-.1em'
@@ -81,7 +83,7 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(C
             display: 'block'
         },
         'mjx-stretchy-v > * > mjx-c': {
-            transform: 'scale(1)',   // improves Firefox positioning
+            transform: 'scale(1)',                // improves Firefox positioning
             'transform-origin': 'left center',
             overflow: 'hidden'
         },


### PR DESCRIPTION
Fix horizontal stretchy characters in CHTML.  This apparently was broken in the adaptive-css branch (the `width:0` for the `mjx-c::before` was the main culprit, but I reorganized a few other bits of CSS as well.