### PR TITLE
Update loader to add a "provides" property

### DIFF
--- a/mathjax3-ts/components/loader.ts
+++ b/mathjax3-ts/components/loader.ts
@@ -129,7 +129,7 @@ export namespace Loader {
                     CONFIG.dependencies[id] = [];
                 }
                 CONFIG.dependencies[id].push(name);
-                new Package(id, true);
+                new Package(id, true, true);
             }
         }
     }

--- a/mathjax3-ts/components/loader.ts
+++ b/mathjax3-ts/components/loader.ts
@@ -129,7 +129,6 @@ export namespace Loader {
                 extension.provides(CONFIG.provides[name]);
             }
             extension.loaded();
-//            loadProvided(name);
         }
     };
 

--- a/mathjax3-ts/components/loader.ts
+++ b/mathjax3-ts/components/loader.ts
@@ -107,7 +107,7 @@ export namespace Loader {
             let extension = Package.packages.get(name);
             if (!extension) {
                 extension = new Package(name);
-                addProvided(name);
+                extension.provides(CONFIG.provides[name]);
             }
             extension.checkNoLoad();
             promises.push(extension.promise);
@@ -115,30 +115,6 @@ export namespace Loader {
         Package.loadAll();
         return Promise.all(promises);
     };
-
-    /**
-     * Add packages that are provided by the named one (which will be marked as loaded by preLoad()
-     *   when this package loads).
-     *
-     * @param {string} name    The name of the package whose subpackages are being provided
-     */
-    function addProvided(name: string) {
-        for (const id of CONFIG.provides[name] || []) {
-            if (!Package.packages.get(id)) {
-                if (!CONFIG.dependencies[id]) {
-                    CONFIG.dependencies[id] = [];
-                }
-                CONFIG.dependencies[id].push(name);
-                new Package(id, true, true);
-            }
-        }
-    }
-
-    function loadProvided(name: string) {
-        for (const id of CONFIG.provides[name] || []) {
-            Package.packages.get(id).loaded();
-        }
-    }
 
     /**
      * Indicate that the named packages are being loaded by hand (e.g., as part of a larger package).
@@ -150,10 +126,10 @@ export namespace Loader {
             let extension = Package.packages.get(name);
             if (!extension) {
                 extension = new Package(name, true);
-                addProvided(name);
+                extension.provides(CONFIG.provides[name]);
             }
             extension.loaded();
-            loadProvided(name);
+//            loadProvided(name);
         }
     };
 

--- a/mathjax3-ts/components/loader.ts
+++ b/mathjax3-ts/components/loader.ts
@@ -44,7 +44,7 @@ export interface MathJaxConfig extends MJConfig {
         paths?: {[name: string]: string};          // The path prefixes for use in locations
         source?: {[name: string]: string};         // The URLs for the extensions, e.g., tex: [mathjax]/input/tex.js
         dependencies?: {[name: string]: string[]}; // The dependencies for each package
-        provides?: {[name: string]: string[]};     // The sub-packges provided by each package
+        provides?: {[name: string]: string[]};     // The sub-packages provided by each package
         load?: string[];                           // The packages to load (found in locations or [mathjax]/name])
         ready?: PackageReady;                      // A function to call when MathJax is ready
         failed?: PackageFailed;                    // A function to call when MathJax fails to load

--- a/mathjax3-ts/components/package.ts
+++ b/mathjax3-ts/components/package.ts
@@ -140,10 +140,12 @@ export class Package {
     /**
      * @param {string} name        The name of the package
      * @param {boolean} noLoad     True when the package is just for reference, not loading
+     * @param {boolean} preLoad    True when this package is being preloaded by another
      */
-    constructor(name: string, noLoad: boolean = false) {
+    constructor(name: string, noLoad: boolean = false, preLoad: boolean = false) {
         this.name = name;
         this.noLoad = noLoad;
+        this.isLoading = preLoad;
         Package.packages.set(name, this);
         this.promise = this.makePromise(this.makeDependencies());
     }


### PR DESCRIPTION
This makes it possible to make modules that include other modules (e.g., combined modules that include both an input and an output module) and allow the loader to know that the sub-modules have been loaded.