### PR TITLE
Make sure window exists before using it

### DIFF
--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -47,7 +47,8 @@ declare namespace window {
 /**
  * True when platform is a Mac (so we can enable CMD menu item for zoom trigger)
  */
-const isMac = (window.navigator && window.navigator.platform.substr(0,3) === 'Mac');
+const isMac = (typeof window !== 'undefined' &&
+               window.navigator && window.navigator.platform.substr(0,3) === 'Mac');
 
 /*==========================================================================*/
 
@@ -1013,3 +1014,4 @@ export class Menu {
     /*======================================================================*/
 
 }
+


### PR DESCRIPTION
This makes it possible to load components that include the menu code into node.  Though you won't be able to use the menus there, at least you will be able to load and use the components themselves.