### PR TITLE
Fixes incorrect computation of surrogate pair unicode chars.

### DIFF
--- a/mathjax3-ts/util/string.ts
+++ b/mathjax3-ts/util/string.ts
@@ -53,7 +53,7 @@ export function unicodeChars(text: string) {
     for (let i = 0, m = text.length; i < m; i++) {
         let n = text.charCodeAt(i);
         if (n >= 0xD800 && n < 0xDBFF) {
-            n = (((n - 0xD800) << 10) + (text.charCodeAt(i++) - 0xDC00)) + 0x10000;
+            n = (((n - 0xD800) << 10) + (text.charCodeAt(++i) - 0xDC00)) + 0x10000;
         }
         unicode.push(n);
     }


### PR DESCRIPTION
Computation in `unicodeChars` was incorrect as the counter was incremented after the computation only. 
Took me a while to track down.
Overall, we have the surrogate pair computation in a number of places, we should combine those at some point.