### PR TITLE
Add a REMOVE option for arrays, corresponding to APPEND

### DIFF
--- a/mathjax3-ts/util/Options.ts
+++ b/mathjax3-ts/util/Options.ts
@@ -154,35 +154,81 @@ export function copy(def: OptionList): OptionList {
  */
 export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
     for (let key of keys(src)) {
+        //
+        // Check if the key is valid (i.e., is in the defaults or in an expandable block)
+        //
         if (warn && dst[key] === undefined && !(dst instanceof Expandable)) {
             if (typeof key === 'symbol') {
                 key = key.toString();
             }
             throw new Error('Invalid option "' + key + '" (no default value).');
         }
+        //
+        // Shorthands for the source and destination values
+        //
         let sval = src[key], dval = dst[key];
+        //
+        // If the source is an object literal and the destination exists and is either an
+        //   object or a function (so can have properties added to it)...
+        //
         if (isObject(sval) && dval !== null &&
             (typeof dval === 'object' || typeof dval === 'function')) {
             const ids = keys(sval);
-            if (Array.isArray(dval) &&
-                ((ids.length === 1 && (ids[0] === APPEND || ids[0] === REMOVE) && Array.isArray(sval[ids[0]])) ||
-                  (ids.length === 2 && ids.sort().join(',') === APPEND + ',' + REMOVE &&
-                   Array.isArray(sval[APPEND]) && Array.isArray(sval[REMOVE])))) {
+            //
+            // Check for APPEND or REMOVE objects:
+            //
+            if (
+                //
+                // If the destination value is an array...
+                //
+                Array.isArray(dval) &&
+                (
+                    //
+                    // If there is only one key and it is APPEND or REMOVE and the keys value is an array...
+                    //
+                    (ids.length === 1 && (ids[0] === APPEND || ids[0] === REMOVE) && Array.isArray(sval[ids[0]])) ||
+                    //
+                    // Or if there are two keys and they are APPEND and REMOVE and both keys' values
+                    //   are arrays...
+                    //
+                    (ids.length === 2 && ids.sort().join(',') === APPEND + ',' + REMOVE &&
+                     Array.isArray(sval[APPEND]) && Array.isArray(sval[REMOVE]))
+                )
+             ) {
+                //
+                // Then remove any values to be removed
+                //
                 if (sval[REMOVE]) {
                     dval = dst[key] = dval.filter(x => sval[REMOVE].indexOf(x) < 0);
                 }
+                //
+                // And append any values to be added (make a copy so as not to modify the original)
+                //
                 if (sval[APPEND]) {
-                    dval.push(...sval[APPEND]);
+                    dst[key] = [...dval, ...sval[APPEND]];
                 }
             } else {
+                //
+                // Otherwise insert the values of the source object into the destination object
+                //
                 insert(dval, sval, warn);
             }
         } else if (Array.isArray(sval)) {
+            //
+            // If the source is an array, replace the destination with an empty array
+            //   and copy the source values into it.
+            //
             dst[key] = [];
             insert(dst[key], sval, false);
         } else if (isObject(sval)) {
+            //
+            // If the source is an object literal, set the destination to a copy of it
+            //
             dst[key] = copy(sval);
         } else {
+            //
+            // Otherwise set the destination to the source value
+            //
             dst[key] = sval;
         }
     }


### PR DESCRIPTION
This PR adds a `REMOVE` option similar to the `APPEND` one so that if an option's default value is an array, you can use `prop: {[REMOVE]: [items]}` to remove the given items from the default values.  You can include both `APPEND` and `REMOVE` if you want, in order to remove some entries and then add others.