### PR TITLE
Fixes to AllPackages.ts

### DIFF
--- a/components/src/input/tex/extensions/all-packages/all-packages.js
+++ b/components/src/input/tex/extensions/all-packages/all-packages.js
@@ -3,29 +3,6 @@ import './lib/all-packages.js';
 import {AllPackages} from '../../../../../../mathjax3/input/tex/AllPackages.js';
 import {insert} from '../../../../../../mathjax3/util/Options.js';
 
-Loader.preLoad(
-    '[tex]/action',
-    '[tex]/ams',
-    '[tex]/ams_cd',
-    '[tex]/bbox',
-    '[tex]/boldsymbol',
-    '[tex]/braket',
-    '[tex]/cancel',
-    '[tex]/color',
-    '[tex]/configMacros',
-    '[tex]/enclose',
-    '[tex]/extpfeil',
-    '[tex]/html',
-    '[tex]/mhchem',
-    '[tex]/newcommand',
-    '[tex]/noerrors',
-    '[tex]/noundefined',
-    '[tex]/physics',
-    '[tex]/require',
-    '[tex]/unicode',
-    '[tex]/verb'
-);
-
 if (MathJax.startup) {
     if (!MathJax.config.tex) {
         MathJax.config.tex = {};

--- a/mathjax3-ts/input/tex/AllPackages.ts
+++ b/mathjax3-ts/input/tex/AllPackages.ts
@@ -43,17 +43,42 @@ import './require/RequireConfiguration.js';
 import './unicode/UnicodeConfiguration.js';
 import './verb/VerbConfiguration.js';
 
+declare const MathJax: any;
+if (typeof MathJax !== 'undefined' && MathJax.loader) {
+    MathJax.loader.preLoad(
+        '[tex]/action',
+        '[tex]/ams',
+        '[tex]/amsCd',
+        '[tex]/bbox',
+        '[tex]/boldsymbol',
+        '[tex]/braket',
+        '[tex]/cancel',
+        '[tex]/color',
+        '[tex]/enclose',
+        '[tex]/extpfeil',
+        '[tex]/html',
+        '[tex]/mhchem',
+        '[tex]/newcommand',
+        '[tex]/noerrors',
+        '[tex]/noundefined',
+        '[tex]/physics',
+        '[tex]/require',
+        '[tex]/unicode',
+        '[tex]/verb',
+        '[tex]/configMacros'
+    );
+}
+
 export const AllPackages: string[] = [
     'base',
     'action',
     'ams',
-    'amscd',
+    'amsCd',
     'bbox',
     'boldsymbol',
     'braket',
     'cancel',
     'color',
-    'configMacros',
     'enclose',
     'extpfeil',
     'html',
@@ -64,5 +89,6 @@ export const AllPackages: string[] = [
     'physics',
     'require',
     'unicode',
-    'verb'
+    'verb',
+    'configMacros'
 ];


### PR DESCRIPTION
Move `preLoad()` from component to `AllPackages.ts` so that if `AllPackages.js` is imported directly into a node project, `\require` won't try to reload these packages.

Also, fix incorrect package name for `amsCd`, and move `configMacros` to the end so that user macros will override package macros.