### PR TITLE
Update lab to save checkboxes properly when "keep" is used

### DIFF
--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -452,6 +452,10 @@ const Lab = window.Lab = {
      *   and set their values to correspond to the current state
      */
     initMenu() {
+        this.setVariable('renderer', this.renderer, true);
+        this.setVariable('collapsible', this.collapse, true);
+        this.setVariable('explorer', this.explore, true);
+
         this.menuVariable('explorer').registerCallback(() => {
             this.explore = this.doc.menu.settings.explorer;
             document.getElementById('explore').checked = this.explore;
@@ -478,10 +482,6 @@ const Lab = window.Lab = {
         });
         this.menuVariable('semantics').registerCallback(() => this.outputMML(this.mathItem));
         this.menuVariable('texHints').registerCallback(() => this.outputMML(this.mathItem));
-
-        this.setVariable('renderer', this.renderer, true);
-        this.setVariable('collapsible', this.collapse, true);
-        this.setVariable('explorer', this.explore, true);
     },
 
     /**
@@ -621,9 +621,7 @@ const Lab = window.Lab = {
         const flags = data.substr(8,n); 
         let i = 0;
         for (const key in Lab.packages) {
-            if (flags.charAt(i++) === '1') {
-                document.getElementById(Lab.packages[key]).checked = true;
-            }
+            document.getElementById(Lab.packages[key]).checked = (flags.charAt(i++) === '1');
         }
         if (this.format === 'MathML') Lab.disablePackages(true);
     }


### PR DESCRIPTION
The enrich and complexity checkboxes aren't properly preserved if collapsible or explorer are not also checked (this is because the menu code unsets them during the initialization of the explorer and collapsible menu items.  Moving the setting of those value to *before* when the menu callbacks are set resolves that problem.

The `autoload` checkbox isn't preserved properly by "keep"; explicitly setting values to false (not just true) during initialization resolves that issue.