### PR TITLE
Remove dependency on loader/startup from AllPackages

### DIFF
--- a/components/src/input/tex-full/tex-full.js
+++ b/components/src/input/tex-full/tex-full.js
@@ -3,30 +3,12 @@ import './lib/tex-full.js';
 import {registerTeX} from '../tex/register.js';
 import {Loader} from '../../../../mathjax3/components/loader.js';
 import {AllPackages} from '../../../../mathjax3/input/tex/AllPackages.js';
+import '../../../../mathjax3/input/tex/require/RequireConfiguration.js';
 
 Loader.preLoad(
     'input/tex-base',
     '[tex]/all-packages',
-    '[tex]/action',
-    '[tex]/ams',
-    '[tex]/ams_cd',
-    '[tex]/bbox',
-    '[tex]/boldsymbol',
-    '[tex]/braket',
-    '[tex]/cancel',
-    '[tex]/color',
-    '[tex]/configMacros',
-    '[tex]/enclose',
-    '[tex]/extpfeil',
-    '[tex]/html',
-    '[tex]/mhchem',
-    '[tex]/newcommand',
-    '[tex]/noerrors',
-    '[tex]/noundefined',
-    '[tex]/physics',
-    '[tex]/require',
-    '[tex]/unicode',
-    '[tex]/verb'
+    '[tex]/require'
 );
 
-registerTeX(AllPackages);
+registerTeX(['require',...AllPackages]);

--- a/components/src/input/tex/extensions/all-packages/all-packages.js
+++ b/components/src/input/tex/extensions/all-packages/all-packages.js
@@ -1,6 +1,7 @@
 import './lib/all-packages.js';
 
 import {AllPackages} from '../../../../../../mathjax3/input/tex/AllPackages.js';
+import '../../../../../../mathjax3/input/tex/require/RequireConfiguration.js';
 import {insert} from '../../../../../../mathjax3/util/Options.js';
 
 if (MathJax.startup) {
@@ -8,7 +9,7 @@ if (MathJax.startup) {
         MathJax.config.tex = {};
     }
     let packages = MathJax.config.tex.packages;
-    MathJax.config.tex.packages = [...AllPackages];
+    MathJax.config.tex.packages = ['require',...AllPackages];
     if (packages) {
         insert(MathJax.config.tex, {packages});
     }

--- a/components/src/input/tex/extensions/all-packages/all-packages.js
+++ b/components/src/input/tex/extensions/all-packages/all-packages.js
@@ -1,15 +1,19 @@
 import './lib/all-packages.js';
 
 import {AllPackages} from '../../../../../../mathjax3/input/tex/AllPackages.js';
+import '../../../../../../mathjax3/input/tex/autoload/AutoloadConfiguration.js';
 import '../../../../../../mathjax3/input/tex/require/RequireConfiguration.js';
 import {insert} from '../../../../../../mathjax3/util/Options.js';
 
+if (MathJax.loader) {
+    MathJax.loader.preLoad('[tex]/autoload', '[tex]/require');
+}
 if (MathJax.startup) {
     if (!MathJax.config.tex) {
         MathJax.config.tex = {};
     }
     let packages = MathJax.config.tex.packages;
-    MathJax.config.tex.packages = ['require',...AllPackages];
+    MathJax.config.tex.packages = ['autoload', 'require', ...AllPackages];
     if (packages) {
         insert(MathJax.config.tex, {packages});
     }

--- a/components/src/input/tex/extensions/all-packages/build.json
+++ b/components/src/input/tex/extensions/all-packages/build.json
@@ -1,5 +1,9 @@
 {
     "component": "input/tex/extensions/all-packages",
-    "targets": ["input/tex/AllPackages.ts"]
+    "targets": [
+        "input/tex/AllPackages.ts",
+        "input/tex/autoload",
+        "input/tex/require"
+    ]
 }
 

--- a/mathjax3-ts/input/tex/AllPackages.ts
+++ b/mathjax3-ts/input/tex/AllPackages.ts
@@ -39,7 +39,6 @@ import './newcommand/NewcommandConfiguration.js';
 import './noerrors/NoErrorsConfiguration.js';
 import './noundefined/NoUndefinedConfiguration.js';
 import './physics/PhysicsConfiguration.js';
-import './require/RequireConfiguration.js';
 import './unicode/UnicodeConfiguration.js';
 import './verb/VerbConfiguration.js';
 
@@ -62,7 +61,6 @@ if (typeof MathJax !== 'undefined' && MathJax.loader) {
         '[tex]/noerrors',
         '[tex]/noundefined',
         '[tex]/physics',
-        '[tex]/require',
         '[tex]/unicode',
         '[tex]/verb',
         '[tex]/configMacros'
@@ -86,8 +84,6 @@ export const AllPackages: string[] = [
     'newcommand',
     'noerrors',
     'noundefined',
-    'physics',
-    'require',
     'unicode',
     'verb',
     'configMacros'


### PR DESCRIPTION
Remove `require` from `AllPackages.ts` (since it forces loading of loader/startup code), and put it into the `tex-full` and `all-packages` components directly.  Remove `physics` from the `AllPackages` list, since it conflicts with standard definitions.  Authors who want `physics` or `require` must add them to their package list by hand, e.g.,

```
packages: [...AllPackages, 'require', 'physics']
```

Finally, remove `preload()` calls for the TeX extensions from `tex-full`, since the preload is now done in `AllPackages.ts` (when the loader has been used).