### PR TITLE
Fix \vec and stretchy horizontal characters in CHTML

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -42,7 +42,7 @@ export class CHTMLTextNode<N, T, D> extends CommonTextNodeMixin<CHTMLConstructor
     public static autoStyle = false;
 
     public static styles: StyleList = {
-        'mjx-c, mjx-c::before': {
+        'mjx-c': {
             display: 'inline-block'
         },
         'mjx-utext': {

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -60,8 +60,11 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(C
             overflow: 'hidden',
             width: '100%'
         },
-        'mjx-stretchy-h > mjx-ext > mjx-c': {
+        'mjx-stretchy-h > mjx-ext > mjx-c::before': {
             transform: 'scalex(500)'
+        },
+        'mjx-stretchy-h > mjx-ext > mjx-c': {
+            width: 0
         },
         'mjx-stretchy-h > mjx-beg > mjx-c': {
             'margin-right': '-.1em'

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -97,6 +97,9 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(C
             border: '0px solid transparent',
             overflow: 'hidden'
         },
+        'mjx-stretchy-v > mjx-ext > mjx-c::before': {
+            width: 'initial'
+        },
         'mjx-stretchy-v > mjx-ext > mjx-c': {
             transform: 'scaleY(500) translateY(.1em)',
             overflow: 'visible'

--- a/mathjax3-ts/output/chtml/fonts/tex.ts
+++ b/mathjax3-ts/output/chtml/fonts/tex.ts
@@ -132,89 +132,89 @@ CommonTeXFontMixin<CHTMLCharOptions, CHTMLVariantData, CHTMLDelimiterData, CHTML
     protected static defaultStyles = {
         ...CHTMLFontData.defaultStyles,
 
-        '.MJX-TEX .mjx-n mjx-c': {
+        '.mjx-n mjx-c': {
             'font-family': 'MJXZERO, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-i mjx-c': {
+        '.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-b mjx-c': {
+        '.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-b.mjx-i mjx-c': {
+        '.mjx-b.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-BI, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-cal mjx-c': {
+        '.mjx-cal mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-C, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-cal.mjx-b mjx-c': {
+        '.mjx-cal.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-ds mjx-c': {
+        '.mjx-ds mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-A, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1'
         },
 
-        '.MJX-TEX .mjx-fr mjx-c': {
+        '.mjx-fr mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-FR, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-fr.mjx-b mjx-c': {
+        '.mjx-fr.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-FR-B, MJXTEX-FR, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-sc mjx-c': {
+        '.mjx-sc mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SC, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-sc.mjx-b mjx-c': {
+        '.mjx-sc.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SC-B, MJXTEX-SC, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-ss mjx-c': {
+        '.mjx-ss mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-ss.mjx-b mjx-c': {
+        '.mjx-ss.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-ss.mjx-i mjx-c': {
+        '.mjx-ss.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS-I, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-ss.mjx-b.mjx-i mjx-c': {
+        '.mjx-ss.mjx-b.mjx-i mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-SS-B, MJXTEX-SS-I, MJXTEX-BI, MJXTEX-B, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-ty mjx-c': {
+        '.mjx-ty mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-T, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-var mjx-c': {
+        '.mjx-var mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-A, MJXTEX, MJXTEX-I, MJXTEX-S1'
         },
 
-        '.MJX-TEX .mjx-os mjx-c': {
+        '.mjx-os mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-C, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
-        '.MJX-TEX .mjx-os.mjx-b mjx-c': {
+        '.mjx-os.mjx-b mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-C-B, MJXTEX-C, MJXTEX-B, MJXTEX-BI, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-mit mjx-c': {
+        '.mjx-mit mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-MI, MJXTEX-I, MJXTEX, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-lop mjx-c': {
+        '.mjx-lop mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-S2, MJXTEX-S1, MJXTEX, MJXTEX-I, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-sop mjx-c': {
+        '.mjx-sop mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-S1, MJXTEX, MJXTEX-I, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-s3 mjx-c': {
+        '.mjx-s3 mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-S3, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
-        '.MJX-TEX .mjx-s4 mjx-c': {
+        '.mjx-s4 mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-S4, MJXTEX, MJXTEX-I, MJXTEX-S1, MJXTEX-A'
         },
 
@@ -222,7 +222,7 @@ CommonTeXFontMixin<CHTMLCharOptions, CHTMLVariantData, CHTMLDelimiterData, CHTML
             'font-family': 'MJXZERO'
         },
 
-        '.MJX-TEX mjx-stretchy-v mjx-c, .MJX-TEX mjx-stretchy-h mjx-c': {
+        'mjx-stretchy-v mjx-c, mjx-stretchy-h mjx-c': {
             'font-family': 'MJXZERO, MJXTEX-S1, MJXTEX-S4, MJXTEX, MJXTEX-A ! important'
         }
     };


### PR DESCRIPTION
Fix problem where `\vec` did not produce the right character (the font CSS was being overriden), and where stretchy horizontal characters could be too long if the extender had to be shorter than its natural length.

The change in `TextNode.ts` was to remove a redundant CSS specification.

The change in `mo.ts` was to get horizontal stretchy characters to be the right length when the extender is shorter than the character's natural length (the older version would cause the extender to have a minimum width of the character's natural width, and so the length of the stretched character as a whole would be too long).

The change to `fonts/tex.js` is to prevent those CSS rules from overriding the ones set for the individual characters (it was preventing the `\vec` from specifying an alternate font).