### PR TITLE
A11y explorer

### DIFF
--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -98,38 +98,57 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
         protected refocus: boolean = false;
 
         /**
+         * Save explorer id during rerendering.
+         */
+        protected savedId: string = null;
+
+        /**
          * Add the explorer to the output for this math item
          *
          * @param {HTMLDocument} docuemnt   The MathDocument for the MathItem
          */
         public explorable(document: ExplorerMathDocument) {
+          console.log('Start Explorable');
             if (this.state() >= STATE.EXPLORER) return;
             const node = this.typesetRoot;
             const mml = toMathML(this.root);
+            if (this.savedId) {
+                this.typesetRoot.setAttribute('explorer-id', this.savedId);
+                this.savedId = null;
+            }
             this.explorer = SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
             this.state(STATE.EXPLORER);
+          console.log('End Explorable');
         }
 
+
+        // Multiple explorer facilities:
+        // For any that is active: restart.
         /**
          * @override
          */
         public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
+          console.log('Rerendering');
+            this.savedId = this.typesetRoot.getAttribute('explorer-id');
             this.refocus = (window.document.activeElement === this.typesetRoot);
             if (this.explorer && (this.explorer as any).active) {
                 this.restart = true;
                 this.explorer.Stop();
             }
             super.rerender(document, start);
+          console.log('Done Rerendering');
         }
 
         /**
          * @override
          */
         public updateDocument(document: ExplorerMathDocument) {
+          console.log('Updating Document');
             super.updateDocument(document);
             this.refocus && this.typesetRoot.focus();
             this.restart && this.explorer.Start();
             this.refocus = this.restart = false;
+          console.log('Done Updating Document');
         }
 
     };

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -131,7 +131,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
           console.log('Rerendering');
             this.savedId = this.typesetRoot.getAttribute('explorer-id');
             this.refocus = (window.document.activeElement === this.typesetRoot);
-            if (this.explorer && (this.explorer as any).active) {
+            if (this.explorer && this.explorer.active) {
                 this.restart = true;
                 this.explorer.Stop();
             }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -108,7 +108,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
          * @param {HTMLDocument} docuemnt   The MathDocument for the MathItem
          */
         public explorable(document: ExplorerMathDocument) {
-          console.log('Start Explorable');
             if (this.state() >= STATE.EXPLORER) return;
             const node = this.typesetRoot;
             const mml = toMathML(this.root);
@@ -118,7 +117,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
             }
             this.explorer = SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
             this.state(STATE.EXPLORER);
-          console.log('End Explorable');
         }
 
 
@@ -128,7 +126,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
          * @override
          */
         public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-          console.log('Rerendering');
             this.savedId = this.typesetRoot.getAttribute('explorer-id');
             this.refocus = (window.document.activeElement === this.typesetRoot);
             if (this.explorer && this.explorer.active) {
@@ -136,19 +133,16 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.explorer.Stop();
             }
             super.rerender(document, start);
-          console.log('Done Rerendering');
         }
 
         /**
          * @override
          */
         public updateDocument(document: ExplorerMathDocument) {
-          console.log('Updating Document');
             super.updateDocument(document);
             this.refocus && this.typesetRoot.focus();
             this.restart && this.explorer.Start();
             this.refocus = this.restart = false;
-          console.log('Done Updating Document');
         }
 
     };

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -45,7 +45,7 @@ export interface Explorer {
    * @param {boolean=} force Forces the update in any case. (E.g., even if
    *     explorer is inactive.)
    */
-  // Update(force?: boolean): void;
+  Update(force?: boolean): void;
 
 }
 
@@ -176,6 +176,11 @@ export class AbstractExplorer implements Explorer {
     }
   }
 
+  /**
+   * @override
+   */
+  public Update(force: boolean = false): void {}
+
 }
 
 
@@ -285,8 +290,8 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     console.log('End Stop');
   }
 
-  public Update() {
-    if (!this.active) return;
+  public Update(force: boolean = false) {
+    if (!this.active && !force) return;
     this.highlighter.unhighlight();
     this.highlighter.highlight(this.walker.getFocus().getNodes());
     this.region.Update(this.walker.speech());

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -226,24 +226,33 @@ export abstract class AbstractKeyExplorer extends AbstractExplorer implements Ke
 // element, which the first generation would set in on the A11ydocument.
 export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
 
-  private started: boolean = false;
 
+  /**
+   * The attached SRE walker.
+   * @type {sre.Walker}
+   */
   protected walker: sre.Walker;
+
+  /**
+   * The SRE highlighter associated with the walker.
+   * @type {sre.Highlighter}
+   */
   protected highlighter: sre.Highlighter;
-  private speechGenerator: sre.SpeechGenerator;
+
+
+  /**
+   * The SRE speech generator associated with the walker.
+   * @type {sre.SpeechGenerator}
+   */
+  protected speechGenerator: sre.SpeechGenerator;
+
   private foreground: sre.colorType = {color: 'red', alpha: 1};
   private background: sre.colorType = {color: 'blue', alpha: .2};
 
-  // /**
-  //  * @override
-  //  */
-  // protected events: [string, (x: Event) => void][] =
-  //   super.Events().concat(
-  //     [['mouseover', this.Hover.bind(this)],
-  //      ['mouseout', this.UnHover.bind(this)]]);
-
-  // Maybe the A11yDocument should have a get region?
-  // Maybe we need more than one region (Braille)?
+  /**
+   * @constructor
+   * @extends {AbstractKeyExplorer}
+   */
   constructor(public document: A11yDocument,
               protected region: Region,
               protected node: HTMLElement,
@@ -252,23 +261,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     this.initWalker();
   }
 
-  private initWalker() {
-    const jax = this.document.outputJax.name;
-    this.highlighter = sre.HighlighterFactory.highlighter(
-      this.background, this.foreground,
-      {renderer: jax}
-    );
-    // Add speech
-    this.speechGenerator = new sre.TreeSpeechGenerator();
-    // We could have this in a separate explorer. Not sure if that makes sense.
-    let dummy = new sre.DummyWalker(
-      this.node, this.speechGenerator, this.highlighter, this.mml);
-    this.Speech(dummy);
-    this.speechGenerator = new sre.DirectSpeechGenerator();
-    this.walker = new sre.TableWalker(
-      this.node, this.speechGenerator, this.highlighter, this.mml);
-  }
 
+  /**
+   * @override
+   */
   public Start() {
     super.Start();
     this.region.Show(this.node, this.highlighter);
@@ -276,6 +272,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     this.Update();
   }
 
+
+  /**
+   * @override
+   */
   public Stop() {
     if (this.active) {
       this.highlighter.unhighlight();
@@ -284,6 +284,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     super.Stop();
   }
 
+
+  /**
+   * @override
+   */
   public Update(force: boolean = false) {
     if (!this.active && !force) return;
     this.highlighter.unhighlight();
@@ -291,7 +295,12 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     this.region.Update(this.walker.speech());
   }
 
-  public Speech(walker: any) {
+
+  /**
+   * Computes the speech for the current expression once SRE is ready.
+   * @param {sre.Walker} walker The sre walker.
+   */
+  public Speech(walker: sre.Walker) {
     sreReady.then(() => {
       let speech = walker.speech();
       this.node.setAttribute('hasspeech', 'true');
@@ -299,6 +308,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     }).catch((error: Error) => console.log(error.message));
   }
 
+
+  /**
+   * @override
+   */
   public KeyDown(event: KeyboardEvent) {
     const code = event.keyCode;
     if (code === 27) {
@@ -317,9 +330,34 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     }
   }
 
+
+  /**
+   * @override
+   */
   public Move(key: number) {
     this.walker.move(key);
     this.Update();
+  }
+
+
+  /**
+   * Initialises the SRE walker.
+   */
+  private initWalker() {
+    const jax = this.document.outputJax.name;
+    this.highlighter = sre.HighlighterFactory.highlighter(
+      this.background, this.foreground,
+      {renderer: jax}
+    );
+    // Add speech
+    this.speechGenerator = new sre.TreeSpeechGenerator();
+    // We could have this in a separate explorer. Not sure if that makes sense.
+    let dummy = new sre.DummyWalker(
+      this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.Speech(dummy);
+    this.speechGenerator = new sre.DirectSpeechGenerator();
+    this.walker = new sre.TableWalker(
+      this.node, this.speechGenerator, this.highlighter, this.mml);
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -5,6 +5,11 @@ import {sreReady} from '../sre.js';
 export interface Explorer {
 
   /**
+   * @return {boolean} Flag indicating if the explorer is active.
+   */
+  active: boolean;
+
+  /**
    * Attaches navigator and its event handlers to a node.
    */
   Attach(): void;
@@ -37,8 +42,10 @@ export interface Explorer {
 
   /**
    * Update the explorer after state changes.
+   * @param {boolean=} force Forces the update in any case. (E.g., even if
+   *     explorer is inactive.)
    */
-  // Update(): void;
+  // Update(force?: boolean): void;
 
 }
 
@@ -57,7 +64,7 @@ export class AbstractExplorer implements Explorer {
 
   protected events: [string, (x: Event) => void][] = [];
 
-  protected active: boolean = false;
+  private _active: boolean = false;
   private oldIndex: number = null;
 
   protected static stopEvent(event: Event) {
@@ -97,6 +104,20 @@ export class AbstractExplorer implements Explorer {
     return explorer;
   }
 
+  /**
+   * @override
+   */
+  public get active(): boolean {
+    return this._active;
+  }
+
+  /**
+   * @override
+   */
+  public set active(flag: boolean) {
+    this._active = flag;
+  }
+  
   /**
    * @override
    */

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -151,7 +151,6 @@ export class AbstractExplorer implements Explorer {
    */
   public Stop() {
     if (this.active) {
-      console.log('Clearing and hiding');
       this.region.Clear();
       this.region.Hide();
       this.active = false;
@@ -271,23 +270,18 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
   }
 
   public Start() {
-    console.log('Begin Start');
     super.Start();
     this.region.Show(this.node, this.highlighter);
     this.walker.activate();
     this.Update();
-    console.log('End of Start');
   }
 
   public Stop() {
-    console.log('Start Stop');
     if (this.active) {
-      console.log('Was active');
       this.highlighter.unhighlight();
       this.walker.deactivate();
     }
     super.Stop();
-    console.log('End Stop');
   }
 
   public Update(force: boolean = false) {
@@ -298,9 +292,7 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
   }
 
   public Speech(walker: any) {
-      console.log('Computing Speech Start');
     sreReady.then(() => {
-      console.log('Computing Speech Callback');
       let speech = walker.speech();
       this.node.setAttribute('hasspeech', 'true');
       this.Update();

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -249,9 +249,7 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     super.Start();
     this.region.Show(this.node, this.highlighter);
     this.walker.activate();
-    this.highlighter.unhighlight();
-    this.highlighter.highlight(this.walker.getFocus().getNodes());
-    this.region.Update(this.walker.speech());
+    this.Update();
     console.log('End of Start');
   }
 
@@ -266,17 +264,20 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     console.log('End Stop');
   }
 
+  public Update() {
+    if (!this.active) return;
+    this.highlighter.unhighlight();
+    this.highlighter.highlight(this.walker.getFocus().getNodes());
+    this.region.Update(this.walker.speech());
+  }
+
   public Speech(walker: any) {
       console.log('Computing Speech Start');
     sreReady.then(() => {
       console.log('Computing Speech Callback');
       let speech = walker.speech();
       this.node.setAttribute('hasspeech', 'true');
-      if (this.active) {
-        this.highlighter.unhighlight();
-        this.highlighter.highlight(this.walker.getFocus().getNodes());
-        this.region.Update(this.walker.speech());
-      }
+      this.Update();
     }).catch((error: Error) => console.log(error.message));
   }
 
@@ -300,11 +301,7 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
 
   public Move(key: number) {
     this.walker.move(key);
-    if (this.active) {
-      this.highlighter.unhighlight();
-      this.highlighter.highlight(this.walker.getFocus().getNodes());
-      this.region.Update(this.walker.speech());
-    }
+    this.Update();
   }
 
 }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -29,6 +29,7 @@ declare namespace sre {
   
   interface Walker {
     activate(): void;
+    deactivate(): void;
     speech(): string;
     move(key: number): void;
     getFocus(): Focus;
@@ -37,6 +38,7 @@ declare namespace sre {
   class AbstractWalker implements Walker {
     constructor(node: Node, generator: SpeechGenerator, highlighter: Highlighter, mml: Node);
     activate(): void;
+    deactivate(): void;
     speech(): string;
     move(key: number): void;
     getFocus(): Focus;


### PR DESCRIPTION
Updates the explorer to restart correctly after re-rendering events, like expand/collapse.

Note, that the way the old explorer is attached is not very elegant. Once I've added the Braille explorer, this will be handled in a more extensible way. 