### PR TITLE
Fixes for require and autoload

### DIFF
--- a/mathjax3-ts/input/tex/Configuration.ts
+++ b/mathjax3-ts/input/tex/Configuration.ts
@@ -207,10 +207,14 @@ export class Configuration {
   register(config: Configuration, jax: TeX<any, any, any>, options: OptionList = {}) {
     this.append(config);
     config.init(this);
-    jax.parseOptions.handlers = new SubHandlers(this);
-    jax.parseOptions.nodeFactory.setCreators(config.nodes);
-    defaultOptions(jax.parseOptions.options, config.options);
-    userOptions(jax.parseOptions.options, options);
+    const parser = jax.parseOptions;
+    parser.handlers = new SubHandlers(this);
+    parser.nodeFactory.setCreators(config.nodes);
+    for (const kind of Object.keys(config.items)) {
+      parser.itemFactory.setNodeClass(kind, config.items[kind]);
+    }
+    defaultOptions(parser.options, config.options);
+    userOptions(parser.options, options);
     config.config(this, jax);
     for (const pre of config.preprocessors) {
       Array.isArray(pre) ? jax.preFilters.add(pre[0], pre[1]) : jax.preFilters.add(pre);

--- a/mathjax3-ts/input/tex/require/RequireConfiguration.ts
+++ b/mathjax3-ts/input/tex/require/RequireConfiguration.ts
@@ -46,10 +46,10 @@ const MJCONFIG = (global.MathJax ? global.MathJax.config || {} : {});
  * @param {string} name   The name of the extension being added (e.g., '[tex]/amsCd')
  */
 function RegisterExtension(jax: TeX<any, any, any>, name: string) {
-    const required = jax.parseOptions.options.require.required;
-    if (required.indexOf(name) < 0) {
-        const extension = name.substr(6);
-        required.push(name);
+    const require = jax.parseOptions.options.require;
+    const extension = name.substr(require.prefix.length);
+    if (require.required.indexOf(extension) < 0) {
+        require.required.push(extension);
         //
         //  Register any dependencies that were loaded to handle this one
         //
@@ -117,8 +117,8 @@ export function RequireLoad(parser: TexParser, name: string) {
  */
 function config(config: Configuration, jax: TeX<any, any, any>) {
     const options = jax.parseOptions.options.require;
-    options.jax = jax;             // \require needs access to this
-    options.required = [];         // stores the names of the packages that have been added
+    options.jax = jax;                             // \require needs access to this
+    options.required = [...jax.options.packages];  // stores the names of the packages that have been added
     const prefix = options.prefix;
     if (prefix.match(/[^_a-zA-Z0-9]/)) {
         throw Error('Illegal characters used in \\require prefix');


### PR DESCRIPTION
This PR fixes a problem with `require` and `autoload` where packages with dependencies would cause the dependent packages to be appended a second time if they were already appended as part of the initial `packages` option when the TeX input jax was created.  This is because the require extension only kept track of the packages that it loaded, not the initial ones.  This adds the initial packages to the loaded package list.

It also fixes the configuration registration function to add the configurations StackItems to the configuration (this was accidentally left out initially).

Finally, it fixes a problem with removing the `[tex]/` prefix from extension package names when the prefix name has been changed in the configuration.