### PR TITLE
Update TeX packages

### DIFF
--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -667,8 +667,8 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
      * @param {Error} err      The Error object for the error
      */
     public compileError(math: MathItem<N, T, D>, err: Error) {
-        math.root = this.mmlFactory.create('math', {'data-mjx-error': err.message}, [
-            this.mmlFactory.create('merror', null, [
+        math.root = this.mmlFactory.create('math', null, [
+            this.mmlFactory.create('merror', {'data-mjx-error': err.message}, [
                 this.mmlFactory.create('mtext', null, [
                     (this.mmlFactory.create('text') as TextNode).setText('Math input error')
                 ])

--- a/mathjax3-ts/input/tex/ams_cd/AmsCdConfiguration.ts
+++ b/mathjax3-ts/input/tex/ams_cd/AmsCdConfiguration.ts
@@ -33,11 +33,13 @@ export const AmsCdConfiguration = Configuration.create(
     macro: ['amsCd_macros'],
     environment: ['amsCd_environment']
   },
-   options: {
-    colspace: '5pt',
-    rowspace: '5pt',
-    harrowsize: '2.75em',
-    varrowsize: '1.75em',
-    hideHorizontalLabels: false
+  options: {
+    amsCd: {
+      colspace: '5pt',
+      rowspace: '5pt',
+      harrowsize: '2.75em',
+      varrowsize: '1.75em',
+      hideHorizontalLabels: false
+    }
   }}
 );

--- a/mathjax3-ts/input/tex/ams_cd/AmsCdMethods.ts
+++ b/mathjax3-ts/input/tex/ams_cd/AmsCdMethods.ts
@@ -47,14 +47,15 @@ let AmsCdMethods: Record<string, ParseMethod> = {};
 AmsCdMethods.CD = function(parser: TexParser, begin: StackItem) {
   parser.Push(begin);
   let item = parser.itemFactory.create('array') as ArrayItem;
+  let options = parser.configuration.options.amsCd;
   item.setProperties({
-    minw: parser.stack.env.CD_minw || parser.configuration.options.harrowsize,
-    minh: parser.stack.env.CD_minh || parser.configuration.options.varrowsize
+    minw: parser.stack.env.CD_minw || options.harrowsize,
+    minh: parser.stack.env.CD_minh || options.varrowsize
   });
   item.arraydef = {
       columnalign: 'center',
-      columnspacing: parser.configuration.options.colspace,
-      rowspacing: parser.configuration.options.rowspace,
+      columnspacing: options.colspace,
+      rowspacing: options.rowspace,
       displaystyle: true
   };
   return item;
@@ -122,14 +123,14 @@ AmsCdMethods.arrow = function(parser: TexParser, name: string) {
         if (a) {
           let nodeA = new TexParser(a, parser.stack.env, parser.configuration).mml();
           let mpadded = parser.create('node', 'mpadded', [nodeA], pad);
-          NodeUtil.setAttribute(mpadded, 'voffset', '1em');
+          NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
           NodeUtil.setChild(mml, mml.over, mpadded);
         }
         if (b) {
           let nodeB = new TexParser(b, parser.stack.env, parser.configuration).mml();
           NodeUtil.setChild(mml, mml.under, parser.create('node', 'mpadded', [nodeB], pad));
         }
-          if (parser.configuration.options.hideHorizontalLabels) {
+          if (parser.configuration.options.amsCd.hideHorizontalLabels) {
             mml = parser.create('node', 'mpadded', mml, {depth: 0, height: '.67em'});
           }
         }

--- a/mathjax3-ts/input/tex/color/ColorConfiguration.ts
+++ b/mathjax3-ts/input/tex/color/ColorConfiguration.ts
@@ -28,7 +28,11 @@ import { Configuration } from '../Configuration.js';
 import { ColorMethods } from './ColorMethods.js';
 import { ColorModel } from './ColorUtil.js';
 
+import { TeX } from '../../tex.js';
 
+/**
+ * The color macros
+ */
 new CommandMap('color', {
     color: 'Color',
     textcolor: 'TextColor',
@@ -38,19 +42,29 @@ new CommandMap('color', {
 }, ColorMethods);
 
 /**
- * Init method for Color package.
+ * Config method for Color package.
+ *
  * @param {Configuration} config The current configuration.
+ * @param {TeX} jax              The TeX jax having that configuration
  */
-const init = function(config: Configuration) {
-    config.options['colorModel'] = new ColorModel();
+const config = function(config: Configuration, jax: TeX<any, any, any>) {
+    jax.parseOptions.options.color.model = new ColorModel();
 };
 
-export const ColorConfiguration = Configuration.create('color', {
-    handler: {
-        macro: ['color'],
-    }, options: {
-        colorPadding: '5px',
-        colorBorderWidth: '2px',
-    },
-    init: init
-});
+/**
+ * The configuration for the color macros
+ */
+export const ColorConfiguration = Configuration.create(
+    'color', {
+        handler: {
+            macro: ['color'],
+        },
+        options: {
+            color: {
+                padding: '5px',
+                borderWidth: '2px'
+            }
+        },
+        config: config
+    }
+);

--- a/mathjax3-ts/input/tex/color/ColorMethods.ts
+++ b/mathjax3-ts/input/tex/color/ColorMethods.ts
@@ -62,7 +62,7 @@ export const ColorMethods: Record<string, ParseMethod> = {};
 ColorMethods.Color = function (parser: TexParser, name: string) {
     const model = parser.GetBrackets(name, '');
     const colorDef = parser.GetArgument(name);
-    const colorModel: ColorModel = parser.options['colorModel'];
+    const colorModel: ColorModel = parser.options.color.model;
     const color = colorModel.getColor(model, colorDef);
 
     const style = parser.itemFactory.create('style')
@@ -82,7 +82,7 @@ ColorMethods.Color = function (parser: TexParser, name: string) {
 ColorMethods.TextColor = function (parser: TexParser, name: string) {
     const model = parser.GetBrackets(name, '');
     const colorDef = parser.GetArgument(name);
-    const colorModel: ColorModel = parser.options['colorModel'];
+    const colorModel: ColorModel = parser.options.color.model;
     const color = colorModel.getColor(model, colorDef);
     const old = parser.stack.env['color'];
 
@@ -110,7 +110,7 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
     const model = parser.GetArgument(name);
     const def = parser.GetArgument(name);
 
-    const colorModel: ColorModel = parser.options['colorModel'];
+    const colorModel: ColorModel = parser.options.color.model;
     colorModel.defineColor(model, cname, def);
 };
 
@@ -123,13 +123,14 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
 ColorMethods.ColorBox = function (parser: TexParser, name: string) {
     const cname = parser.GetArgument(name);
     const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
-    const colorModel: ColorModel = parser.options['colorModel'];
+    const options = parser.options.color;
+    const colorModel: ColorModel = options.model;
 
     const node = parser.create('node', 'mpadded', math, {
         mathbackground: colorModel.getColor('named', cname)
     });
 
-    NodeUtil.setProperties(node, padding(parser.options['colorPadding']));
+    NodeUtil.setProperties(node, padding(options.padding));
     parser.Push(node);
 };
 
@@ -143,13 +144,14 @@ ColorMethods.FColorBox = function (parser: TexParser, name: string) {
     const fname = parser.GetArgument(name);
     const cname = parser.GetArgument(name);
     const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
-    const colorModel: ColorModel = parser.options['colorModel'];
+    const options = parser.options.color;
+    const colorModel: ColorModel = options.model;
 
     const node = parser.create('node', 'mpadded', math, {
         mathbackground: colorModel.getColor('named', cname),
-        style: `border: ${parser.options['colorBorderWidth']} solid ${colorModel.getColor('named', fname)}`
+        style: `border: ${options.borderWidth} solid ${colorModel.getColor('named', fname)}`
     });
 
-    NodeUtil.setProperties(node, padding(parser.options['colorPadding']));
+    NodeUtil.setProperties(node, padding(options.padding));
     parser.Push(node);
 };

--- a/mathjax3-ts/input/tex/noerrors/NoErrorsConfiguration.ts
+++ b/mathjax3-ts/input/tex/noerrors/NoErrorsConfiguration.ts
@@ -36,7 +36,7 @@ import {NodeFactory} from '../NodeFactory.js';
 function noErrors(factory: NodeFactory,
                   message: string, id: string, expr: string) {
   let mtext = factory.create('token', 'mtext', {}, expr.replace(/\n/g, ' '));
-  let error = factory.create('node', 'merror', [mtext]);
+  let error = factory.create('node', 'merror', [mtext], {'data-mjx-error': message});
   return error;
 };
 


### PR DESCRIPTION
This updates existing TeX packages to use the new configuration functionality, and to make them work with the `\require` macro (coming in a PR shortly).  This includes moving options into sub-blocks, for example, the `amsCd` options are moved into an `amsCd` block, and you would configure the TeX jax using

```
new TeX({
  packages: {[APPEND]: ['amsCd']},
  amsCd: {
    colspace: '10pt',
    rowspace: '10pt'
  }
});
```

for example.  This makes it clearer what those options refer to.  In addition to the `amsCd` options, the `color` extension's options are moved to a `color` block.

The `noerrors` package now adds a `data-mix-error` attribute that stores the actual error message (for easier retrieval), and the similar error attribute for "Math input error" messages `MathDocument` class has been moved to the `merror` element for consistency.  (Eventually, the context menu should retrieve this message and make it available to the user.)