### PR TITLE
Add ability to get font metrics for a given element.  #269

### DIFF
--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -444,10 +444,8 @@ const Lab = window.Lab = {
      *   for the output area and save them to be used for the MathItems during typesetting.
      */
     initMetrics() {
-        let test = this.doc.outputJax.getTestElement(this.output);
-        let {em, ex, containerWidth, lineWidth, scale} = this.doc.outputJax.measureMetrics(test);
+        let {em, ex, containerWidth, lineWidth, scale} = MathJax.getMetricsFor(this.output);
         this.metrics = [em, ex, containerWidth, lineWidth, scale];
-        this.output.removeChild(test);
     },
 
     /**

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -33,6 +33,7 @@ import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {Handler} from '../core/Handler.js';
 import {InputJax, AbstractInputJax} from '../core/InputJax.js';
 import {OutputJax, AbstractOutputJax} from '../core/OutputJax.js';
+import {CommonOutputJax} from '../output/common/OutputJax.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {PrioritizedList} from '../util/PrioritizedList.js';
 import {OptionList} from '../util/Options.js';
@@ -67,6 +68,7 @@ export type HANDLER = Handler<any, any, any>;
 export type DOMADAPTOR = DOMAdaptor<any, any, any>;
 export type INPUTJAX = InputJax<any, any, any>;
 export type OUTPUTJAX = OutputJax<any, any, any>;
+export type COMMONJAX = CommonOutputJax<any, any, any, any, any, any, any>;
 export type TEX = TeX<any, any, any>;
 
 /**
@@ -339,6 +341,7 @@ export namespace Startup {
      * The outputStylesheet() method returns the styleSheet object for the output.
      * Use MathJax.startup.adaptor.innerHTML(MathJax.outputStylesheet()) to get the serialized
      *   version of the stylesheet.
+     * The getMetricsFor(node, display) method returns the metric data for the given node
      *
      * @param {string} iname     The name of the input jax
      * @param {string} oname     The name of the output jax
@@ -357,6 +360,11 @@ export namespace Startup {
                 return mathjax.handleRetriesFor(() => document.convert(math, options));
             };
         MathJax[oname + 'Stylesheet'] = () => output.styleSheet(document);
+        if (output instanceof CommonOutputJax) {
+            MathJax.getMetricsFor = (node: any, display: boolean) => {
+                return (output as COMMONJAX).getMetricsFor(node, display);
+            }
+        }
     };
 
     /**

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -620,13 +620,16 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
      * @override
      */
     public convert(math: string, options: OptionList = {}) {
-        const {format, display, end, ex, em, cwidth, lwidth, scale} = userOptions({
+        var {format, display, end, ex, em, containerWidth, lineWidth, scale} = userOptions({
             format: this.inputJax[0].name, display: true, end: STATE.LAST,
-            em: 16, ex: 8, cwidth: 1000000, lwidth: 1000000, scale: 1
+            em: 16, ex: 8, containerWidth: null, lineWidth: 1000000, scale: 1
         }, options);
+        if (containerWidth === null) {
+            containerWidth = 80 * ex;
+        }
         const jax = this.inputJax.reduce((jax, ijax) => (ijax.name === format ? ijax : jax), null);
         const mitem = new this.options.MathItem(math, jax, display);
-        mitem.setMetrics(em, ex, cwidth, lwidth, scale);
+        mitem.setMetrics(em, ex, containerWidth, lineWidth, scale);
         mitem.convert(this, end);
         return (mitem.typesetRoot || mitem.root);
     }

--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -620,7 +620,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
      * @override
      */
     public convert(math: string, options: OptionList = {}) {
-        var {format, display, end, ex, em, containerWidth, lineWidth, scale} = userOptions({
+        let {format, display, end, ex, em, containerWidth, lineWidth, scale} = userOptions({
             format: this.inputJax[0].name, display: true, end: STATE.LAST,
             em: 16, ex: 8, containerWidth: null, lineWidth: 1000000, scale: 1
         }, options);

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -264,7 +264,7 @@ export abstract class CommonOutputJax<
 
     /**
      * @param {N} node            The container node whose metrics are to be measured
-     * @param {boolean} display   True for the metrics are for displayed math
+     * @param {boolean} display   True if the metrics are for displayed math
      * @return {Metrics}          Object containing em, ex, containerWidth, etc.
      */
     public getMetricsFor(node: N, display: boolean) {

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -263,6 +263,18 @@ export abstract class CommonOutputJax<
     }
 
     /**
+     * @param {N} node            The container node whose metrics are to be measured
+     * @param {boolean} display   True for the metrics are for displayed math
+     * @return {Metrics}          Object containing em, ex, containerWidth, etc.
+     */
+    public getMetricsFor(node: N, display: boolean) {
+        const test = this.getTestElement(node, display);
+        const metrics = this.measureMetrics(test);
+        this.adaptor.remove(test);
+        return metrics;
+    }
+
+    /**
      * Get a MetricMap for the math list
      *
      * @param {MathDocument} html  The math document whose math list is to be processed.


### PR DESCRIPTION
This PR adds a `getMetricsFor()` method to common output jax, and uses it in the startup code and lab.  This will make it easier to use `convert()` in some cases, such as the demos in the [node demos](https://github.com/mathjax/mj3-demos-node) repository.  See issue #269.