### PR TITLE
Fix missing support for pageReady() in startup module

### DIFF
--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -258,9 +258,11 @@ export namespace Startup {
     export function defaultReady() {
         getComponents();
         makeMethods();
-        if (CONFIG.typeset && MathJax.TypesetPromise) {
-            promise = pagePromise.then(() => MathJax.TypesetPromise());
+        if (CONFIG.pageReady) {
+            pagePromise = pagePromise.then(CONFIG.pageReady);
         }
+        promise = (CONFIG.typeset && MathJax.TypesetPromise ?
+                   pagePromise.then(MathJax.TypesetPromise) : pagePromise);
     };
 
     /**

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -259,6 +259,10 @@ export namespace Startup {
         getComponents();
         makeMethods();
         if (CONFIG.pageReady) {
+            //
+            //  Add in the user's pageReady function, which runs when the page content is
+            //    ready, but before the initial typesetting call.
+            //
             pagePromise = pagePromise.then(CONFIG.pageReady);
         }
         promise = (CONFIG.typeset && MathJax.TypesetPromise ?


### PR DESCRIPTION
This PR fixes the startup module to perfrom the `pageReady()` function when the page is ready, which was defined in the configuration, but never actually executed.  It also makes the typeset promise always be defined, even if no typesetting occurs (this makes it easier to use, as you don't have to test for a null value).