### PR TITLE
Corrects some explorer problems.

### DIFF
--- a/mathjax3-ts/a11y/complexity/collapse.ts
+++ b/mathjax3-ts/a11y/complexity/collapse.ts
@@ -382,6 +382,14 @@ export class Collapse {
         }
     }
 
+    private idCount = 0;
+    /**
+     * @return {string} A unique id string.
+     */
+    private makeId(): string {
+        return 'mjx-collapse-' + this.idCount++;
+    }
+
     public makeAction(node: MmlNode) {
         if (node.isKind('math')) {
             node = this.addMrow(node);
@@ -389,10 +397,11 @@ export class Collapse {
         const factory = this.complexity.factory;
         const marker = node.getProperty('collapse-marker') as string;
         const parent = node.parent;
-        var maction = factory.create('maction', {
+        let maction = factory.create('maction', {
             actiontype: 'toggle',
             selection: 2,
             'data-collapsible': true,
+            id: this.makeId(),
             'data-semantic-complexity': node.attributes.get('data-semantic-complexity')
         }, [
             factory.create('mtext', {mathcolor: 'blue'}, [

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -225,7 +225,7 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     const jax = this.document.outputJax.name;
     this.highlighter = sre.HighlighterFactory.highlighter(
       this.background, this.foreground,
-      {renderer: jax === 'CHTML' ? 'CommonHTML' : jax}
+      {renderer: jax}
     );
     // Add speech
     this.speechGenerator = new sre.TreeSpeechGenerator();


### PR DESCRIPTION
Two corrections to  allow collapsing with keyboard in explorer:
* `maction` nodes added in `collapse.ts` get a unique id.
* Does no longer map `CHTML` to old `CommonHTML` highlighter.  Note, this only works with the latest `develop` branch in SRE.