### PR TITLE
Allow forward references for \ref and \eqref macros

### DIFF
--- a/mathjax3-ts/core/MathDocument.ts
+++ b/mathjax3-ts/core/MathDocument.ts
@@ -653,7 +653,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
             const recompile = [];
             for (const math of this.math) {
                 this.compileMath(math);
-                if (math.inputData.redo !== undefined) {
+                if (math.inputData.recompile !== undefined) {
                     recompile.push(math);
                 }
             }
@@ -662,9 +662,9 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
             //    compile them again
             //
             for (const math of recompile) {
-                const redo = math.inputData.redo;
-                math.state(redo.state);
-                math.inputData.recompile = redo;
+                const data = math.inputData.recompile;
+                math.state(data.state);
+                math.inputData.recompile = data;
                 this.compileMath(math);
             }
             this.processed.set('compile');

--- a/mathjax3-ts/input/tex.ts
+++ b/mathjax3-ts/input/tex.ts
@@ -172,15 +172,15 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    */
   public compile(math: MathItem<N, T, D>): MmlNode {
     this.parseOptions.clear();
-    let node: MmlNode;
-    let parser: TexParser;
-    let display = math.display;
     this.executeFilters(this.preFilters, math, this.parseOptions);
+    let display = math.display;
     this.latex = math.math;
+    let node: MmlNode;
+    this.parseOptions.tags.startEquation(math);
     try {
-      parser = new TexParser(this.latex,
-                             {display: display, isInner: false},
-                             this.parseOptions);
+      let parser = new TexParser(this.latex,
+                                 {display: display, isInner: false},
+                                 this.parseOptions);
       node = parser.mml();
     } catch (err) {
       if (!(err instanceof TexError)) {
@@ -193,6 +193,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     if (display) {
       NodeUtil.setAttribute(node, 'display', 'block');
     }
+    this.parseOptions.tags.finishEquation(math);
     this.parseOptions.root = node;
     this.executeFilters(this.postFilters, math, this.parseOptions);
     this.mathNode = this.parseOptions.root;

--- a/mathjax3-ts/input/tex/Tags.ts
+++ b/mathjax3-ts/input/tex/Tags.ts
@@ -469,7 +469,7 @@ export class AbstractTags implements Tags {
    */
   public finishEquation(math: MathItem<any, any, any>) {
     if (this.redo) {
-      math.inputData.redo = {
+      math.inputData.recompile = {
         state: math.state(),
         counter: this.allCounter
       };

--- a/mathjax3-ts/input/tex/Tags.ts
+++ b/mathjax3-ts/input/tex/Tags.ts
@@ -24,6 +24,7 @@
 
 import TexParser from './TexParser.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {MathItem} from '../../core/MathItem.js';
 import {EnvList} from './StackItem.js';
 import ParseOptions from './ParseOptions.js';
 import {OptionList} from '../../util/Options.js';
@@ -107,18 +108,22 @@ export interface Tags {
   allLabels: {[key: string]: Label};
 
   /**
-   * Nodes with unresolved references.
-   * @type {MmlNode[]}
-   */
-  // TODO: Not sure how to handle this at the moment.
-  //       array of nodes with unresolved references
-  refs: MmlNode[];
-
-  /**
    * The label to use for the next tag.
    * @type {string}
    */
   label: string;
+
+  /**
+   * True if the equation contains an undefined label and must be reprocessed later.
+   * @type {boolean}
+   */
+  redo: boolean;
+
+  /**
+   * True when recompiling to update undefined references
+   * @type {boolean}
+   */
+  refUpdate: boolean;
 
   /**
    * The environment that is currently tagged.
@@ -175,8 +180,22 @@ export interface Tags {
   reset(offset?: number): void;
 
   /**
+   * Initialise tagging for a MathItem
+   * (clear equation-specific labels and ids, set counter
+   * and check for recompile)
+   * @param {MathItem} math   The MathItem for the current equation
+   */
+    startEquation(math: MathItem<any, any, any>): void;
+
+  /**
+   * Move equation-specific labels and ids to global ones,
+   * save the counter, and marth the MathItem for redos
+   */
+    finishEquation(math: MathItem<any, any, any>): void;
+
+  /**
    * Finalizes tag creation.
-   * @param {MmlNode} node 
+   * @param {MmlNode} node
    * @param {EnvList} env List of environment properties.
    * @return {MmlNode} The newly created tag.
    */
@@ -226,10 +245,10 @@ export class AbstractTags implements Tags {
   protected counter: number = 0;
 
   /**
-   * Current starting equation number (for when equation is restarted).
+   * Equation number as equation begins.
    * @type {number}
    */
-  protected offset: number = 0;
+  protected allCounter: number = 0;
 
   /**
    * @override
@@ -247,22 +266,24 @@ export class AbstractTags implements Tags {
   public allIds: {[key: string]: boolean} = {};
 
   /**
-   * Labels in the current equation.
-   * @type {Object.<boolean>}
+   * @override
    */
   public labels: {[key: string]: Label} = {};
 
   /**
-   * Labels in previous equations.
-   * @type {Object.<boolean>}
+   * @override
    */
   public allLabels: {[key: string]: Label} = {};
 
   /**
-   * Nodes with unresolved references.
-   * @type {MmlNode[]}
+   * @override
    */
-  public refs: MmlNode[] = new Array();
+  public redo: boolean = false;
+
+  /**
+   * @override
+   */
+  public refUpdate: boolean = false;
 
   /**
    * @override
@@ -413,6 +434,8 @@ export class AbstractTags implements Tags {
    */
   public resetTag() {
     this.history = [];
+    this.redo = false;
+    this.refUpdate = false;
     this.clearTag();
   }
 
@@ -421,9 +444,41 @@ export class AbstractTags implements Tags {
    */
   public reset(offset: number = 0) {
     this.resetTag();
-    this.offset = offset;
+    this.counter = this.allCounter = offset;
+    this.allLabels = {};
+    this.allIds = {};
+  }
+
+  /**
+   * @override
+   */
+  public startEquation(math: MathItem<any, any, any>) {
     this.labels = {};
     this.ids = {};
+    this.counter = this.allCounter;
+    this.redo = false;
+    const recompile = math.inputData.recompile;
+    if (recompile) {
+      this.refUpdate = true;
+      this.counter = recompile.counter;
+    }
+  }
+
+  /**
+   * @override
+   */
+  public finishEquation(math: MathItem<any, any, any>) {
+    if (this.redo) {
+      math.inputData.redo = {
+        state: math.state(),
+        counter: this.allCounter
+      };
+    }
+    if (!this.refUpdate) {
+      this.allCounter = this.counter;
+    }
+    Object.assign(this.allIds, this.ids);
+    Object.assign(this.allLabels, this.labels);
   }
 
   /**
@@ -552,19 +607,20 @@ export namespace TagsFactory {
   export let OPTIONS: OptionList = {
     // Tagging style, used to be autonumber in v2.
     tags: defaultTags,
-    //  This specifies the side on which \tag{} macros will place the tags.
-    //  Set to 'left' to place on the left-hand side.
+    // This specifies the side on which \tag{} macros will place the tags.
+    // Set to 'left' to place on the left-hand side.
     TagSide: 'right',
-    //  This is the amound of indentation (from right or left) for the tags.
+    // This is the amound of indentation (from right or left) for the tags.
     TagIndent: '0.8em',
-    //  This is the width to use for the multline environment
+    // This is the width to use for the multline environment
     MultLineWidth: '85%',
     // make element ID's use \label name rather than equation number
     // MJ puts in an equation prefix: mjx-eqn
     // When true it uses the label name XXX as mjx-eqn-XXX
     // If false it uses the actual number N that is displayed: mjx-eqn-N
     useLabelIds: true,
-    refUpdate: false
+    // Set to true in order to prevent error messages for duplicate label ids
+    ignoreDuplicateLabels: false
   };
 
 

--- a/mathjax3-ts/input/tex/base/BaseMethods.ts
+++ b/mathjax3-ts/input/tex/base/BaseMethods.ts
@@ -1528,15 +1528,14 @@ BaseMethods.HandleLabel = function(parser: TexParser, name: string) {
     // @test Label Empty
     return;
   }
-  // TODO: refUpdate is currently not implemented.
-  if (!parser.options['refUpdate']) {
+  if (!parser.tags.refUpdate) {
     // @test Label, Ref, Ref Unknown
     if (parser.tags.label) {
       // @test Double Label Error
       throw new TexError('MultipleCommand', 'Multiple %1', parser.currentCS);
     }
     parser.tags.label = label;
-    if (parser.tags.allLabels[label] || parser.tags.labels[label]) {
+    if ((parser.tags.allLabels[label] || parser.tags.labels[label]) && !parser.options['ignoreDuplicateLabels']) {
       // @ Duplicate Label Error
       throw new TexError('MultipleLabel', 'Label \'%1\' multiply defined', label);
     }
@@ -1558,6 +1557,9 @@ BaseMethods.HandleRef = function(parser: TexParser, name: string, eqref: boolean
   let ref = parser.tags.allLabels[label] || parser.tags.labels[label];
   if (!ref) {
     // @test Ref Unknown
+    if (!parser.tags.refUpdate) {
+      parser.tags.redo = true;
+    }
     ref = new Label();
   }
   let tag = ref.tag;


### PR DESCRIPTION
This PR includes fixes to allow forward references in `\ref` and `\eqref` macros.  This is handled by keeping track of equations that have references to undefined labels, and then recompiling them after all the other expressions have been processed.  That is accomplished in the `compile()` method of the `MathDocument`, which uses the `inputData` object to pass information back to the document that a `MathItem` needs to be recompiled (the `inputData.recompile` item, which includes the MathItem's previous state and the tag counter).

In order to get the labels and equation numbers to be correct, the Tags object stores the ids, labels, and counter for the current equation separately from the ids, labels, and counter for the previously processed equations.  That way, if an equation is restarted due to a `\require` or autoloaded extension, for example, and the equation is reprocessed, the id's, labels, and counter for the partially processed equation can be removed (so there will not be duplicate label warnings, and the counter will start at the right place).  This is the reason for the `allIds`, `allLabels`, and `allCounter` properties to be separate from `ids`, `labels`, and `counter`.

When an expression is reprocessed because of missing label references, the counter is reset to the proper one for when it was originally processed so it gets the proper auto tags when recompiled.