### PR TITLE
Add new TeX components

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -55,6 +55,7 @@ const config = JSON.parse(fs.readFileSync(process.argv[2] || 'build.json'));
  */
 const TARGETS = config.targets || [];                                       // the files to include in the component
 const EXCLUDE = new Map((config.exclude || []).map(name => [name, true]));  // files to exclude from the component
+const EXCLUDESUBDIRS = config.excludeSubdirs === 'true';                    // exclude subdirectories
 const MATHJAX3 = config.mathjax3 || mj3path;                                // path to the mathjax3 .js files
 const LIB = config.lib || './lib';                                          // path to the lib directory to create
 const COMPONENT = path.basename(config.component || 'part');                // name of the component
@@ -71,14 +72,17 @@ let PACKAGE = [];
  * @param {string} base    The root directory for the .ts files
  * @param {string} dir     The relative path within the root for the files to process
  * @param {string[]} list  An array of file/directory names to process
+ * @param {boolean} top    True if this is the initial list of files
  */
-function processList(base, dir, list) {
+function processList(base, dir, list, top = true) {
     for (const item of list) {
         const file = path.join(dir, item);
         if (!EXCLUDE.has(file)) {
             const stat = fs.statSync(path.resolve(base, file));
             if (stat.isDirectory()) {
-                processDir(base, file);
+                if (top || !EXCLUDESUBDIRS) {
+                    processDir(base, file);
+                }
             } else if (file.match(/\.ts/)) {
                 processFile(base, file);
             }
@@ -94,7 +98,7 @@ function processList(base, dir, list) {
  */
 function processDir(base, dir) {
     const root = path.resolve(base, dir);
-    processList(base, dir, fs.readdirSync(root));
+    processList(base, dir, fs.readdirSync(root), false);
 }
 
 /**

--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -25,6 +25,7 @@ exports.dependencies = {
     '[tex]/noundefined': ['input/tex-base'],
     '[tex]/physics': ['input/tex-base'],
     '[tex]/require': ['input/tex-base'],
+    '[tex]/tagFormat': ['input/tex-base'],
     '[tex]/unicode': ['input/tex-base'],
     '[tex]/verb': ['input/tex-base']
 };

--- a/components/src/input/tex-base/build.json
+++ b/components/src/input/tex-base/build.json
@@ -1,29 +1,7 @@
 {
     "component": "input/tex-base",
     "targets": ["input/tex.ts", "input/tex"],
-    "exclude": [
-        "input/tex/AllPackages.ts",
-        "input/tex/action",
-        "input/tex/ams",
-        "input/tex/ams_cd",
-        "input/tex/autoload",
-        "input/tex/bbox",
-        "input/tex/boldsymbol",
-        "input/tex/braket",
-        "input/tex/cancel",
-        "input/tex/color",
-        "input/tex/config_macros",
-        "input/tex/enclose",
-        "input/tex/extpfeil",
-        "input/tex/html",
-        "input/tex/mhchem",
-        "input/tex/newcommand",
-        "input/tex/noerrors",
-        "input/tex/noundefined",
-        "input/tex/physics",
-        "input/tex/require",
-        "input/tex/unicode",
-        "input/tex/verb"
-    ]
+    "exclude": ["input/tex/AllPackages.ts"],
+    "excludeSubdirs": "true"
 }
 

--- a/components/src/input/tex-base/build.json
+++ b/components/src/input/tex-base/build.json
@@ -1,0 +1,29 @@
+{
+    "component": "input/tex-base",
+    "targets": ["input/tex.ts", "input/tex"],
+    "exclude": [
+        "input/tex/AllPackages.ts",
+        "input/tex/action",
+        "input/tex/ams",
+        "input/tex/ams_cd",
+        "input/tex/autoload",
+        "input/tex/bbox",
+        "input/tex/boldsymbol",
+        "input/tex/braket",
+        "input/tex/cancel",
+        "input/tex/color",
+        "input/tex/config_macros",
+        "input/tex/enclose",
+        "input/tex/extpfeil",
+        "input/tex/html",
+        "input/tex/mhchem",
+        "input/tex/newcommand",
+        "input/tex/noerrors",
+        "input/tex/noundefined",
+        "input/tex/physics",
+        "input/tex/require",
+        "input/tex/unicode",
+        "input/tex/verb"
+    ]
+}
+

--- a/components/src/input/tex-base/tex-base.js
+++ b/components/src/input/tex-base/tex-base.js
@@ -1,0 +1,6 @@
+import './lib/tex-base.js';
+
+import {registerTeX} from '../tex/register.js';
+
+registerTeX(['base']);
+

--- a/components/src/input/tex-base/webpack.config.js
+++ b/components/src/input/tex-base/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex-base',                   // the package to build
+    '../../../../mathjax3',             // location of the mathjax3 library
+    ['components/src/core/lib'],        // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/input/tex-full/build.json
+++ b/components/src/input/tex-full/build.json
@@ -1,6 +1,9 @@
 {
     "component": "input/tex-full",
     "targets": ["input/tex.ts", "input/tex"],
-    "exclude": ["input/tex/mhchem/mhchem_parser.d.ts"]
+    "exclude": [
+        "input/tex/tag_format",
+        "input/tex/mhchem/mhchem_parser.d.ts"
+    ]
 }
 

--- a/components/src/input/tex-full/build.json
+++ b/components/src/input/tex-full/build.json
@@ -1,0 +1,6 @@
+{
+    "component": "input/tex-full",
+    "targets": ["input/tex.ts", "input/tex"],
+    "exclude": ["input/tex/mhchem/mhchem_parser.d.ts"]
+}
+

--- a/components/src/input/tex-full/tex-full.js
+++ b/components/src/input/tex-full/tex-full.js
@@ -1,0 +1,32 @@
+import './lib/tex-full.js';
+
+import {registerTeX} from '../tex/register.js';
+import {Loader} from '../../../../mathjax3/components/loader.js';
+import {AllPackages} from '../../../../mathjax3/input/tex/AllPackages.js';
+
+Loader.preLoad(
+    'input/tex-base',
+    '[tex]/all-packages',
+    '[tex]/action',
+    '[tex]/ams',
+    '[tex]/ams_cd',
+    '[tex]/bbox',
+    '[tex]/boldsymbol',
+    '[tex]/braket',
+    '[tex]/cancel',
+    '[tex]/color',
+    '[tex]/configMacros',
+    '[tex]/enclose',
+    '[tex]/extpfeil',
+    '[tex]/html',
+    '[tex]/mhchem',
+    '[tex]/newcommand',
+    '[tex]/noerrors',
+    '[tex]/noundefined',
+    '[tex]/physics',
+    '[tex]/require',
+    '[tex]/unicode',
+    '[tex]/verb'
+);
+
+registerTeX(AllPackages);

--- a/components/src/input/tex-full/webpack.config.js
+++ b/components/src/input/tex-full/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex-full',                   // the package to build
+    '../../../../mathjax3',             // location of the mathjax3 library
+    ['components/src/core/lib'],        // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/build.json
+++ b/components/src/input/tex/build.json
@@ -1,5 +1,23 @@
 {
     "component": "input/tex",
-    "targets": ["input/tex.ts", "input/tex"]
+    "targets": ["input/tex.ts", "input/tex"],
+    "exclude": [
+        "input/tex/AllPackages.ts",
+        "input/tex/action",
+        "input/tex/ams_cd",
+        "input/tex/bbox",
+        "input/tex/boldsymbol",
+        "input/tex/braket",
+        "input/tex/cancel",
+        "input/tex/color",
+        "input/tex/enclose",
+        "input/tex/extpfeil",
+        "input/tex/html",
+        "input/tex/mhchem",
+        "input/tex/noerrors",
+        "input/tex/physics",
+        "input/tex/unicode",
+        "input/tex/verb"
+    ]
 }
 

--- a/components/src/input/tex/build.json
+++ b/components/src/input/tex/build.json
@@ -1,23 +1,17 @@
 {
     "component": "input/tex",
-    "targets": ["input/tex.ts", "input/tex"],
-    "exclude": [
-        "input/tex/AllPackages.ts",
-        "input/tex/action",
-        "input/tex/ams_cd",
-        "input/tex/bbox",
-        "input/tex/boldsymbol",
-        "input/tex/braket",
-        "input/tex/cancel",
-        "input/tex/color",
-        "input/tex/enclose",
-        "input/tex/extpfeil",
-        "input/tex/html",
-        "input/tex/mhchem",
-        "input/tex/noerrors",
-        "input/tex/physics",
-        "input/tex/unicode",
-        "input/tex/verb"
-    ]
+    "targets": [
+        "input/tex.ts",
+        "input/tex",
+        "input/tex/base",
+        "input/tex/ams",
+        "input/tex/newcommand",
+        "input/tex/noundefined",
+        "input/tex/require",
+        "input/tex/autoload",
+        "input/tex/config_macros"
+    ],
+    "exclude": ["input/tex/AllPackages.ts"],
+    "excludeSubdirs": "true"
 }
 

--- a/components/src/input/tex/extensions/action/action.js
+++ b/components/src/input/tex/extensions/action/action.js
@@ -1,0 +1,1 @@
+import './lib/action.js';

--- a/components/src/input/tex/extensions/action/build.json
+++ b/components/src/input/tex/extensions/action/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/action",
+    "targets": ["input/tex/action"]
+}
+

--- a/components/src/input/tex/extensions/action/webpack.config.js
+++ b/components/src/input/tex/extensions/action/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/action',      // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/all-packages/all-packages.js
+++ b/components/src/input/tex/extensions/all-packages/all-packages.js
@@ -1,0 +1,38 @@
+import './lib/all-packages.js';
+
+import {AllPackages} from '../../../../../../mathjax3/input/tex/AllPackages.js';
+import {insert} from '../../../../../../mathjax3/util/Options.js';
+
+Loader.preLoad(
+    '[tex]/action',
+    '[tex]/ams',
+    '[tex]/ams_cd',
+    '[tex]/bbox',
+    '[tex]/boldsymbol',
+    '[tex]/braket',
+    '[tex]/cancel',
+    '[tex]/color',
+    '[tex]/configMacros',
+    '[tex]/enclose',
+    '[tex]/extpfeil',
+    '[tex]/html',
+    '[tex]/mhchem',
+    '[tex]/newcommand',
+    '[tex]/noerrors',
+    '[tex]/noundefined',
+    '[tex]/physics',
+    '[tex]/require',
+    '[tex]/unicode',
+    '[tex]/verb'
+);
+
+if (MathJax.startup) {
+    if (!MathJax.config.tex) {
+        MathJax.config.tex = {};
+    }
+    let packages = MathJax.config.tex.packages;
+    MathJax.config.tex.packages = [...AllPackages];
+    if (packages) {
+        insert(MathJax.config.tex, {packages});
+    }
+}

--- a/components/src/input/tex/extensions/all-packages/build.json
+++ b/components/src/input/tex/extensions/all-packages/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/all-packages",
+    "targets": ["input/tex/AllPackages.ts"]
+}
+

--- a/components/src/input/tex/extensions/all-packages/webpack.config.js
+++ b/components/src/input/tex/extensions/all-packages/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/all-packages',// the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/ams/ams.js
+++ b/components/src/input/tex/extensions/ams/ams.js
@@ -1,0 +1,1 @@
+import './lib/ams.js';

--- a/components/src/input/tex/extensions/ams/build.json
+++ b/components/src/input/tex/extensions/ams/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/ams",
+    "targets": ["input/tex/ams"]
+}
+

--- a/components/src/input/tex/extensions/ams/webpack.config.js
+++ b/components/src/input/tex/extensions/ams/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/ams',         // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/ams_cd/amscd.js
+++ b/components/src/input/tex/extensions/ams_cd/amscd.js
@@ -1,0 +1,1 @@
+import './lib/amsCd.js';

--- a/components/src/input/tex/extensions/ams_cd/build.json
+++ b/components/src/input/tex/extensions/ams_cd/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/amscd",
+    "targets": ["input/tex/ams_cd"]
+}
+

--- a/components/src/input/tex/extensions/ams_cd/webpack.config.js
+++ b/components/src/input/tex/extensions/ams_cd/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/amscd',       // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/autoload/autoload.js
+++ b/components/src/input/tex/extensions/autoload/autoload.js
@@ -1,0 +1,1 @@
+import './lib/autoload.js';

--- a/components/src/input/tex/extensions/autoload/build.json
+++ b/components/src/input/tex/extensions/autoload/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/autoload",
+    "targets": ["input/tex/autoload"]
+}
+

--- a/components/src/input/tex/extensions/autoload/webpack.config.js
+++ b/components/src/input/tex/extensions/autoload/webpack.config.js
@@ -1,0 +1,13 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/autoload',    // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex/extensions/require/lib',
+        'components/src/input/tex-base/lib',
+        'components/src/startup/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/bbox/bbox.js
+++ b/components/src/input/tex/extensions/bbox/bbox.js
@@ -1,0 +1,1 @@
+import './lib/bbox.js';

--- a/components/src/input/tex/extensions/bbox/build.json
+++ b/components/src/input/tex/extensions/bbox/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/bbox",
+    "targets": ["input/tex/bbox"]
+}
+

--- a/components/src/input/tex/extensions/bbox/webpack.config.js
+++ b/components/src/input/tex/extensions/bbox/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/bbox',        // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/boldsymbol/boldsymbol.js
+++ b/components/src/input/tex/extensions/boldsymbol/boldsymbol.js
@@ -1,0 +1,1 @@
+import './lib/boldsymbol.js';

--- a/components/src/input/tex/extensions/boldsymbol/build.json
+++ b/components/src/input/tex/extensions/boldsymbol/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/boldsymbol",
+    "targets": ["input/tex/boldsymbol"]
+}
+

--- a/components/src/input/tex/extensions/boldsymbol/webpack.config.js
+++ b/components/src/input/tex/extensions/boldsymbol/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/boldsymbol',  // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/braket/braket.js
+++ b/components/src/input/tex/extensions/braket/braket.js
@@ -1,0 +1,1 @@
+import './lib/braket.js';

--- a/components/src/input/tex/extensions/braket/build.json
+++ b/components/src/input/tex/extensions/braket/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/braket",
+    "targets": ["input/tex/braket"]
+}
+

--- a/components/src/input/tex/extensions/braket/webpack.config.js
+++ b/components/src/input/tex/extensions/braket/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/braket',      // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/cancel/build.json
+++ b/components/src/input/tex/extensions/cancel/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/cancel",
+    "targets": ["input/tex/cancel"]
+}
+

--- a/components/src/input/tex/extensions/cancel/cancel.js
+++ b/components/src/input/tex/extensions/cancel/cancel.js
@@ -1,0 +1,1 @@
+import './lib/cancel.js';

--- a/components/src/input/tex/extensions/cancel/webpack.config.js
+++ b/components/src/input/tex/extensions/cancel/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/cancel',      // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/color/build.json
+++ b/components/src/input/tex/extensions/color/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/color",
+    "targets": ["input/tex/color"]
+}
+

--- a/components/src/input/tex/extensions/color/color.js
+++ b/components/src/input/tex/extensions/color/color.js
@@ -1,0 +1,1 @@
+import './lib/color.js';

--- a/components/src/input/tex/extensions/color/webpack.config.js
+++ b/components/src/input/tex/extensions/color/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/color',       // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/config_macros/build.json
+++ b/components/src/input/tex/extensions/config_macros/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/configMacros",
+    "targets": ["input/tex/config_macros"]
+}
+

--- a/components/src/input/tex/extensions/config_macros/configMacros.js
+++ b/components/src/input/tex/extensions/config_macros/configMacros.js
@@ -1,0 +1,1 @@
+import './lib/configMacros.js';

--- a/components/src/input/tex/extensions/config_macros/webpack.config.js
+++ b/components/src/input/tex/extensions/config_macros/webpack.config.js
@@ -1,0 +1,13 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/configMacros',// the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex/extensions/newcommand/lib',
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib',
+        'components/src/startup/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/enclose/build.json
+++ b/components/src/input/tex/extensions/enclose/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/enclose",
+    "targets": ["input/tex/enclose"]
+}
+

--- a/components/src/input/tex/extensions/enclose/enclose.js
+++ b/components/src/input/tex/extensions/enclose/enclose.js
@@ -1,0 +1,1 @@
+import './lib/enclose.js';

--- a/components/src/input/tex/extensions/enclose/webpack.config.js
+++ b/components/src/input/tex/extensions/enclose/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/enclose',     // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/extpfeil/build.json
+++ b/components/src/input/tex/extensions/extpfeil/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/extpfeil",
+    "targets": ["input/tex/extpfeil"]
+}
+

--- a/components/src/input/tex/extensions/extpfeil/extpfeil.js
+++ b/components/src/input/tex/extensions/extpfeil/extpfeil.js
@@ -1,0 +1,1 @@
+import './lib/extpfeil.js';

--- a/components/src/input/tex/extensions/extpfeil/webpack.config.js
+++ b/components/src/input/tex/extensions/extpfeil/webpack.config.js
@@ -1,0 +1,13 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/extpfeil',    // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex/extensions/ams/lib',
+        'components/src/input/tex/extensions/newcommand/lib',
+        'components/src/input/tex-lib/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/html/build.json
+++ b/components/src/input/tex/extensions/html/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/html",
+    "targets": ["input/tex/html"]
+}
+

--- a/components/src/input/tex/extensions/html/html.js
+++ b/components/src/input/tex/extensions/html/html.js
@@ -1,0 +1,1 @@
+import './lib/html.js';

--- a/components/src/input/tex/extensions/html/webpack.config.js
+++ b/components/src/input/tex/extensions/html/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/html',        // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/mhchem/build.json
+++ b/components/src/input/tex/extensions/mhchem/build.json
@@ -1,0 +1,6 @@
+{
+    "component": "input/tex/extensions/mhchem",
+    "targets": ["input/tex/mhchem"],
+    "exclude": ["input/tex/mhchem/mhchem_parser.d.ts"]
+}
+

--- a/components/src/input/tex/extensions/mhchem/mhchem.js
+++ b/components/src/input/tex/extensions/mhchem/mhchem.js
@@ -1,0 +1,1 @@
+import './lib/mhchem.js';

--- a/components/src/input/tex/extensions/mhchem/webpack.config.js
+++ b/components/src/input/tex/extensions/mhchem/webpack.config.js
@@ -1,0 +1,12 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/mhchem',      // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex/extensions/ams/lib',
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/newcommand/build.json
+++ b/components/src/input/tex/extensions/newcommand/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/newcommand",
+    "targets": ["input/tex/newcommand"]
+}
+

--- a/components/src/input/tex/extensions/newcommand/newcommand.js
+++ b/components/src/input/tex/extensions/newcommand/newcommand.js
@@ -1,0 +1,1 @@
+import './lib/newcommand.js';

--- a/components/src/input/tex/extensions/newcommand/webpack.config.js
+++ b/components/src/input/tex/extensions/newcommand/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/newcommand',  // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/noerrors/build.json
+++ b/components/src/input/tex/extensions/noerrors/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/noerrors",
+    "targets": ["input/tex/noerrors"]
+}
+

--- a/components/src/input/tex/extensions/noerrors/noerrors.js
+++ b/components/src/input/tex/extensions/noerrors/noerrors.js
@@ -1,0 +1,1 @@
+import './lib/noerrors.js';

--- a/components/src/input/tex/extensions/noerrors/webpack.config.js
+++ b/components/src/input/tex/extensions/noerrors/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/noerrors',    // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/noundefined/build.json
+++ b/components/src/input/tex/extensions/noundefined/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/noundefined",
+    "targets": ["input/tex/noundefined"]
+}
+

--- a/components/src/input/tex/extensions/noundefined/noundefined.js
+++ b/components/src/input/tex/extensions/noundefined/noundefined.js
@@ -1,0 +1,1 @@
+import './lib/noundefined.js';

--- a/components/src/input/tex/extensions/noundefined/webpack.config.js
+++ b/components/src/input/tex/extensions/noundefined/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/noundefined', // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/physics/build.json
+++ b/components/src/input/tex/extensions/physics/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/physics",
+    "targets": ["input/tex/physics"]
+}
+

--- a/components/src/input/tex/extensions/physics/physics.js
+++ b/components/src/input/tex/extensions/physics/physics.js
@@ -1,0 +1,1 @@
+import './lib/physics.js';

--- a/components/src/input/tex/extensions/physics/webpack.config.js
+++ b/components/src/input/tex/extensions/physics/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/physics',     // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/require/build.json
+++ b/components/src/input/tex/extensions/require/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/require",
+    "targets": ["input/tex/require"]
+}
+

--- a/components/src/input/tex/extensions/require/require.js
+++ b/components/src/input/tex/extensions/require/require.js
@@ -1,0 +1,1 @@
+import './lib/require.js';

--- a/components/src/input/tex/extensions/require/webpack.config.js
+++ b/components/src/input/tex/extensions/require/webpack.config.js
@@ -1,0 +1,12 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/require',     // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib',
+        'components/src/startup/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/tag_format/build.json
+++ b/components/src/input/tex/extensions/tag_format/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/tagFormat",
+    "targets": ["input/tex/tag_format"]
+}
+

--- a/components/src/input/tex/extensions/tag_format/tagFormat.js
+++ b/components/src/input/tex/extensions/tag_format/tagFormat.js
@@ -1,0 +1,1 @@
+import './lib/tagFormat.js';

--- a/components/src/input/tex/extensions/tag_format/webpack.config.js
+++ b/components/src/input/tex/extensions/tag_format/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/tagFormat',   // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/unicode/build.json
+++ b/components/src/input/tex/extensions/unicode/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/unicode",
+    "targets": ["input/tex/unicode"]
+}
+

--- a/components/src/input/tex/extensions/unicode/unicode.js
+++ b/components/src/input/tex/extensions/unicode/unicode.js
@@ -1,0 +1,1 @@
+import './lib/unicode.js';

--- a/components/src/input/tex/extensions/unicode/webpack.config.js
+++ b/components/src/input/tex/extensions/unicode/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/unicode',     // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/extensions/verb/build.json
+++ b/components/src/input/tex/extensions/verb/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "input/tex/extensions/verb",
+    "targets": ["input/tex/verb"]
+}
+

--- a/components/src/input/tex/extensions/verb/verb.js
+++ b/components/src/input/tex/extensions/verb/verb.js
@@ -1,0 +1,1 @@
+import './lib/verb.js';

--- a/components/src/input/tex/extensions/verb/webpack.config.js
+++ b/components/src/input/tex/extensions/verb/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/tex/extensions/verb',        // the package to build
+    '../../../../../../mathjax3',       // location of the mathjax3 library
+    [                                   // packages to link to
+        'components/src/input/tex-base/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/input/tex/register.js
+++ b/components/src/input/tex/register.js
@@ -1,0 +1,17 @@
+import {TeX} from '../../../../mathjax3/input/tex.js';
+import {insert} from '../../../../mathjax3/util/Options.js';
+
+export function registerTeX(packageList) {
+    if (MathJax.startup) {
+        MathJax.startup.registerConstructor('tex', TeX);
+        MathJax.startup.useInput('tex');
+        if (!MathJax.config.tex) {
+            MathJax.config.tex = {};
+        }
+        let packages = MathJax.config.tex.packages;
+        MathJax.config.tex.packages = packageList;
+        if (packages) {
+            insert(MathJax.config.tex, {packages});
+        }
+    }
+}

--- a/components/src/input/tex/tex.js
+++ b/components/src/input/tex/tex.js
@@ -1,8 +1,24 @@
 import './lib/tex.js';
 
-import {TeX} from '../../../../mathjax3/input/tex.js';
+import {registerTeX} from './register.js';
+import {Loader} from '../../../../mathjax3/components/loader.js';
 
-if (MathJax.startup) {
-    MathJax.startup.registerConstructor('tex', TeX);
-    MathJax.startup.useInput('tex');
-}
+Loader.preLoad(
+    'input/tex-base',
+    '[tex]/ams',
+    '[tex]/newcommand',
+    '[tex]/noundefined',
+    '[tex]/require',
+    '[tex]/autoload',
+    '[tex]/configMacros'
+);
+
+registerTeX([
+    'base',
+    'ams',
+    'newcommand',
+    'noundefined',
+    'require',
+    'autoload',
+    'configMacros'
+]);

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -27,6 +27,7 @@ exports.source = {
     '[tex]/noundefined': `${src}/input/tex/extensions/noundefined/noundefined.js`,
     '[tex]/physics': `${src}/input/tex/extensions/physics/physics.js`,
     '[tex]/require': `${src}/input/tex/extensions/require/require.js`,
+    '[tex]/tagFormat': `${src}/input/tex/extensions/tag_format/tagFormat.js`,
     '[tex]/unicode': `${src}/input/tex/extensions/unicode/unicode.js`,
     '[tex]/verb': `${src}/input/tex/extensions/verb/verb.js`,
     'input/mml': `${src}/input/mml/mml.js`,


### PR DESCRIPTION
This PR adds the definition files for all the TeX extension packages.  It also adds `input/tex-base` and `input/tex-full` components as alternative TeX components.  The original `input/tex` component includes several of the basic extensions (ams, newcommand, noundefined, require, autoload, and configMacros), while `tex-base` is just the raw TeX input jax with the `base` extension, and `tex-full` includes all the main extensions from `AllPackages`.

To make the configurations easier to produce, the `bin/build` command has a new `excludeSubdirs` option that prevents descending into subdirectories (so that you have to list the included subdirectories by hand).