### PR TITLE
Change case of typeset functions created by setup.js

### DIFF
--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -321,17 +321,17 @@ export namespace Startup {
      * TypeseClear() clears all the MathItems from the document.
      */
     export function makeTypesetMethods() {
-        MathJax.Typeset = (elements: any = null) => {
+        MathJax.typeset = (elements: any = null) => {
             document.options.elements = elements;
             document.render();
         };
-        MathJax.TypesetPromise = (elements: any = null) => {
+        MathJax.typesetPromise = (elements: any = null) => {
             document.options.elements = elements;
             return mathjax.handleRetriesFor(() => {
                 document.render();
             })
         };
-        MathJax.TypesetClear = () => document.clear();
+        MathJax.typesetClear = () => document.clear();
     };
 
     /**


### PR DESCRIPTION
This PR changes `MathJax.Typeset()` to `MathJax.typeset()` and similarly for two other functions, in order to follow our function naming conventions.