### PR TITLE
Make newcommand init() not append handlers twice.

### DIFF
--- a/mathjax3-ts/input/tex/newcommand/NewcommandConfiguration.ts
+++ b/mathjax3-ts/input/tex/newcommand/NewcommandConfiguration.ts
@@ -24,6 +24,7 @@
 
 import {Configuration} from '../Configuration.js';
 import {BeginEnvItem} from './NewcommandItems.js';
+import {ExtensionMaps} from '../MapHandler.js';
 import './NewcommandMappings.js';
 
 
@@ -32,20 +33,23 @@ import './NewcommandMappings.js';
  * @param {Configuration} config The current configuration.
  */
 let init = function(config: Configuration) {
-  config.append(Configuration.extension());
+    if (config.handler['macro'].indexOf(ExtensionMaps.NEW_COMMAND) < 0) {
+        config.append(Configuration.extension());
+    }
 };
 
 
 export const NewcommandConfiguration = Configuration.create(
   'newcommand',
-  {handler: {
-    macro: ['Newcommand-macros']
-  },
-   items: {
-     [BeginEnvItem.prototype.kind]: BeginEnvItem,
-   },
-   options: {maxMacros: 1000},
-   init: init
+  {
+    handler: {
+      macro: ['Newcommand-macros']
+    },
+    items: {
+      [BeginEnvItem.prototype.kind]: BeginEnvItem,
+    },
+    options: {maxMacros: 1000},
+    init: init
   }
 );
 


### PR DESCRIPTION
Make newcommand `init()` check that it hasn't already been called before appending its handlers.  This is because other extensions (namely `extpfeil`) can call the newcommand `init()` function themselves, and that would mean that a new set of handlers would be added at that point.  So if macros had already been defined in the earlier handlers, those could be lost.

For example, without this patch

```
\def\x{xyz}
\require{extpfeil}
\x
```

would produce an `Undefined control sequence \x` message (if `extpfeil` hadn't been loaded already).

The PR also reformats the spacing in the configuration object.