### PR TITLE
Give tooltips a z-index, and track tooltip show/hide separately.

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -50,7 +50,8 @@ CommonMactionMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrappe
             display: 'none',
             position: 'absolute',
             bottom: 0, right: 0,
-            Width: 0, height: 0
+            width: 0, height: 0,
+            'z-index': 500
         },
         'mjx-tool > mjx-tip': {
             display: 'inline-block',
@@ -133,13 +134,15 @@ CommonMactionMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrappe
                 // Set up the event handlers to display and remove the tooltip
                 //
                 node.setEventHandler('mouseover', (event: Event) => {
-                    data.stopTimers(data);
-                    data.hoverTimer = setTimeout(() => adaptor.setStyle(tool, 'display', 'block'), data.postDelay);
+                    data.stopTimers(node, data);
+                    const timeout = setTimeout(() => adaptor.setStyle(tool, 'display', 'block'), data.postDelay);
+                    data.hoverTimer.set(node, timeout);
                     event.stopPropagation();
                 });
                 node.setEventHandler('mouseout',  (event: Event) => {
-                    data.stopTimers(data);
-                    data.clearTimer = setTimeout(() => adaptor.setStyle(tool, 'display', ''), data.clearDelay);
+                    data.stopTimers(node, data);
+                    const timeout = setTimeout(() => adaptor.setStyle(tool, 'display', ''), data.clearDelay);
+                    data.clearTimer.set(node, timeout);
                     event.stopPropagation();
                 });
             }

--- a/mathjax3-ts/output/common/Wrappers/maction.ts
+++ b/mathjax3-ts/output/common/Wrappers/maction.ts
@@ -51,20 +51,20 @@ export const TooltipData = {
     postDelay: 600,      // milliseconds before tooltip posts
     clearDelay: 100,     // milliseconds before tooltip is removed
 
-    hoverTimer: null as number,    // timer for posting tooltips
-    clearTimer: null as number,    // timer for removing tooltips
+    hoverTimer: new Map<any, number>(),    // timers for posting tooltips
+    clearTimer: new Map<any, number>(),    // timers for removing tooltips
 
     /*
      * clear the timers if any are active
      */
-    stopTimers: (data: ActionData) => {
-        if (data.clearTimer) {
-            clearTimeout(data.clearTimer);
-            data.clearTimer = null;
+    stopTimers: (node: any, data: ActionData) => {
+        if (data.clearTimer.has(node)) {
+            clearTimeout(data.clearTimer.get(node));
+            data.clearTimer.delete(node);
         }
-        if (data.hoverTimer) {
-            clearTimeout(data.hoverTimer);
-            data.hoverTimer = null;
+        if (data.hoverTimer.has(node)) {
+            clearTimeout(data.hoverTimer.get(node));
+            data.hoverTimer.delete(node);
         }
     }
 

--- a/mathjax3-ts/output/svg/Wrappers/maction.ts
+++ b/mathjax3-ts/output/svg/Wrappers/maction.ts
@@ -136,8 +136,8 @@ CommonMactionMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
                 // Set up the event handlers to display and remove the tooltip
                 //
                 node.setEventHandler('mouseover', (event: Event) => {
-                    data.stopTimers(data);
-                    data.hoverTimer = setTimeout(() => {
+                    data.stopTimers(node, data);
+                    data.hoverTimer.set(node, setTimeout(() => {
                         adaptor.setStyle(tool, 'left', '0');
                         adaptor.setStyle(tool, 'top', '0');
                         adaptor.append(container, tool)
@@ -147,12 +147,13 @@ CommonMactionMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
                         const dy = (nbox.bottom - tbox.bottom) / node.metrics.em + node.dy;
                         adaptor.setStyle(tool, 'left', node.px(dx));
                         adaptor.setStyle(tool, 'top', node.px(dy));
-                    }, data.postDelay);
+                    }, data.postDelay));
                     event.stopPropagation();
                 });
                 node.setEventHandler('mouseout',  (event: Event) => {
-                    data.stopTimers(data);
-                    data.clearTimer = setTimeout(() => adaptor.append(hidden, tool), data.clearDelay);
+                    data.stopTimers(node, data);
+                    const timer = setTimeout(() => adaptor.append(hidden, tool), data.clearDelay);
+                    data.clearTimer.set(node, timer);
                     event.stopPropagation();
                 });
             }


### PR DESCRIPTION
This PR fixes some problems with tools tips in CHTML and SVG output.  In CHTML, the tooltips could fall underneath later mathematics, so this adds a `z-index` to raise the tooltip above the rest of the math.  There was also a problem in both CHTML and SVG where an expression that has multiple tooltips could leave an earlier tooltip open when the mouse moved from its trigger to another tooltip trigger.  This was because the timers for the show/hide operations were stored in a global variable; this fix tracks them by the element they are attached to, so multiple ones can operate at once, and you don't lose the hide from an earlier one when you start a show on a new one.