### PR TITLE
Fix a wrong css property name in TextNode.ts

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -52,7 +52,7 @@ export class CHTMLTextNode<N, T, D> extends CommonTextNodeMixin<CHTMLConstructor
         'mjx-measure-text': {
             position: 'absolute',
             'font-family': 'MJXZERO',
-            'white space': 'nowrap',
+            'white-space': 'nowrap',
             height: '1px',
             width: '1px',
             overflow: 'hidden'


### PR DESCRIPTION
I found a wrong css property name in mathjax3-ts/output/chtml/Wrappers/TextNode.ts. I changed the property name from `'white space'` to `'white-space'` at `mjx-measure-text`.