### PR TITLE
Update speech support

### DIFF
--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -98,6 +98,7 @@ export class AbstractExplorer implements Explorer {
   public Attach() {
     this.oldIndex = this.node.tabIndex;
     this.node.tabIndex = 1;
+    this.node.setAttribute('role', 'application');
     this.AddEvents();
   }
 
@@ -108,6 +109,7 @@ export class AbstractExplorer implements Explorer {
   public Detach() {
     this.node.tabIndex = this.oldIndex;
     this.oldIndex = null;
+    this.node.removeAttribute('role');
     this.RemoveEvents();
   }
 

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -60,6 +60,12 @@ export type Constructor<T> = new(...args: any[]) => T;
 newState('ENRICHED', 30);
 
 /**
+ * Add STATE value for adding speech (after TYPESET)
+ */
+newState('ATTACHSPEECH', 155);
+
+
+/**
  * The funtions added to MathItem for enrichment
  *
  * @template N  The HTMLElement node class
@@ -69,10 +75,14 @@ newState('ENRICHED', 30);
 export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
 
     /**
-     * @param {MathDocument} document  The document where enrchment is occurring
+     * @param {MathDocument} document  The document where enrichment is occurring
      */
     enrich(document: MathDocument<N, T, D>): void;
 
+    /**
+     * @param {MathDocument} document  The document where enrichment is occurring
+     */
+    attachSpeech(document: MathDocument<N, T, D>): void;
 }
 
 /**
@@ -118,6 +128,24 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
             this.state(STATE.ENRICHED);
         }
 
+        /**
+         * @param {MathDocument} docuemnt   The MathDocument for the MathItem
+         */
+        attachSpeech(document: MathDocument<N, T, D>) {
+            if (this.state() >= STATE.ATTACHSPEECH) return;
+            const attributes =this.root.attributes;
+            const speech = (attributes.get('aria-label') || attributes.get('data-semantic-speech')) as string;
+            if (speech) {
+                const adaptor = document.adaptor;
+                const node = this.typesetRoot;
+                adaptor.setAttribute(node, 'aria-label', speech);
+                for (const child of adaptor.childNodes(node) as N[]) {
+                    adaptor.setAttribute(child, 'aria-hidden', 'true');
+                }
+            }
+            this.state(STATE.ATTACHSPEECH);
+        }
+
     };
 
 }
@@ -140,6 +168,12 @@ export interface EnrichedMathDocument<N, T, D> extends AbstractMathDocument<N, T
      */
     enrich(): EnrichedMathDocument<N, T, D>;
 
+    /**
+     * Attach speech to the MathItems in the MathDocument
+     *
+     * @return {EnrichedMathDocument}   The MathDocument (so calls can be chained)
+     */
+    attachSpeech(): EnrichedMathDocument<N, T, D>;
 }
 
 /**
@@ -166,7 +200,8 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
             enrichSpeech: 'none',                   // or 'shallow', or 'deep'
             renderActions: expandable({
                 ...BaseDocument.OPTIONS.renderActions,
-                enrich: [STATE.ENRICHED]
+                enrich:       [STATE.ENRICHED],
+                attachSpeech: [STATE.ATTACHSPEECH]
             })
         };
 
@@ -183,6 +218,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
             const ProcessBits = (this.constructor as typeof AbstractMathDocument).ProcessBits;
             if (!ProcessBits.has('enriched')) {
                 ProcessBits.allocate('enriched');
+                ProcessBits.allocate('attach-speech');
             }
             const visitor = new SerializedMmlVisitor(this.mmlFactory);
             const toMathML = ((node: MmlNode) => visitor.visitTree(node));
@@ -190,6 +226,19 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
                 EnrichedMathItemMixin<N, T, D, Constructor<AbstractMathItem<N, T, D>>>(
                     this.options.MathItem, MmlJax, toMathML
                 );
+        }
+
+        /**
+         * Attach speech from a MathItem to a node
+         */
+        public attachSpeech() {
+            if (!this.processed.isSet('attach-speech')) {
+                for (const math of this.math) {
+                    (math as EnrichedMathItem<N, T, D>).attachSpeech(this);
+                }
+                this.processed.set('attach-speech');
+            }
+            return this;
         }
 
         /**

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -102,18 +102,6 @@ export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<N, T, D
         if (display && shift && !adaptor.hasAttribute(chtml, 'width')) {
             this.setIndent(chtml, align, shift);
         }
-        //
-        // Transfer speech to aria-label and hide child nodes
-        //
-        const speech = attributes.get('data-semantic-speech') as string;
-        if (speech && !attributes.get('aria-label')) {
-            adaptor.setAttribute(this.chtml, 'aria-label', speech);
-            if (attributes.get('data-semantic-speech')) {
-                for (const child of this.childNodes[0].childNodes) {
-                    adaptor.setAttribute(child.chtml, 'aria-hidden', 'true');
-                }
-            }
-        }
     }
 
     /**

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -50,6 +50,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     public static NAME: string = 'SVG';
     public static OPTIONS: OptionList = {
         ...CommonOutputJax.OPTIONS,
+        internalSpeechTitles: true,     // insert <title> tags with speech content
         titleID: 0,                     // initial id number to use for aria-labeledby titles
         fontCache: 'local',             // or 'global' or 'none'
         localID: null,                  // ID to use for local font cache (for single equation processing)
@@ -228,6 +229,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         const svg = adaptor.append(this.container, this.svg('svg', {
             xmlns: SVGNS,
             width: this.ex(W), height: this.ex(h + d),
+            role: 'img', focusable: false,
             style: {'vertical-align': this.ex(-d)},
             viewBox: [0, this.fixed(-h * 1000, 1), this.fixed(W * 1000, 1), this.fixed((h + d) * 1000, 1)].join(' ')
         }, [g])) as N;

--- a/mathjax3-ts/output/svg/Wrappers/math.ts
+++ b/mathjax3-ts/output/svg/Wrappers/math.ts
@@ -69,15 +69,18 @@ export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<N, T, D>>(S
         if (display && shift) {
             this.jax.shift = shift;
         }
-        const attributes = this.node.attributes;
-        const speech = attributes.get('data-semantic-speech') as string;
-        if (speech && !attributes.get('aria-label')) {
-            const id = this.getTitleID();
-            const label = this.svg('title', {id}, [this.text(speech)]);
-            adaptor.insert(label, adaptor.firstChild(this.element));
-            adaptor.setAttribute(this.element, 'aria-labeledby', id);
-            for (const child of this.childNodes[0].childNodes) {
-                adaptor.setAttribute(child.element, 'aria-hidden', 'true');
+        if (this.jax.document.options.internalSpeechTitles) {
+            const attributes = this.node.attributes;
+            const speech = (attributes.get('aria-label') || attributes.get('data-semantic-speech')) as string;
+            if (speech) {
+                const id = this.getTitleID();
+                const label = this.svg('title', {id}, [this.text(speech)]);
+                adaptor.insert(label, adaptor.firstChild(this.element));
+                adaptor.setAttribute(this.element, 'aria-labeledby', id);
+                adaptor.removeAttribute(this.element, 'aria-label');
+                for (const child of this.childNodes[0].childNodes) {
+                    adaptor.setAttribute(child.element, 'aria-hidden', 'true');
+                }
             }
         }
     }


### PR DESCRIPTION
This PR moves the `aria-label` attributes to the `mjx-container` rather than the element corresponding to the math element, and makes the internal svg `title` element optional (so that it can be included in conversions from tex to svg, for example, where the `mjx-container` is not retained.  This is controlled by the `internalSpeechTitles` option for the SVG output jax.

It also adds `role="application"` when the explorer is present (should this always be set when speech is attached?), and adds `role="img" focusable="false"` to svg elements, as in v2.