### PR TITLE
Prevent texClass from being overwritten.  #121

### DIFF
--- a/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
@@ -262,7 +262,9 @@ export class MmlMo extends AbstractMmlTokenNode {
         let OPTABLE = (this.constructor as typeof MmlMo).OPTABLE;
         let def = OPTABLE[form1][mo] || OPTABLE[form2][mo] || OPTABLE[form3][mo];
         if (def) {
-            this.texClass = def[2];
+            if (this.getProperty('texClass') === null) {
+                this.texClass = def[2];
+            }
             for (const name of Object.keys(def[3] || {})) {
                 this.attributes.setInherited(name, def[3][name]);
             }
@@ -271,7 +273,9 @@ export class MmlMo extends AbstractMmlTokenNode {
         } else {
             let range = this.getRange(mo);
             if (range) {
-                this.texClass = range[2];
+                if (this.getProperty('texClass') === null) {
+                    this.texClass = range[2];
+                }
                 const spacing = (this.constructor as typeof MmlMo).MMLSPACING[range[2]];
                 this.lspace = (spacing[0] + 1) / 18;
                 this.rspace = (spacing[1] + 1) / 18;

--- a/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mo.ts
@@ -262,7 +262,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         let OPTABLE = (this.constructor as typeof MmlMo).OPTABLE;
         let def = OPTABLE[form1][mo] || OPTABLE[form2][mo] || OPTABLE[form3][mo];
         if (def) {
-            if (this.getProperty('texClass') === null) {
+            if (this.getProperty('texClass') === undefined) {
                 this.texClass = def[2];
             }
             for (const name of Object.keys(def[3] || {})) {
@@ -273,7 +273,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         } else {
             let range = this.getRange(mo);
             if (range) {
-                if (this.getProperty('texClass') === null) {
+                if (this.getProperty('texClass') === undefined) {
                     this.texClass = range[2];
                 }
                 const spacing = (this.constructor as typeof MmlMo).MMLSPACING[range[2]];

--- a/mathjax3-ts/input/tex/NodeUtil.ts
+++ b/mathjax3-ts/input/tex/NodeUtil.ts
@@ -121,6 +121,7 @@ namespace NodeUtil {
       let value = properties[name];
       if (name === 'texClass') {
         node.texClass = (value as number);
+        node.setProperty(name, value);
       } else if (name === 'movablelimits') {
         node.setProperty('movablelimits', value);
         if (node.isKind('mo') || node.isKind('mstyle')) {


### PR DESCRIPTION
This PR preserves the `texClass` that has been set by the TeX input jax (it was being ovewritten by the data from the operator dictionary).  To tell when TeX has set it, we set a `texClass` property on the node, otherwise we don't know if it was the value set by the constructor or the TeX input jax.

This resolves issue #121.