### PR TITLE
Add combined components

### DIFF
--- a/components/src/mml-chtml/mml-chtml.js
+++ b/components/src/mml-chtml/mml-chtml.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/mml/mml.js';
+import '../output/chtml/chtml.js';
+import '../output/chtml/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/mml-chtml/preload.js
+++ b/components/src/mml-chtml/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/mml',
+    'output/chtml', 'output/chtml/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/mml-chtml/test.html
+++ b/components/src/mml-chtml/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/mml-chtml.js"></script>
+</head>
+<body>
+
+<math display="block">
+<mi>x</mi>
+<mo>+</mo>
+<mn>1</mn>
+</math>
+
+</body>
+</html>

--- a/components/src/mml-chtml/test.js
+++ b/components/src/mml-chtml/test.js
@@ -1,0 +1,14 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/mml-chtml.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.startup.adaptor.outerHTML(MathJax.mathml2chtml('<math><mi>x</mi></math>')));

--- a/components/src/mml-chtml/webpack.config.js
+++ b/components/src/mml-chtml/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'mml-chtml',                        // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/mml-svg/mml-svg.js
+++ b/components/src/mml-svg/mml-svg.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/mml/mml.js';
+import '../output/svg/svg.js';
+import '../output/svg/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/mml-svg/preload.js
+++ b/components/src/mml-svg/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/mml',
+    'output/svg', 'output/svg/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/mml-svg/test.html
+++ b/components/src/mml-svg/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/mml-svg.js"></script>
+</head>
+<body>
+
+<math display="block">
+<mi>x</mi>
+<mo>+</mo>
+<mn>1</mn>
+</math>
+
+</body>
+</html>

--- a/components/src/mml-svg/test.js
+++ b/components/src/mml-svg/test.js
@@ -1,0 +1,14 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/mml-svg.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.startup.adaptor.outerHTML(MathJax.mathml2svg('<math><mi>x</mi></math>')));

--- a/components/src/mml-svg/webpack.config.js
+++ b/components/src/mml-svg/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'mml-svg',                          // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/tex-chtml/preload.js
+++ b/components/src/tex-chtml/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex',
+    'output/chtml', 'output/chtml/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-chtml/test.html
+++ b/components/src/tex-chtml/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/tex-chtml.js"></script>
+</head>
+<body>
+
+$$\color{red}x+1$$
+
+</body>
+</html>

--- a/components/src/tex-chtml/test.js
+++ b/components/src/tex-chtml/test.js
@@ -1,0 +1,14 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/tex-chtml.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.tex2mml('x+1'));

--- a/components/src/tex-chtml/tex-chtml.js
+++ b/components/src/tex-chtml/tex-chtml.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex/tex.js';
+import '../output/chtml/chtml.js';
+import '../output/chtml/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-chtml/webpack.config.js
+++ b/components/src/tex-chtml/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-chtml',                        // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/tex-mml-chtml/preload.js
+++ b/components/src/tex-mml-chtml/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex', 'input/mml',
+    'output/chtml', 'output/chtml/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-mml-chtml/test.html
+++ b/components/src/tex-mml-chtml/test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/tex-mml-chtml.js"></script>
+</head>
+<body>
+
+$$\color{red}x+1$$
+
+<math display="block">
+<mi>x</mi>
+<mo>+</mo>
+<mn>1</mn>
+</math>
+
+</body>
+</html>

--- a/components/src/tex-mml-chtml/test.js
+++ b/components/src/tex-mml-chtml/test.js
@@ -1,0 +1,15 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/tex-mml-chtml.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.tex2mml('x+1'));
+console.log(MathJax.mathml2mml('<math><mi>x</mi></math>'));

--- a/components/src/tex-mml-chtml/tex-mml-chtml.js
+++ b/components/src/tex-mml-chtml/tex-mml-chtml.js
@@ -1,0 +1,9 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex/tex.js';
+import '../input/mml/mml.js';
+import '../output/chtml/chtml.js';
+import '../output/chtml/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-mml-chtml/webpack.config.js
+++ b/components/src/tex-mml-chtml/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-mml-chtml',                    // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/tex-mml-svg/preload.js
+++ b/components/src/tex-mml-svg/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex', 'input/mml',
+    'output/svg', 'output/svg/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-mml-svg/test.html
+++ b/components/src/tex-mml-svg/test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/tex-mml-svg.js"></script>
+</head>
+<body>
+
+$$\color{red}x+1$$
+
+<math display="block">
+<mi>x</mi>
+<mo>+</mo>
+<mn>1</mn>
+</math>
+
+</body>
+</html>

--- a/components/src/tex-mml-svg/test.js
+++ b/components/src/tex-mml-svg/test.js
@@ -1,0 +1,15 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/tex-mml-svg.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.startup.adaptor.outerHTML(MathJax.tex2svg('x+1')));
+console.log(MathJax.startup.adaptor.outerHTML(MathJax.mathml2svg('<math><mi>x</mi></math>')));

--- a/components/src/tex-mml-svg/tex-mml-svg.js
+++ b/components/src/tex-mml-svg/tex-mml-svg.js
@@ -1,0 +1,9 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex/tex.js';
+import '../input/mml/mml.js';
+import '../output/svg/svg.js';
+import '../output/svg/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-mml-svg/webpack.config.js
+++ b/components/src/tex-mml-svg/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-mml-svg',                      // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/tex-svg/preload.js
+++ b/components/src/tex-svg/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex',
+    'output/svg', 'output/svg/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-svg/test.html
+++ b/components/src/tex-svg/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test combined file</title>
+<script src="../../dist/tex-svg.js"></script>
+</head>
+<body>
+
+$$\color{red}x+1$$
+
+</body>
+</html>

--- a/components/src/tex-svg/test.js
+++ b/components/src/tex-svg/test.js
@@ -1,0 +1,14 @@
+MathJax = {
+    loader: {
+        load: ['adaptors/liteDom.js'],
+        paths: {
+            mathjax: '../../dist'
+        },
+        require: require,
+        ready: () => {}
+    }
+}
+require('../../dist/tex-svg.js');
+MathJax.loader.defaultReady();
+
+console.log(MathJax.startup.adaptor.outerHTML(MathJax.tex2svg('x+1')));

--- a/components/src/tex-svg/tex-svg.js
+++ b/components/src/tex-svg/tex-svg.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex/tex.js';
+import '../output/svg/svg.js';
+import '../output/svg/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-svg/webpack.config.js
+++ b/components/src/tex-svg/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-svg',                          // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);


### PR DESCRIPTION
This PR adds components that combine an input and output jax, making a single file that can be loaded from the CDN that includes a complete MathJax configuration that is ready to use.  These are similar to the combined configuration files from v2.

Because these all include the startup component, you can use the `MathJax` global variable to configure them, and they all include the context menu, so assistive functions can be enabled by the user.

There are test files in each directory, but these can be removed, if you want.