### PR TITLE
Change case of MathJax variable.

### DIFF
--- a/components/samples/tex2mml/tex2mml.js
+++ b/components/samples/tex2mml/tex2mml.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../../../mathjax3/mathjax.js';
+import {mathjax} from '../../../mathjax3/mathjax.js';
 
 import {TeX} from '../../../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../../../mathjax3/handlers/html.js';
@@ -7,7 +7,7 @@ import {HTMLMathItem} from '../../../mathjax3/handlers/html/HTMLMathItem.js';
 
 RegisterHTMLHandler(browserAdaptor());
 
-let html = MathJax.document(document, {InputJax: new TeX()});
+let html = mathjax.document(document, {InputJax: new TeX()});
 
 import {SerializedMmlVisitor as MmlVisitor} from '../../../mathjax3/core/MmlTree/SerializedMmlVisitor.js';
 let visitor = new MmlVisitor();

--- a/components/src/core/core.js
+++ b/components/src/core/core.js
@@ -10,5 +10,5 @@ if (MathJax.startup) {
     MathJax.startup.useAdaptor('browserAdaptor');
 }
 if (MathJax.loader) {
-    MathJax._.mathjax.MathJax.asyncLoad = (name => MathJax.loader.load(name));
+    MathJax._.mathjax.mathjax.asyncLoad = (name => MathJax.loader.load(name));
 }

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MathJax} from '../mathjax.js';
+import {mathjax} from '../mathjax.js';
 import {Handler} from '../core/Handler.js';
 import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../core/MathDocument.js';
 import {MathItem, AbstractMathItem, STATE, newState} from '../core/MathItem.js';
@@ -102,7 +102,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
         public enrich(document: MathDocument<N, T, D>) {
             if (this.state() >= STATE.ENRICHED) return;
             if (typeof sre === 'undefined' || !sre.Engine.isReady()) {
-                MathJax.retryAfter(sreReady);
+                mathjax.retryAfter(sreReady);
             }
             if (document.options.enrichSpeech !== currentSpeech) {
                 SRE.setupEngine({speech: document.options.enrichSpeech});

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -129,7 +129,7 @@ export namespace Startup {
     const extensions = new PrioritizedList<HandlerExtension>();
 
     let visitor: any;  // the visitor for toMML();
-    let mathjax: any;  // variable for the mathjax variable from mathjax.js
+    let mathjax: any;  // the mathjax variable from mathjax.js
 
     /**
      * The constructors (or other data) registered by the loaded packages

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -129,7 +129,7 @@ export namespace Startup {
     const extensions = new PrioritizedList<HandlerExtension>();
 
     let visitor: any;  // the visitor for toMML();
-    let mathjax: any;  // variable for the MathJax variable from mathjax.js
+    let mathjax: any;  // variable for the mathjax variable from mathjax.js
 
     /**
      * The constructors (or other data) registered by the loaded packages
@@ -276,7 +276,7 @@ export namespace Startup {
      */
     export function getComponents() {
         visitor = new MathJax._.core.MmlTree.SerializedMmlVisitor.SerializedMmlVisitor();
-        mathjax = MathJax._.mathjax.MathJax;
+        mathjax = MathJax._.mathjax.mathjax;
         input = getInputJax();
         output = getOutputJax();
         adaptor = getAdaptor();

--- a/mathjax3-ts/handlers/html.ts
+++ b/mathjax3-ts/handlers/html.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MathJax} from '../mathjax.js';
+import {mathjax} from '../mathjax.js';
 import {HTMLHandler} from './html/HTMLHandler.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 
@@ -37,6 +37,6 @@ import {DOMAdaptor} from '../core/DOMAdaptor.js';
  */
 export function RegisterHTMLHandler<N, T, D>(adaptor: DOMAdaptor<N, T, D>) {
     const handler = new HTMLHandler<N, T, D>(adaptor)
-    MathJax.handlers.register(handler);
+    mathjax.handlers.register(handler);
     return handler;
 }

--- a/mathjax3-ts/input/tex/require/RequireConfiguration.ts
+++ b/mathjax3-ts/input/tex/require/RequireConfiguration.ts
@@ -31,7 +31,7 @@ import {TeX} from '../../tex.js';
 
 import {Package} from '../../../components/package.js';
 import {Loader, CONFIG as LOADERCONFIG} from '../../../components/loader.js';
-import {MathJax as mathjax} from '../../../mathjax.js';
+import {mathjax} from '../../../mathjax.js';
 import {userOptions, OptionList, expandable} from '../../../util/Options.js';
 
 /**

--- a/mathjax3-ts/mathjax.ts
+++ b/mathjax3-ts/mathjax.ts
@@ -30,7 +30,7 @@ import {MathDocument} from './core/MathDocument.js';
 /**
  * The main MathJax global object
  */
-export const MathJax = {
+export const mathjax = {
     /**
      *  The MathJax version number
      */
@@ -49,7 +49,7 @@ export const MathJax = {
      * @return {MathDocument}       The MathDocument to handle the document
      */
     document: function (document: any, options: OptionList) {
-        return MathJax.handlers.document(document, options);
+        return mathjax.handlers.document(document, options);
     },
 
     /**

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MathJax as mathjax} from '../../mathjax.js';
+import {mathjax} from '../../mathjax.js';
 
 import {MathItem, STATE} from '../../core/MathItem.js';
 import {OutputJax} from '../../core/OutputJax.js';

--- a/mathjax3-ts/ui/menu/MenuHandler.ts
+++ b/mathjax3-ts/ui/menu/MenuHandler.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MathJax} from '../../mathjax.js';
+import {mathjax} from '../../mathjax.js';
 
 import {MathItem, STATE, newState} from '../../core/MathItem.js';
 import {MathDocumentConstructor} from '../../core/MathDocument.js';
@@ -124,7 +124,7 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
          */
         public checkLoading(document: MenuMathDocument) {
             if (document.menu.isLoading) {
-                MathJax.retryAfter(document.menu.loadingPromise.catch((err) => console.log(err)));
+                mathjax.retryAfter(document.menu.loadingPromise.catch((err) => console.log(err)));
             }
         }
 
@@ -279,7 +279,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
          */
         public checkLoading() {
             if (this.menu.isLoading) {
-                MathJax.retryAfter(this.menu.loadingPromise.catch((err) => console.log(err)));
+                mathjax.retryAfter(this.menu.loadingPromise.catch((err) => console.log(err)));
             }
             return this;
         }

--- a/mathjax3-ts/util/AsyncLoad.ts
+++ b/mathjax3-ts/util/AsyncLoad.ts
@@ -21,20 +21,20 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MathJax} from '../mathjax.js';
+import {mathjax} from '../mathjax.js';
 
 /**
- * Load a file asynchronously using the MathJax.asynchLoad method, if there is one
+ * Load a file asynchronously using the mathjax.asynchLoad method, if there is one
  *
  * @param {string} name  The name of the file to load
  * @return {Promise}     The promise that is satisfied when the file is loaded
  */
 export function asyncLoad(name: string) {
-    if (!MathJax.asyncLoad) {
+    if (!mathjax.asyncLoad) {
         return Promise.reject(`Can't load '${name}': No asyncLoad method specified`);
     }
     return new Promise((ok, fail) => {
-        const result = MathJax.asyncLoad(name);
+        const result = mathjax.asyncLoad(name);
         if (result instanceof Promise) {
             result.then((value: any) => ok(value)).catch((err: Error) => fail(err));
         } else {

--- a/mathjax3-ts/util/asyncLoad/node.ts
+++ b/mathjax3-ts/util/asyncLoad/node.ts
@@ -1,12 +1,35 @@
-import {MathJax} from '../../mathjax.js';
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements asynchronous loading for use with node applications
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {mathjax} from '../../mathjax.js';
 
 declare var require: (name: string) => any;
 declare var __dirname: string;
 
 const root = __dirname.replace(/\/[^\/]*\/[^\/]*$/, '/');
 
-if (!MathJax.asyncLoad && typeof require !== 'undefined') {
-    MathJax.asyncLoad = (name: string) => {
+if (!mathjax.asyncLoad && typeof require !== 'undefined') {
+    mathjax.asyncLoad = (name: string) => {
         return require(name.charAt(0) === '.' ? root + name : name);
     };
 }

--- a/mathjax3-ts/util/asyncLoad/system.ts
+++ b/mathjax3-ts/util/asyncLoad/system.ts
@@ -1,12 +1,35 @@
-import {MathJax} from '../../mathjax.js';
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements asynchronous loading for use with SystemJS
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {mathjax} from '../../mathjax.js';
 
 declare var System: {import: (name: string, url?: string) => any};
 declare var __dirname: string;
 
 let root = 'file://' + __dirname.replace(/\/\/[^\/]*$/, '/');
 
-if (!MathJax.asyncLoad && typeof System !== 'undefined' && System.import) {
-    MathJax.asyncLoad = (name: string) => {
+if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
+    mathjax.asyncLoad = (name: string) => {
         return System.import(name, root);
     };
 }

--- a/samples/asciimath-document.js
+++ b/samples/asciimath-document.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {AsciiMath} from '../mathjax3/input/asciimath.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -26,7 +26,7 @@ const HTML = [
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath()
         .compile()

--- a/samples/asciimath-json.js
+++ b/samples/asciimath-json.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {AsciiMath} from '../mathjax3/input/asciimath.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -6,7 +6,7 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-const html = MathJax.document('<html></html>', {
+const html = mathjax.document('<html></html>', {
   InputJax: new AsciiMath()
 });
 
@@ -14,7 +14,7 @@ import {JsonMmlVisitor} from '../mathjax3/core/MmlTree/JsonMmlVisitor.js';
 const visitor = new JsonMmlVisitor();
 const toJSON = (node => visitor.visitTree(node));
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '').compile();
     let math = html.math.pop().root;

--- a/samples/find-asciimath.js
+++ b/samples/find-asciimath.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {AsciiMath} from '../mathjax3/input/asciimath.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
@@ -25,7 +25,7 @@ const HTML = [
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath();
     printFound(html);

--- a/samples/find-mml.js
+++ b/samples/find-mml.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {MathML} from '../mathjax3/input/mathml.js';
 import {htmlDocument} from './lib/chooseHTML.js';
@@ -24,7 +24,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath();
     for (const math of html.math) {

--- a/samples/find-strings.js
+++ b/samples/find-strings.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {adaptor, htmlDocument} from './lib/chooseHTML.js';
@@ -25,7 +25,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath();
     printFound(html);

--- a/samples/find-tex-dollars.js
+++ b/samples/find-tex-dollars.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {APPEND} from '../mathjax3/util/Options.js';
@@ -26,7 +26,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath();
     printFound(html);

--- a/samples/find-tex.js
+++ b/samples/find-tex.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {htmlDocument} from './lib/chooseHTML.js';
@@ -16,7 +16,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath();
     printFound(html);

--- a/samples/html-full.js
+++ b/samples/html-full.js
@@ -1,13 +1,13 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>');
+let html = mathjax.document('<html></html>');
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
   html.findMath()
       .compile()

--- a/samples/lib/chooseHTML.js
+++ b/samples/lib/chooseHTML.js
@@ -16,7 +16,7 @@ export function htmlDocument(HTML, OPTIONS) {
         html = mathjax.document(document, OPTIONS);
         document.documentElement.setAttribute('xmlns:m', 'http://www.w3.org/1998/Math/MathML');
         document.body.insertBefore(document.createElement('hr'), document.body.firstChild);
-        var div = document.createElement('div');
+        const div = document.createElement('div');
         div.innerHTML = HTML; div.style.marginBottom = '1em';
         document.body.insertBefore(div, document.body.firstChild);
     } catch (err) {

--- a/samples/lib/chooseHTML.js
+++ b/samples/lib/chooseHTML.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../../mathjax3/mathjax.js';
+import {mathjax} from '../../mathjax3/mathjax.js';
 
 import {RegisterHTMLHandler} from '../../mathjax3/handlers/html.js';
 import {chooseAdaptor} from '../../mathjax3/adaptors/chooseAdaptor.js';
@@ -13,7 +13,7 @@ export function htmlDocument(HTML, OPTIONS) {
         //
         //  Use browser document, if there is one
         //
-        html = MathJax.document(document, OPTIONS);
+        html = mathjax.document(document, OPTIONS);
         document.documentElement.setAttribute('xmlns:m', 'http://www.w3.org/1998/Math/MathML');
         document.body.insertBefore(document.createElement('hr'), document.body.firstChild);
         var div = document.createElement('div');
@@ -23,7 +23,7 @@ export function htmlDocument(HTML, OPTIONS) {
         //
         //  Otherwise, make a new document (measurements not supported here)
         //
-        html = MathJax.document(
+        html = mathjax.document(
             '<html xmlns:m="http://www.w3.org/1998/Math/MathML">'
                 + '<head><title>Test MathJax3</title></head><body>'
                 + HTML +

--- a/samples/mml-bbox.js
+++ b/samples/mml-bbox.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {MathML} from '../mathjax3/input/mathml.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -8,7 +8,7 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-const html = MathJax.document('<html></html>', {
+const html = mathjax.document('<html></html>', {
     InputJax: new MathML(),
     OutputJax: new CHTML()
 });
@@ -21,7 +21,7 @@ function showBBox(node, space) {
     }
 }
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '<math></math>').compile().typeset();
     let math = html.math.pop();

--- a/samples/mml-nodes.js
+++ b/samples/mml-nodes.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {MathML} from '../mathjax3/input/mathml.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -6,7 +6,7 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new MathML()
 });
 
@@ -15,7 +15,7 @@ import {TestMmlVisitor as MmlVisitor} from '../mathjax3/core/MmlTree/TestMmlVisi
 let visitor = new MmlVisitor();
 let toMathML = (node => visitor.visitTree(node, html.document));
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '').compile();
     let math = html.math.pop();

--- a/samples/mml2html.js
+++ b/samples/mml2html.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {MathML} from '../mathjax3/input/mathml.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -8,12 +8,12 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new MathML(),
   OutputJax: new CHTML()
 });
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '<math></math>').compile().typeset();
     let math = html.math.pop();

--- a/samples/mml2svg.js
+++ b/samples/mml2svg.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {MathML} from '../mathjax3/input/mathml.js';
 import {SVG} from '../mathjax3/output/svg.js';
@@ -8,12 +8,12 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new MathML(),
   OutputJax: new SVG()
 });
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '<math></math>').compile().typeset();
     let math = html.math.pop();

--- a/samples/tex-document.js
+++ b/samples/tex-document.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -16,7 +16,7 @@ const HTML = process.argv[3] || `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath()
         .compile()

--- a/samples/tex-json.js
+++ b/samples/tex-json.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -8,7 +8,7 @@ import '../mathjax3/input/tex/AllPackages.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new TeX({packages: AllPackages})
 });
 
@@ -16,7 +16,7 @@ import {JsonMmlVisitor} from '../mathjax3/core/MmlTree/JsonMmlVisitor.js';
 let visitor = new JsonMmlVisitor();
 let toJSON = (node => visitor.visitTree(node));
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     math.setTeXclass();

--- a/samples/tex-multi-document.js
+++ b/samples/tex-multi-document.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -22,7 +22,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath({elements: ['#p1']})
         .compile()

--- a/samples/tex-nodes.js
+++ b/samples/tex-nodes.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -6,7 +6,7 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>',{
+let html = mathjax.document('<html></html>',{
   InputJax: new TeX()
 });
 
@@ -14,7 +14,7 @@ import {TestMmlVisitor} from '../mathjax3/core/MmlTree/TestMmlVisitor.js';
 let visitor = new TestMmlVisitor();
 let toMathML = (node => visitor.visitTree(node, html.document));
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '').compile();
     let math = html.math.pop().root;

--- a/samples/tex-string.js
+++ b/samples/tex-string.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -7,11 +7,11 @@ import {STATE} from '../mathjax3/core/MathItem.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new TeX()
 });
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     console.log(math.toString());

--- a/samples/tex-typeset.js
+++ b/samples/tex-typeset.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -16,7 +16,7 @@ const HTML = `
 
 const html = htmlDocument(HTML, OPTIONS);
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.findMath()
         .compile()

--- a/samples/tex2html.js
+++ b/samples/tex2html.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {CHTML} from '../mathjax3/output/chtml.js';
@@ -9,12 +9,12 @@ import {STATE} from '../mathjax3/core/MathItem.js';
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new TeX(),
   OutputJax: new CHTML()
 });
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
     console.log(adaptor.outerHTML(math.typesetRoot));

--- a/samples/tex2mml.js
+++ b/samples/tex2mml.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
@@ -8,7 +8,7 @@ import '../mathjax3/input/tex/AllPackages.js';
 
 RegisterHTMLHandler(chooseAdaptor());
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new TeX({packages: AllPackages})
 });
 
@@ -16,7 +16,7 @@ import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/core/MmlTree/Seria
 let visitor = new MmlVisitor();
 let toMml = (node => visitor.visitTree(node, html.document));
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
     math.setTeXclass();

--- a/samples/tex2svg.js
+++ b/samples/tex2svg.js
@@ -1,4 +1,4 @@
-import {MathJax} from '../mathjax3/mathjax.js';
+import {mathjax} from '../mathjax3/mathjax.js';
 
 import {TeX} from '../mathjax3/input/tex.js';
 import {SVG} from '../mathjax3/output/svg.js';
@@ -8,12 +8,12 @@ import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
 const adaptor = chooseAdaptor();
 RegisterHTMLHandler(adaptor);
 
-let html = MathJax.document('<html></html>', {
+let html = mathjax.document('<html></html>', {
   InputJax: new TeX(),
   OutputJax: new SVG()
 });
 
-MathJax.handleRetriesFor(() => {
+mathjax.handleRetriesFor(() => {
 
     html.TestMath(process.argv[3] || '').compile().typeset();
     let math = html.math.pop();


### PR DESCRIPTION
Change case of `MathJax` to `mathjax` in `mathjax.js` (for consistency and to separate it from the MathJax global used by the components modules).  This is one of the tasks from #166.

Most of the changed files are samples, so they are not critical.