### PR TITLE
Fix equation stack item to handle \over

### DIFF
--- a/mathjax3-ts/input/tex/base/BaseItems.ts
+++ b/mathjax3-ts/input/tex/base/BaseItems.ts
@@ -1054,6 +1054,13 @@ export class EquationItem extends BaseItem {
   /**
    * @override
    */
+  get isOpen() {
+    return true;
+  }
+
+  /**
+   * @override
+   */
   public checkItem(item: StackItem): CheckType {
     if (item.isKind('end')) {
       let mml = this.toMml();


### PR DESCRIPTION
Make the `equation` stack item be an open item so that if it contains `\over`, it will be processed properly.

Currently,

```
\begin{equation}
x \over y
\end{equation}
```

produces an 'x' followed by an empty fraction.