### PR TITLE
Rewrites some TeX sample files to remove TestMath.

### DIFF
--- a/samples/tex-json.js
+++ b/samples/tex-json.js
@@ -3,6 +3,7 @@ import {MathJax} from '../mathjax3/mathjax.js';
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
+import {STATE} from '../mathjax3/core/MathItem.js';
 import '../mathjax3/input/tex/base/BaseConfiguration.js';
 import '../mathjax3/input/tex/ams/AmsConfiguration.js';
 import '../mathjax3/input/tex/noundefined/NoUndefinedConfiguration.js';
@@ -17,15 +18,13 @@ let html = MathJax.document('<html></html>', {
   InputJax: new TeX({packages: ['base', 'ams', 'boldsymbol', 'newcommand', 'mhchem', 'braket']})
 });
 
-console.log(html.inputJax[0].configuration);
 import {JsonMmlVisitor} from '../mathjax3/core/MmlTree/JsonMmlVisitor.js';
 let visitor = new JsonMmlVisitor();
 let toJSON = (node => visitor.visitTree(node));
 
 MathJax.handleRetriesFor(() => {
 
-    html.TestMath(process.argv[3] || '').compile();
-    let math = html.math.pop().root;
+    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     math.setTeXclass();
     console.log(JSON.stringify(toJSON(math)));
 

--- a/samples/tex-string.js
+++ b/samples/tex-string.js
@@ -3,6 +3,7 @@ import {MathJax} from '../mathjax3/mathjax.js';
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
+import {STATE} from '../mathjax3/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
@@ -12,8 +13,7 @@ let html = MathJax.document('<html></html>', {
 
 MathJax.handleRetriesFor(() => {
 
-    html.TestMath(process.argv[3] || '').compile();
-    let math = html.math.pop().root;
+    let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
     console.log(math.toString());
 
 }).catch(err => console.log(err.stack));

--- a/samples/tex-string.js
+++ b/samples/tex-string.js
@@ -13,7 +13,7 @@ let html = MathJax.document('<html></html>', {
 
 MathJax.handleRetriesFor(() => {
 
-    let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
+    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     console.log(math.toString());
 
 }).catch(err => console.log(err.stack));

--- a/samples/tex2html.js
+++ b/samples/tex2html.js
@@ -4,6 +4,7 @@ import {TeX} from '../mathjax3/input/tex.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
+import {STATE} from '../mathjax3/core/MathItem.js';
 
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
@@ -15,8 +16,7 @@ let html = MathJax.document('<html></html>', {
 
 MathJax.handleRetriesFor(() => {
 
-    html.TestMath(process.argv[3] || '').compile().typeset();
-    let math = html.math.pop();
+    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     console.log(adaptor.outerHTML(math.typesetRoot));
 
 }).catch(err => console.log(err.stack));

--- a/samples/tex2html.js
+++ b/samples/tex2html.js
@@ -16,7 +16,7 @@ let html = MathJax.document('<html></html>', {
 
 MathJax.handleRetriesFor(() => {
 
-    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
+    let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
     console.log(adaptor.outerHTML(math.typesetRoot));
 
 }).catch(err => console.log(err.stack));

--- a/samples/tex2mml.js
+++ b/samples/tex2mml.js
@@ -3,6 +3,7 @@ import {MathJax} from '../mathjax3/mathjax.js';
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
+import {STATE} from '../mathjax3/core/MathItem.js';
 import '../mathjax3/input/tex/base/BaseConfiguration.js';
 import '../mathjax3/input/tex/ams/AmsConfiguration.js';
 import '../mathjax3/input/tex/noundefined/NoUndefinedConfiguration.js';
@@ -16,15 +17,13 @@ let html = MathJax.document('<html></html>', {
   InputJax: new TeX({packages: ['base', 'ams', 'boldsymbol', 'newcommand', 'braket']})
 });
 
-// import {TestMmlVisitor as MmlVisitor} from '../mathjax3/core/MmlTree/TestMmlVisitor.js';
 import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new MmlVisitor();
 let toMml = (node => visitor.visitTree(node, html.document));
 
 MathJax.handleRetriesFor(() => {
 
-    html.TestMath(process.argv[3] || '').compile();
-    let math = html.math.pop().root;
+    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     math.setTeXclass();
     console.log(toMml(math));
 


### PR DESCRIPTION
Removes no longer existing TestMath from some of the files.
Before I continue, we should discuss, which of these are still useful. 
For example, it seems to me that `tex-nodes.js` does the same as `tex2mml.js`.
