### PR TITLE
Better handling of arrows in menclose

### DIFF
--- a/mathjax3-ts/input/tex/cancel/CancelConfiguration.ts
+++ b/mathjax3-ts/input/tex/cancel/CancelConfiguration.ts
@@ -62,8 +62,9 @@ CancelMethods.CancelTo = function(parser: TexParser, name: string) {
   let value = parser.ParseArg(name);
   const math = parser.ParseArg(name);
   const def = ParseUtil.keyvalOptions(attr, ENCLOSE_OPTIONS);
-  def ['notation'] = TexConstant.Notation.UPDIAGONALSTRIKE + ' ' +
-    TexConstant.Notation.UPDIAGONALARROW;
+  def ['notation'] = [TexConstant.Notation.UPDIAGONALSTRIKE,
+                      TexConstant.Notation.UPDIAGONALARROW,
+                      TexConstant.Notation.NORTHEASTARROW].join(' ');
   value = parser.create('node', 'mpadded', [value],
                         {depth: '-.1em', height: '+.1em', voffset: '.1em'});
   parser.Push(parser.create('node', 'msup',

--- a/mathjax3-ts/output/common/Notation.ts
+++ b/mathjax3-ts/output/common/Notation.ts
@@ -148,8 +148,8 @@ export const arrowDef = {
  *   [c, pi, double, remove]
  */
 export const diagonalArrowDef = {
-    updiagonal:         [-1, 0,       false, 'updiagonalstrike'],
-    northeast:          [-1, 0,       false, 'updiagonalstrike'],
+    updiagonal:         [-1, 0,       false, 'updiagonalstrike northeastarrow'],
+    northeast:          [-1, 0,       false, 'updiagonalstrike updiagonalarrow'],
     southeast:          [ 1, 0,       false, 'downdiagonalstrike'],
     northwest:          [ 1, Math.PI, false, 'downdiagonalstrike'],
     southwest:          [-1, Math.PI, false, 'updiagonalstrike'],


### PR DESCRIPTION
Make `northeastarrow` remove `updiagonalarrow`, and vice versa, so there won't be duplicate elements in the oputput.  Make `\cancelto` use `northeastarrow` (as well as `updiagonalarrow` and `updiogonalstrike`) since that is what is in the MathML spec.