### PR TITLE
Update TeX input jax

### DIFF
--- a/mathjax3-ts/input/tex.ts
+++ b/mathjax3-ts/input/tex.ts
@@ -134,30 +134,19 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   constructor(options: OptionList = {}) {
-    let packages = defaultOptions({packages: TeX.OPTIONS.packages}, selectOptions(options, 'packages')).packages;
-    let configuration = TeX.configure(packages);
-    let parseOptions = new ParseOptions(configuration,
-                                        [TeX.OPTIONS, TagsFactory.OPTIONS, {'packages': packages}]);
-    let [tex, find, skip, rest] = separateOptions(options, FindTeX.OPTIONS, {packages: []}, parseOptions.options);
+    const [rest, tex, find] = separateOptions(options, TeX.OPTIONS, FindTeX.OPTIONS);
     super(tex);
+    this.findTeX = this.options['FindTeX'] || new FindTeX(find);
+    const packages = this.options.packages;
+    const configuration = this.configuration = TeX.configure(packages);
+    const parseOptions = this._parseOptions = new ParseOptions(configuration, [this.options, TagsFactory.OPTIONS]);
     userOptions(parseOptions.options, rest);
-    parseOptions.options.jax = this;
     TeX.tags(parseOptions, configuration);
-    this._parseOptions = parseOptions;
-    this.configuration = configuration;
-    for (let pre of configuration.preprocessors) {
-      typeof pre === 'function' ? this.preFilters.add(pre) :
-        this.preFilters.add(pre[0], pre[1]);
-    }
-    for (let post of configuration.postprocessors) {
-      typeof post === 'function' ? this.postFilters.add(post) :
-        this.postFilters.add(post[0], post[1]);
-    }
+    configuration.config(configuration, this);
     this.postFilters.add(FilterUtil.cleanSubSup, -4);
     this.postFilters.add(FilterUtil.cleanStretchy, -3);
     this.postFilters.add(FilterUtil.cleanAttributes, -2);
     this.postFilters.add(FilterUtil.combineRelations, -1);
-    this.findTeX = this.parseOptions.options['FindTeX'] || new FindTeX(find);
   }
 
   /**

--- a/mathjax3-ts/input/tex.ts
+++ b/mathjax3-ts/input/tex.ts
@@ -141,8 +141,8 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     const configuration = this.configuration = TeX.configure(packages);
     const parseOptions = this._parseOptions = new ParseOptions(configuration, [this.options, TagsFactory.OPTIONS]);
     userOptions(parseOptions.options, rest);
-    TeX.tags(parseOptions, configuration);
     configuration.config(configuration, this);
+    TeX.tags(parseOptions, configuration);
     this.postFilters.add(FilterUtil.cleanSubSup, -4);
     this.postFilters.add(FilterUtil.cleanStretchy, -3);
     this.postFilters.add(FilterUtil.cleanAttributes, -2);

--- a/mathjax3-ts/input/tex.ts
+++ b/mathjax3-ts/input/tex.ts
@@ -22,7 +22,7 @@
  */
 
 import {AbstractInputJax} from '../core/InputJax.js';
-import {defaultOptions, userOptions, separateOptions, OptionList} from '../util/Options.js';
+import {defaultOptions, userOptions, separateOptions, selectOptions, OptionList} from '../util/Options.js';
 import {MathItem} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
@@ -134,13 +134,14 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   constructor(options: OptionList = {}) {
-    let packages = options['packages'] || TeX.OPTIONS['packages'];
+    let packages = defaultOptions({packages: TeX.OPTIONS.packages}, selectOptions(options, 'packages')).packages;
     let configuration = TeX.configure(packages);
     let parseOptions = new ParseOptions(configuration,
                                         [TeX.OPTIONS, TagsFactory.OPTIONS, {'packages': packages}]);
-    let [tex, find, rest] = separateOptions(options, FindTeX.OPTIONS, parseOptions.options);
+    let [tex, find, skip, rest] = separateOptions(options, FindTeX.OPTIONS, {packages: []}, parseOptions.options);
     super(tex);
     userOptions(parseOptions.options, rest);
+    parseOptions.options.jax = this;
     TeX.tags(parseOptions, configuration);
     this._parseOptions = parseOptions;
     this.configuration = configuration;

--- a/mathjax3-ts/input/tex/AllPackages.ts
+++ b/mathjax3-ts/input/tex/AllPackages.ts
@@ -30,6 +30,7 @@ import './boldsymbol/BoldsymbolConfiguration.js';
 import './braket/BraketConfiguration.js';
 import './cancel/CancelConfiguration.js';
 import './color/ColorConfiguration.js';
+import './config_macros/ConfigMacrosConfiguration.js';
 import './enclose/EncloseConfiguration.js';
 import './extpfeil/ExtpfeilConfiguration.js';
 import './html/HtmlConfiguration.js';
@@ -38,6 +39,7 @@ import './newcommand/NewcommandConfiguration.js';
 import './noerrors/NoErrorsConfiguration.js';
 import './noundefined/NoUndefinedConfiguration.js';
 import './physics/PhysicsConfiguration.js';
+import './require/RequireConfiguration.js';
 import './unicode/UnicodeConfiguration.js';
 import './verb/VerbConfiguration.js';
 
@@ -50,7 +52,8 @@ export const AllPackages: string[] = [
     'boldsymbol',
     'braket',
     'cancel',
-//  'color',
+    'color',
+    'configMacros',
     'enclose',
     'extpfeil',
     'html',
@@ -59,6 +62,7 @@ export const AllPackages: string[] = [
     'noerrors',
     'noundefined',
     'physics',
+    'require',
     'unicode',
     'verb'
 ];

--- a/mathjax3-ts/input/tex/AllPackages.ts
+++ b/mathjax3-ts/input/tex/AllPackages.ts
@@ -1,0 +1,64 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Loads all the TeX extensions
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import './base/BaseConfiguration.js';
+import './action/ActionConfiguration.js';
+import './ams/AmsConfiguration.js';
+import './ams_cd/AmsCdConfiguration.js';
+import './bbox/BboxConfiguration.js';
+import './boldsymbol/BoldsymbolConfiguration.js';
+import './braket/BraketConfiguration.js';
+import './cancel/CancelConfiguration.js';
+import './color/ColorConfiguration.js';
+import './enclose/EncloseConfiguration.js';
+import './extpfeil/ExtpfeilConfiguration.js';
+import './html/HtmlConfiguration.js';
+import './mhchem/MhchemConfiguration.js';
+import './newcommand/NewcommandConfiguration.js';
+import './noerrors/NoErrorsConfiguration.js';
+import './noundefined/NoUndefinedConfiguration.js';
+import './physics/PhysicsConfiguration.js';
+import './unicode/UnicodeConfiguration.js';
+import './verb/VerbConfiguration.js';
+
+export const AllPackages: string[] = [
+    'base',
+    'action',
+    'ams',
+    'amscd',
+    'bbox',
+    'boldsymbol',
+    'braket',
+    'cancel',
+//  'color',
+    'enclose',
+    'extpfeil',
+    'html',
+    'mhchem',
+    'newcommand',
+    'noerrors',
+    'noundefined',
+    'physics',
+    'unicode',
+    'verb'
+];

--- a/mathjax3-ts/input/tex/Configuration.ts
+++ b/mathjax3-ts/input/tex/Configuration.ts
@@ -28,7 +28,7 @@ import {ExtensionMaps, HandlerType} from './MapHandler.js';
 import {StackItemClass} from './StackItem.js';
 import {TagsClass} from './Tags.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import {defaultOptions, OptionList} from '../../util/Options.js';
+import {userOptions, defaultOptions, OptionList} from '../../util/Options.js';
 import ParseOptions from './ParseOptions.js';
 import *  as sm from './SymbolMap.js';
 import {SubHandlers} from './MapHandler.js';
@@ -204,12 +204,13 @@ export class Configuration {
    * @param {Configuration} config   The configuration to be registered in this one
    * @param {TeX} jax                The TeX jax where it is being registered
    */
-  register(config: Configuration, jax: TeX<any, any, any>) {
+  register(config: Configuration, jax: TeX<any, any, any>, options: OptionList = {}) {
     this.append(config);
     config.init(this);
     jax.parseOptions.handlers = new SubHandlers(this);
     jax.parseOptions.nodeFactory.setCreators(config.nodes);
     defaultOptions(jax.parseOptions.options, config.options);
+    userOptions(jax.parseOptions.options, options);
     config.config(this, jax);
     for (const pre of config.preprocessors) {
       Array.isArray(pre) ? jax.preFilters.add(pre[0], pre[1]) : jax.preFilters.add(pre);

--- a/mathjax3-ts/input/tex/Configuration.ts
+++ b/mathjax3-ts/input/tex/Configuration.ts
@@ -31,7 +31,9 @@ import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import {defaultOptions, OptionList} from '../../util/Options.js';
 import ParseOptions from './ParseOptions.js';
 import *  as sm from './SymbolMap.js';
+import {SubHandlers} from './MapHandler.js';
 import {FunctionList} from '../../util/FunctionList.js';
+import {TeX} from '../tex.js';
 
 
 export type HandlerConfig = {[P in HandlerType]?: string[]}
@@ -49,6 +51,12 @@ export class Configuration {
    * @type {FunctionList}
    */
   protected initMethod: FunctionList = new FunctionList();
+
+  /**
+   * Priority list of init methods to call once jax is ready.
+   * @type {FunctionList}
+   */
+  protected configMethod: FunctionList = new FunctionList();
 
   /**
    * Creates a configuration for a package.
@@ -79,7 +87,9 @@ export class Configuration {
                                 preprocessors?: ProcessorList,
                                 postprocessors?: ProcessorList,
                                 init?: Function,
-                                priority?: number
+                                priority?: number,
+                                config?: Function,
+                                configPriority?: number
                                } = {}) {
     return new Configuration(name,
                              config.handler || {},
@@ -90,7 +100,8 @@ export class Configuration {
                              config.nodes || {},
                              config.preprocessors || [],
                              config.postprocessors || [],
-                             [config.init, config.priority]
+                             [config.init, config.priority],
+                             [config.config, config.configPriority]
                             );
   }
 
@@ -127,9 +138,29 @@ export class Configuration {
 
   /**
    * Init method for the configuration.
+   *
+   * @param {Configuration} configuration   The configuration where this one is being initialized
    */
   public init(configuration: Configuration) {
     this.initMethod.execute(configuration);
+  }
+
+  /**
+   * Init method for when the jax is ready
+   *
+   * @param {Configuration} configuration   The configuration where this one is being initialized
+   * @param {TeX} jax                       The TeX jax for this configuration
+   */
+  public config(configuration: Configuration, jax: TeX<any, any, any>) {
+    this.configMethod.execute(configuration, jax);
+    for (const pre of this.preprocessors) {
+      typeof pre === 'function' ? jax.preFilters.add(pre) :
+        jax.preFilters.add(pre[0], pre[1]);
+    }
+    for (const post of this.postprocessors) {
+      typeof post === 'function' ? jax.postFilters.add(post) :
+        jax.postFilters.add(post[0], post[1]);
+    }
   }
 
 
@@ -158,11 +189,35 @@ export class Configuration {
     for (let post of config.postprocessors) {
       this.postprocessors.push(post);
     };
-    for (let init of config.initMethod.toArray()) {
+    for (let init of config.initMethod) {
       this.initMethod.add(init.item, init.priority);
+    };
+    for (let init of config.configMethod) {
+      this.configMethod.add(init.item, init.priority);
     };
   }
 
+  /**
+   * Appends configurations to this configuration. Note that fallbacks are
+   * overwritten, while order of configurations is preserved.
+   *
+   * @param {Configuration} config   The configuration to be registered in this one
+   * @param {TeX} jax                The TeX jax where it is being registered
+   */
+  register(config: Configuration, jax: TeX<any, any, any>) {
+    this.append(config);
+    config.init(this);
+    jax.parseOptions.handlers = new SubHandlers(this);
+    jax.parseOptions.nodeFactory.setCreators(config.nodes);
+    defaultOptions(jax.parseOptions.options, config.options);
+    config.config(this, jax);
+    for (const pre of config.preprocessors) {
+      Array.isArray(pre) ? jax.preFilters.add(pre[0], pre[1]) : jax.preFilters.add(pre);
+    }
+    for (const post of config.postprocessors) {
+      Array.isArray(post) ? jax.postFilters.add(post[0], post[1]) : jax.postFilters.add(post);
+    }
+  }
 
   /**
    * @constructor
@@ -176,10 +231,14 @@ export class Configuration {
                       readonly nodes: {[key: string]: any} = {},
                       readonly preprocessors: ProcessorList = [],
                       readonly postprocessors: ProcessorList = [],
-                      [init, priority]: [Function, number]
+                      [init, priority]: [Function, number],
+                      [config, configPriority]: [Function, number]
              ) {
     if (init) {
       this.initMethod.add(init, priority || 0);
+    }
+    if (config) {
+      this.configMethod.add(config, configPriority || priority || 0);
     }
     this.handler = Object.assign(
       {character: [], delimiter: [], macro: [], environment: []}, handler);

--- a/mathjax3-ts/input/tex/Tags.ts
+++ b/mathjax3-ts/input/tex/Tags.ts
@@ -372,7 +372,7 @@ export class AbstractTags implements Tags {
   public autoTag() {
     if (this.currentTag.tag == null) {
       this.counter++;
-      this.tag(this.counter.toString(), false);
+      this.tag(this.formatNumber(this.counter), false);
     }
   }
 

--- a/mathjax3-ts/input/tex/mhchem/MhchemConfiguration.ts
+++ b/mathjax3-ts/input/tex/mhchem/MhchemConfiguration.ts
@@ -29,7 +29,7 @@ import TexError from '../TexError.js';
 import TexParser from '../TexParser.js';
 import BaseMethods from '../base/BaseMethods.js';
 import AmsMethods from '../ams/AmsMethods.js';
-import './mhchem_parser.js';
+import {mhchemParser, texify} from './mhchem_parser.js';
 
 // Namespace
 let MhchemMethods: Record<string, ParseMethod> = {};

--- a/mathjax3-ts/input/tex/mhchem/mhchem_parser.d.ts
+++ b/mathjax3-ts/input/tex/mhchem/mhchem_parser.d.ts
@@ -1,7 +1,7 @@
-declare namespace mhchemParser {
+export declare namespace mhchemParser {
   export function go(input: string, stateMachine: string): any[];
 }
 
-declare namespace texify {
+export declare namespace texify {
   export function go(input: any[], isInner?: boolean): string;
 }

--- a/mathjax3-ts/input/tex/mhchem/mhchem_parser.js
+++ b/mathjax3-ts/input/tex/mhchem/mhchem_parser.js
@@ -2,7 +2,7 @@
 // Core parser for mhchem syntax  (recursive)
 //
 /** @type {MhchemParser} */
-var mhchemParser = {
+export var mhchemParser = {
   //
   // Parses mchem \ce syntax
   //
@@ -1283,7 +1283,7 @@ mhchemParser.stateMachines = {
 // texify: Take MhchemParser output and convert it to TeX
 //
 /** @type {Texify} */
-var texify = {
+export var texify = {
   go: function (input, isInner) {  // (recursive, max 4 levels)
     if (!input) { return ""; }
     var res = "";
@@ -1606,7 +1606,7 @@ var texify = {
 // Will show type error at calling position
 //
 /** @param {number} a */
-function assertNever(a) {}
+export function assertNever(a) {}
 /** @param {string} a */
-function assertString(a) {}
+export function assertString(a) {}
 


### PR DESCRIPTION
This PR makes several changes to the TeX input jax and it configuration object.

1.  The handling of options to the TeX jax is reorganized a bit in order to process the options before setting up the configuration.  This allows the `packages` option to be processed for `APPEND` and `REMOVE` values (like the arrays), rather than pulling out the `packages` option by hand initially (and not handling `APPEND`/`REMOVE`).

2. A second initialization function is added to the configuration objects, and this is called after the TeX jax and its `parseOptions` object is set up.  This allows configurations to initialize themselves based on the user-provided options (e.g., the `configMacros` extension needs access to the user-supplied `macros` option, which is not available during the `configuration.init()` call).

3.  The installation of the pre- and post-filters for the packages is moved to the `configuration.config()` call.

4.  A new `register()` method is defined that adds a package to the configuration after the input jax has been created.  This is used by the `\require` command to load additional packages and include them into the input jax's configuration.

5.  The `mhchem_parser.js` file is modified to make it compatible with webpack (the global values were problematic).

6.  The `AllPackages.js` file is added to make it easier to enable all the packages.  It includes a couple of packages that will be created by PRs that I haven't yet made, but they will be coming shortly.