### PR TITLE
Correct name of function to produce page elements

### DIFF
--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -159,7 +159,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     /**
      * @override
      */
-    public documentPageElements(html: MathDocument<N, T, D>) {
+    public pageElements(html: MathDocument<N, T, D>) {
         if (this.options.fontCache === 'global' && !this.findCache(html)) {
             return this.svg('svg', {id: SVG.FONTCACHEID, style: {display: 'none'}}, [this.fontCache.getCache()]);
         }


### PR DESCRIPTION
This fixes a problem in SVG output which caused the global `<defs>` element to be missing from the page when `fontCache: 'global'` is specified (the default is `'local'` font caching within each equation).