### PR TITLE
Fix detection of MathJax root URL

### DIFF
--- a/mathjax3-ts/components/loader.ts
+++ b/mathjax3-ts/components/loader.ts
@@ -151,7 +151,7 @@ export namespace Loader {
         if (typeof document !== 'undefined') {
             const script = document.currentScript || document.getElementById('MathJax-script');
             if (script) {
-                root = script.getAttribute('src').replace(/\/[^\/]*$/, '');
+                root = (script as HTMLScriptElement).src.replace(/\/[^\/]*$/, '');
             }
         }
         return root;


### PR DESCRIPTION
Use `src` property rather than attribute in order to get full path when determining the MathJax root URL.  The attribute is whatever was used in the page itself, but the property is the full path.