### PR TITLE
A11y subtitle selection.

### DIFF
--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -198,7 +198,10 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
             renderActions: expandable({
                 ...BaseDocument.OPTIONS.renderActions,
                 explorable: [STATE.EXPLORER]
-            })
+            }),
+          a11y: {
+            subtitles: false
+          }
         };
 
         /**

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {Explorer, SpeechExplorer, Magnifier} from './explorer/Explorer.js';
+import {AbstractKeyExplorer, TypeExplorer, RoleExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -83,9 +83,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
     return class extends BaseMathItem {
 
         /**
-         * The Explorer object for this math item
+         * The Explorer objects for this math item
          */
-        protected explorer: Explorer = null;
+        protected explorers: Explorer[] = [];
 
         /**
          * True when a rerendered element should restart the explorer
@@ -112,26 +112,53 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
             const node = this.typesetRoot;
             const mml = toMathML(this.root);
             if (this.savedId) {
-                this.typesetRoot.setAttribute('explorer-id', this.savedId);
+                this.typesetRoot.setAttribute('sre-explorer-id', this.savedId);
                 this.savedId = null;
             }
-            this.explorer = SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
+            this.addExplorers(
+                SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
+                SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
+                Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
+                TypeExplorer.create(document, document.explorerObjects.tooltip, node),
+                RoleExplorer.create(document, document.explorerObjects.tooltip2, node)
+            );
             this.state(STATE.EXPLORER);
         }
 
 
-        // Multiple explorer facilities:
-        // For any that is active: restart.
+        /**
+         * Adds a list of explorers and makes sure the right one stops propagating.
+         * @param {Explorer[]} ...explorers
+         */
+        private addExplorers(...explorers: Explorer[]) {
+            this.explorers = explorers;
+            if (explorers.length <= 1) return;
+            let lastKeyExplorer: AbstractKeyExplorer = null;
+            for (let explorer of this.explorers) {
+                if (!(explorer instanceof AbstractKeyExplorer)) continue;
+                if (lastKeyExplorer) {
+                    lastKeyExplorer.stoppable = false;
+                }
+                lastKeyExplorer = explorer;
+            }
+        }
+
+
         /**
          * @override
          */
         public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-            this.savedId = this.typesetRoot.getAttribute('explorer-id');
+            this.savedId = this.typesetRoot.getAttribute('sre-explorer-id');
             this.refocus = (window.document.activeElement === this.typesetRoot);
-            if (this.explorer && this.explorer.active) {
-                this.restart = true;
-                this.explorer.Stop();
+            let savedExplorers = [];
+            for (let explorer of this.explorers) {
+                if (explorer.active) {
+                    this.restart = true;
+                    explorer.Stop();
+                    savedExplorers.push(explorer);
+                }
             }
+            this.explorers = savedExplorers;
             super.rerender(document, start);
         }
 
@@ -141,7 +168,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
         public updateDocument(document: ExplorerMathDocument) {
             super.updateDocument(document);
             this.refocus && this.typesetRoot.focus();
-            this.restart && this.explorer.Start();
+            this.restart && this.explorers.forEach(x => x.Start());
             this.refocus = this.restart = false;
         }
 
@@ -156,6 +183,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
  */
 export type ExplorerObjects = {
     region?: LiveRegion,
+    region2?: LiveRegion,
     tooltip?: ToolTip,
     tooltip2?: ToolTip,
     tooltip3?: ToolTip,
@@ -200,7 +228,13 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
                 explorable: [STATE.EXPLORER]
             }),
           a11y: {
-            subtitles: false
+            subtitles: true,
+            foregroundColor: 'Black',
+            foregroundOpacity: 1,
+            backgroundColor: 'Blue',
+            backgroundOpacity: .2,
+            align: 'top',
+            magnify: 500
           }
         };
 
@@ -227,6 +261,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
             this.options.MathItem = ExplorerMathItemMixin(this.options.MathItem, toMathML);
             this.explorerObjects = {
                 region: new LiveRegion(this),
+                region2: new LiveRegion(this),
                 tooltip: new ToolTip(this),
                 tooltip2: new ToolTip(this),
                 tooltip3: new ToolTip(this),

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -267,7 +267,9 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
    */
   public Start() {
     super.Start();
-    this.region.Show(this.node, this.highlighter);
+    if (this.document.options.a11y.subtitles) {
+      this.region.Show(this.node, this.highlighter);
+    }
     this.walker.activate();
     this.Update();
   }

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -157,9 +157,20 @@ export abstract class AbstractRegion implements Region {
     this.div.classList.add(this.CLASS.className + '_Show');
   }
 
+
+  /**
+   * Computes the position where to place the element wrt. to the given node.
+   * @param {HTMLElement} node The reference node.
+   */
   protected abstract position(node: HTMLElement): void;
 
+
+  /**
+   * Highlights the region.
+   * @param {sre.Highlighter} highlighter The SRE highlighter.
+   */
   protected abstract highlight(highlighter: sre.Highlighter): void;
+
 
   /**
    * @override
@@ -188,49 +199,68 @@ export abstract class AbstractRegion implements Region {
   }
 
 
-}
-
-export class ToolTip extends AbstractRegion {
-
-  protected static className = 'MJX_ToolTip';
-  protected static style: CssStyles =
-    new CssStyles({['.' + ToolTip.className]: {
-      position: 'absolute',
-      display: 'inline-block',
-      height: '1px', width: '1px'
-    },
-                   ['.' + ToolTip.className + '_Show']: {
-                     width: 'auto', height: 'auto',
-                     opacity: 1,
-                     'text-align': 'center',
-                     'border-radius': '6px',
-                     padding: '0px 0px',
-                     'border-bottom': '1px dotted black',
-                     position: 'absolute',
-                     'z-index': 202
-                   }
-                  }
-                 );
-
-  protected position(node: HTMLElement) {
+  /**
+   * Auxiliary position method that stacks shown regions of the same type.
+   * @param {HTMLElement} node The reference node.
+   */
+  protected stackRegions(node: HTMLElement) {
+    // TODO: This could be made more efficient by caching regions of a class.
     const rect = node.getBoundingClientRect();
     let baseBottom = 0;
     let baseLeft = Number.POSITIVE_INFINITY;
-    let tooltips = this.document.adaptor.document.getElementsByClassName(this.CLASS.className + '_Show');
-    for (let i = 0, tooltip; tooltip = tooltips[i]; i++) {
-      if (tooltip !== this.div) {
-        baseBottom = Math.max(tooltip.getBoundingClientRect().bottom, baseBottom);
-        baseLeft = Math.min(tooltip.getBoundingClientRect().left, baseLeft);
+    let regions = this.document.adaptor.document.getElementsByClassName(
+      this.CLASS.className + '_Show');
+    // Get all the shown regions (one is this element!) and append at bottom. 
+    for (let i = 0, region; region = regions[i]; i++) {
+      if (region !== this.div) {
+        baseBottom = Math.max(region.getBoundingClientRect().bottom, baseBottom);
+        baseLeft = Math.min(region.getBoundingClientRect().left, baseLeft);
       }
     }
-    // Get all the shown tooltips and then put at the bottom. One of which is
-    // the element itself!
     const bot = (baseBottom ? baseBottom : rect.bottom + 10) + window.pageYOffset;
     const left = (baseLeft < Number.POSITIVE_INFINITY ? baseLeft : rect.left) + window.pageXOffset;
     this.div.style.top = bot + 'px';
     this.div.style.left = left + 'px';
   }
 
+}
+
+export class ToolTip extends AbstractRegion {
+
+  /**
+   * @override
+   */
+  protected static className = 'MJX_ToolTip';
+
+  /**
+   * @override
+   */
+  protected static style: CssStyles =
+    new CssStyles({
+      ['.' + ToolTip.className]: {
+        position: 'absolute', display: 'inline-block',
+        height: '1px', width: '1px'
+      },
+      ['.' + ToolTip.className + '_Show']: {
+        width: 'auto', height: 'auto', opacity: 1, 'text-align': 'center',
+        'border-radius': '6px', padding: '0px 0px',
+        'border-bottom': '1px dotted black', position: 'absolute',
+        'z-index': 202
+      }
+    });
+
+
+  /**
+   * @override
+   */
+  protected position(node: HTMLElement) {
+    this.stackRegions(node);
+  }
+
+
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
@@ -251,19 +281,19 @@ export class LiveRegion extends AbstractRegion {
    * @override
    */
   protected static style: CssStyles =
-    new CssStyles({['.' + LiveRegion.className]: {
-      position: 'absolute', top: '0', height: '1px', width: '1px',
-      padding: '1px', overflow: 'hidden'
-    },
-                   ['.' + LiveRegion.className + '_Show']:
-                   {
-                     top: '0', position: 'absolute', width: 'auto', height: 'auto',
-                     padding: '0px 0px', opacity: 1, 'z-index': '202',
-                     left: 0, right: 0, 'margin': '0 auto',
-                     'background-color': 'rgba(0, 0, 255, 0.2)', 'box-shadow': '0px 10px 20px #888',
-                     border: '2px solid #CCCCCC'
-                   }
-                  });
+    new CssStyles({
+      ['.' + LiveRegion.className]: {
+        position: 'absolute', top: '0', height: '1px', width: '1px',
+        padding: '1px', overflow: 'hidden'
+      },
+      ['.' + LiveRegion.className + '_Show']: {
+        top: '0', position: 'absolute', width: 'auto', height: 'auto',
+        padding: '0px 0px', opacity: 1, 'z-index': '202',
+        left: 0, right: 0, 'margin': '0 auto',
+        'background-color': 'rgba(0, 0, 255, 0.2)', 'box-shadow': '0px 10px 20px #888',
+        border: '2px solid #CCCCCC'
+      }
+    });
 
 
   /**
@@ -283,15 +313,16 @@ export class LiveRegion extends AbstractRegion {
     super.Show(node, highlighter);
   }
 
-
+  /**
+   * @override
+   */
   protected position(node: HTMLElement) {
-    const rect = node.getBoundingClientRect();
-    const bot = rect.bottom + 10 + window.pageYOffset;
-    const left = rect.left + window.pageXOffset;
-    this.div.style.top = bot + 'px';
-    this.div.style.left = left + 'px';
+    this.stackRegions(node);
   }
 
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
@@ -301,7 +332,7 @@ export class LiveRegion extends AbstractRegion {
 }
 
 
-// Regions that overlays the current element.
+// Region that overlays the current element.
 export class HoverRegion extends AbstractRegion {
 
   /**
@@ -313,20 +344,18 @@ export class HoverRegion extends AbstractRegion {
    * @override
    */
   protected static style: CssStyles =
-    new CssStyles({['.' + HoverRegion.className]: {
-      position: 'absolute', top: '0', height: '1px', width: '1px',
-      padding: '1px', overflow: 'hidden'
-    },
-                   ['.' + HoverRegion.className + '_Show']:
-                   {
-                     top: '0', position: 'absolute', width: 'max-content', height: 'auto',
-                     padding: '0px 0px', opacity: 1, 'z-index': '202',
-                     left: 0, right: 0, 'margin': '0 auto',
-                     'background-color': 'rgba(0, 0, 255, 0.2)',
-                     'box-shadow': '0px 10px 20px #888',
-                     border: '2px solid #CCCCCC'
-                   }
-                  });
+    new CssStyles({
+      ['.' + HoverRegion.className]: {
+        position: 'absolute', height: '1px', width: '1px',
+        padding: '1px', overflow: 'hidden'
+      },
+      ['.' + HoverRegion.className + '_Show']: {
+        position: 'absolute', width: 'max-content', height: 'auto',
+        padding: '0px 0px', opacity: 1, 'z-index': '202', 'margin': '0 auto',
+        'background-color': 'rgba(0, 0, 255, 0.2)',
+        'box-shadow': '0px 10px 20px #888', border: '2px solid #CCCCCC'
+      }
+    });
 
 
   /**
@@ -335,36 +364,97 @@ export class HoverRegion extends AbstractRegion {
    */
   constructor(public document: A11yDocument) {
     super(document);
-    this.div.style.fontSize = '800%';
-    this.inner.classList.add('MJX-TEX');
+    this.div.style.fontSize = document.options.a11y.magnify + '%';
+    this.inner.style.lineHeight = '0';
   }
 
   /**
-   * Shows the live region as a subtitle of a node.
-   * @override
+   * Sets the position of the region with respect to align parameter.  There are
+   * three options: top, bottom and center. Center is the default.
+   *
+   * @param {HTMLElement} node The node that is displayed.
    */
-  public Show(node: HTMLElement, highlighter: sre.Highlighter) {
-    super.Show(node, highlighter);
-  }
-
-
   protected position(node: HTMLElement) {
-    const rect = node.getBoundingClientRect();
-    const top = rect.top;
-    const left = rect.left;
+    const nodeRect = node.getBoundingClientRect();
+    const divRect = this.div.getBoundingClientRect();
+    const xCenter = nodeRect.left + (nodeRect.width / 2);
+    let left = xCenter - (divRect.width / 2);
+    left = (left < 0) ? 0 : left;
+    left = left + window.pageXOffset;
+    let top;
+    switch (this.document.options.a11y.align) {
+    case 'top':
+      top = nodeRect.top - divRect.height - 10 ;
+      break;
+    case 'bottom':
+      top = nodeRect.bottom + 10;
+      break;
+    case 'center':
+    default:
+      const yCenter = nodeRect.top + (nodeRect.height / 2);
+      top = yCenter - (divRect.height / 2);
+    }
+    top = top + window.pageYOffset;
+    top = (top < 0) ? 0 : top;
     this.div.style.top = top + 'px';
     this.div.style.left = left + 'px';
   }
 
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
-    // const color = highlighter.colorString();
-    // this.inner.style.backgroundColor = color.background;
-    // this.inner.style.color = color.foreground;
+    const color = highlighter.colorString();
+    this.inner.style.backgroundColor = color.background;
+    this.inner.style.color = color.foreground;
   }
 
-  public AddNode(node: HTMLElement): void {
+  /**
+   * @override
+   */
+  public Show(node: HTMLElement, highlighter: sre.Highlighter) {
+    this.AddNode(node);
+    super.Show(node, highlighter);
+  }
+
+  /**
+   * Adds a clone of the given node to the hover region.
+   * @param {HTMLElement} node The current HTML node.
+   */
+  public AddNode(node: HTMLElement) {
     this.Clear();
-    this.inner.appendChild(node);
+    let mjx = node.cloneNode(true) as HTMLElement;
+    if (mjx.nodeName !== 'MJX-CONTAINER') {
+      // remove element spacing (could be done in CSS)
+      if (mjx.nodeName !== 'g') {
+        mjx.style.marginLeft = mjx.style.marginRight = '0';
+      }
+      let container = node;
+      while (container && container.nodeName !== 'MJX-CONTAINER') {
+        container = container.parentNode as HTMLElement;
+      }
+      if (mjx.nodeName !== 'MJX-MATH' && mjx.nodeName !== 'svg') {
+        const child = container.firstChild;
+        mjx = child.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+        //
+        // SVG specific
+        //
+        if (mjx.nodeName === 'svg') {
+          (mjx.firstChild as HTMLElement).setAttribute('transform', 'matrix(1 0 0 -1 0 0)');
+          const W = parseFloat(mjx.getAttribute('viewBox').split(/ /)[2]);
+          const w = parseFloat(mjx.getAttribute('width'));
+          const {x, y, width, height} = (node as any).getBBox();
+          mjx.setAttribute('viewBox', [x, -(y + height), width, height].join(' '));
+          mjx.removeAttribute('style');
+          mjx.setAttribute('width', (w/W * width) + 'ex');
+          mjx.setAttribute('height', (w/W * height) + 'ex');
+        }
+      }
+      mjx = container.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+      //  remove displayed math margins (could be done in CSS)
+      mjx.style.margin = '0';
+    }
+    this.inner.appendChild(mjx);
   }
 
 }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -16,6 +16,8 @@ declare namespace sre {
   
   class DirectSpeechGenerator extends AbstractSpeechGenerator { }
   
+  class DummySpeechGenerator extends AbstractSpeechGenerator { }
+
 
   interface Highlighter {
     highlight(nodes: Node[]): void;

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -387,7 +387,8 @@ export class Menu {
                     this.variable<string> ('background'),
                     this.variable<string> ('foreground'),
                     this.variable<boolean>('speech'),
-                    this.variable<boolean>('subtitles'),
+                    this.variable<boolean>('subtitles', (subtitles: boolean) =>
+                                           this.document.options.a11y.subtitles = subtitles),
                     this.variable<string> ('speechrules'),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -384,8 +384,10 @@ export class Menu {
                     this.variable<string> ('scale', (scale: string) => this.setScale(scale)),
                     this.variable<boolean>('explorer', (explore: boolean) => this.setExplorer(explore)),
                     this.variable<string> ('highlight'),
-                    this.variable<string> ('background'),
-                    this.variable<string> ('foreground'),
+                    this.variable<string> ('background', (background: string) =>
+                                           this.document.options.a11y.backgroundColor = background),
+                    this.variable<string> ('foreground', (foreground: string) =>
+                                           this.document.options.a11y.foregroundColor = foreground),
                     this.variable<boolean>('speech'),
                     this.variable<boolean>('subtitles', (subtitles: boolean) =>
                                            this.document.options.a11y.subtitles = subtitles),


### PR DESCRIPTION
Adds selective subtitle for speech.
Also adds options in an `a11y` category for the `Explorer` mixin that holds the custuomisable information for the different types of explorers.

I am thinking it might be cleaner to add that to a more dedicated class.  There is already a dummy type `A11yDocument` in `Region.js` that could serve that purpose. We could also add that via an `A11y` mixin (from which the `Explorer` mixin could inherit). We should discuss what the cleaner design is .

I also have not quite figured out how the initial menu selections are passed into the document options.