### PR TITLE
A11y contrast

### DIFF
--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {Explorer, SpeechExplorer, Magnifier} from './explorer/Explorer.js';
+import {TypeExplorer, Explorer, SpeechExplorer, Magnifier} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -116,6 +116,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.savedId = null;
             }
             this.explorer = SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
+          TypeExplorer.create(document, document.explorerObjects.tooltip, node);
             this.state(STATE.EXPLORER);
         }
 
@@ -200,7 +201,11 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
                 explorable: [STATE.EXPLORER]
             }),
           a11y: {
-            subtitles: false
+            subtitles: true,
+            foregroundColor: 'Black',
+            foregroundOpacity: 1,
+            backgroundColor: 'Blue',
+            backgroundOpacity: .2
           }
         };
 

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -116,7 +116,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.savedId = null;
             }
             this.explorer = SpeechExplorer.create(document, document.explorerObjects.region, node, mml);
-          TypeExplorer.create(document, document.explorerObjects.tooltip, node);
             this.state(STATE.EXPLORER);
         }
 

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {TypeExplorer, Explorer, SpeechExplorer, Magnifier} from './explorer/Explorer.js';
+import {Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -5,9 +5,16 @@ import {sreReady} from '../sre.js';
 export interface Explorer {
 
   /**
-   * @return {boolean} Flag indicating if the explorer is active.
+   * Flag indicating if the explorer is active.
+   * @type {boolean}
    */
   active: boolean;
+
+  /**
+   * Flag indicating if event bubbling is stopped.
+   * @type {boolean}
+   */
+  stoppable: boolean;
 
   /**
    * Attaches navigator and its event handlers to a node.
@@ -62,6 +69,16 @@ export interface Explorer {
  */
 export class AbstractExplorer implements Explorer {
 
+
+  /**
+   * @override
+   */
+  public stoppable: boolean = true;
+
+  /**
+   * Named events and their functions.
+   * @type {[string, function(x: Event)][]}
+   */
   protected events: [string, (x: Event) => void][] = [];
 
   /**
@@ -73,6 +90,11 @@ export class AbstractExplorer implements Explorer {
   private _active: boolean = false;
   private oldIndex: number = null;
 
+
+  /**
+   * Stops event bubbling.
+   * @param {Event} event The event that is stopped.
+   */
   protected static stopEvent(event: Event) {
     if (event.preventDefault) {
       event.preventDefault();
@@ -202,6 +224,16 @@ export class AbstractExplorer implements Explorer {
       {renderer: this.document.outputJax.name});
   }
 
+  /**
+   * Stops the events of this explorer from bubbling.
+   * @param {Event} event The event to stop.
+   */
+  protected stopEvent(event: Event) {
+    if (this.stoppable) {
+      AbstractExplorer.stopEvent(event);
+    }
+  }
+
 }
 
 
@@ -261,6 +293,13 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
    */
   protected speechGenerator: sre.SpeechGenerator;
 
+  /**
+   * Flag in case the start method is triggered before the walker is fully
+   * initialised. I.e., we have to wait for SRE. Then region is re-shown if
+   * necessary, as otherwise it leads to incorrect stacking.
+   * @type {boolean}
+   */
+  private restarted: boolean = false;
 
   /**
    * @constructor
@@ -283,11 +322,12 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     this.speechGenerator = new sre.DirectSpeechGenerator();
     this.walker = new sre.TableWalker(
       this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.walker.activate();
+    this.Update();
     if (this.document.options.a11y.subtitles) {
       this.region.Show(this.node, this.highlighter);
     }
-    this.walker.activate();
-    this.Update();
+    this.restarted = true;
   }
 
 
@@ -323,6 +363,9 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
       let speech = walker.speech();
       this.node.setAttribute('hasspeech', 'true');
       this.Update();
+      if (this.restarted && this.document.options.a11y.subtitles) {
+        this.region.Show(this.node, this.highlighter);
+      }
     }).catch((error: Error) => console.log(error.message));
   }
 
@@ -334,17 +377,17 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     const code = event.keyCode;
     if (code === 27) {
       this.Stop();
-      AbstractExplorer.stopEvent(event);
+      this.stopEvent(event);
       return;
     }
     if (this.active) {
       this.Move(code);
-      AbstractExplorer.stopEvent(event);
+      this.stopEvent(event);
       return;
     }
     if (code === 32 && event.shiftKey) {
       this.Start();
-      AbstractExplorer.stopEvent(event);
+      this.stopEvent(event);
     }
   }
 
@@ -372,28 +415,63 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
 }
 
 
-// Reimplement without speech and proper setting of region.
-export class Magnifier extends SpeechExplorer {
+export class Magnifier extends AbstractKeyExplorer {
+
+  /**
+   * The walker for the magnifier.
+   * @type {sre.Walker}
+   */
+  private walker: sre.Walker;
+
+  /**
+   * @constructor
+   * @extends {AbstractKeyExplorer}
+   */
+  constructor(public document: A11yDocument,
+              protected region: Region,
+              protected node: HTMLElement,
+              private mml: HTMLElement) {
+    super(document, region, node);
+    this.walker = new sre.TableWalker(
+        this.node, new sre.DummySpeechGenerator(), this.highlighter, this.mml);
+  }
+
 
   public Start() {
     super.Start();
     this.region.Show(this.node, this.highlighter);
     this.walker.activate();
-    this.highlighter.highlight(this.walker.getFocus().getNodes());
     this.showFocus();
   }
 
   private showFocus() {
     let node = this.walker.getFocus().getNodes()[0] as HTMLElement;
-    let mjx = node.cloneNode(true) as HTMLElement;
-    const region = this.region as HoverRegion;
-    region.Show(node, this.highlighter);
-    region.AddNode(mjx);
+    this.region.Show(node, this.highlighter);
   }
 
   public Move(key: number) {
-    this.walker.move(key);
-    this.showFocus();
+    let result = this.walker.move(key);
+    if (result) {
+      this.showFocus();
+    }
+  }
+
+  public KeyDown(event: KeyboardEvent) {
+    const code = event.keyCode;
+    if (code === 27) {
+      this.Stop();
+      this.stopEvent(event);
+      return;
+    }
+    if (this.active && code !== 13) {
+      this.Move(code);
+      this.stopEvent(event);
+      return;
+    }
+    if (code === 32 && event.shiftKey) {
+      this.Start();
+      this.stopEvent(event);
+    }
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -246,8 +246,6 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
    */
   protected speechGenerator: sre.SpeechGenerator;
 
-  private foreground: sre.colorType = {color: 'red', alpha: 1};
-  private background: sre.colorType = {color: 'blue', alpha: .2};
 
   /**
    * @constructor
@@ -267,6 +265,10 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
    */
   public Start() {
     super.Start();
+    this.highlighter = this.getHighlighter();
+    this.speechGenerator = new sre.DirectSpeechGenerator();
+    this.walker = new sre.TableWalker(
+      this.node, this.speechGenerator, this.highlighter, this.mml);
     if (this.document.options.a11y.subtitles) {
       this.region.Show(this.node, this.highlighter);
     }
@@ -341,25 +343,27 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
     this.Update();
   }
 
+  private getHighlighter(): sre.Highlighter {
+    let opts = this.document.options.a11y;
+    let foreground = {color: opts.foregroundColor.toLowerCase(),
+                      alpha: opts.foregroundOpacity};
+    let background = {color: opts.backgroundColor.toLowerCase(),
+                      alpha: opts.backgroundOpacity};
+    return sre.HighlighterFactory.highlighter(
+      background, foreground,
+      {renderer: this.document.outputJax.name});
+  }
 
   /**
    * Initialises the SRE walker.
    */
   private initWalker() {
-    const jax = this.document.outputJax.name;
-    this.highlighter = sre.HighlighterFactory.highlighter(
-      this.background, this.foreground,
-      {renderer: jax}
-    );
     // Add speech
     this.speechGenerator = new sre.TreeSpeechGenerator();
     // We could have this in a separate explorer. Not sure if that makes sense.
     let dummy = new sre.DummyWalker(
       this.node, this.speechGenerator, this.highlighter, this.mml);
     this.Speech(dummy);
-    this.speechGenerator = new sre.DirectSpeechGenerator();
-    this.walker = new sre.TableWalker(
-      this.node, this.speechGenerator, this.highlighter, this.mml);
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -64,6 +64,12 @@ export class AbstractExplorer implements Explorer {
 
   protected events: [string, (x: Event) => void][] = [];
 
+  /**
+   * The SRE highlighter associated with the walker.
+   * @type {sre.Highlighter}
+   */
+  protected highlighter: sre.Highlighter = this.getHighlighter();
+
   private _active: boolean = false;
   private oldIndex: number = null;
 
@@ -142,6 +148,7 @@ export class AbstractExplorer implements Explorer {
    * @override
    */
   public Start() {
+    this.highlighter = this.getHighlighter();
     this.active = true;
   }
 
@@ -179,6 +186,21 @@ export class AbstractExplorer implements Explorer {
    * @override
    */
   public Update(force: boolean = false): void {}
+
+
+  /**
+   * @return {sre.Highlighter} A highlighter for the explorer.
+   */
+  protected getHighlighter(): sre.Highlighter {
+    let opts = this.document.options.a11y;
+    let foreground = {color: opts.foregroundColor.toLowerCase(),
+                      alpha: opts.foregroundOpacity};
+    let background = {color: opts.backgroundColor.toLowerCase(),
+                      alpha: opts.backgroundOpacity};
+    return sre.HighlighterFactory.highlighter(
+      background, foreground,
+      {renderer: this.document.outputJax.name});
+  }
 
 }
 
@@ -234,13 +256,6 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
   protected walker: sre.Walker;
 
   /**
-   * The SRE highlighter associated with the walker.
-   * @type {sre.Highlighter}
-   */
-  protected highlighter: sre.Highlighter;
-
-
-  /**
    * The SRE speech generator associated with the walker.
    * @type {sre.SpeechGenerator}
    */
@@ -265,7 +280,6 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
    */
   public Start() {
     super.Start();
-    this.highlighter = this.getHighlighter();
     this.speechGenerator = new sre.DirectSpeechGenerator();
     this.walker = new sre.TableWalker(
       this.node, this.speechGenerator, this.highlighter, this.mml);
@@ -341,17 +355,6 @@ export class SpeechExplorer extends AbstractKeyExplorer implements KeyExplorer {
   public Move(key: number) {
     this.walker.move(key);
     this.Update();
-  }
-
-  private getHighlighter(): sre.Highlighter {
-    let opts = this.document.options.a11y;
-    let foreground = {color: opts.foregroundColor.toLowerCase(),
-                      alpha: opts.foregroundOpacity};
-    let background = {color: opts.backgroundColor.toLowerCase(),
-                      alpha: opts.backgroundOpacity};
-    return sre.HighlighterFactory.highlighter(
-      background, foreground,
-      {renderer: this.document.outputJax.name});
   }
 
   /**
@@ -447,10 +450,6 @@ export abstract class AbstractMouseExplorer extends AbstractExplorer implements 
 
 export class HoverExplorer extends AbstractMouseExplorer {
 
-  private foreground: sre.colorType = {color: 'red', alpha: 1};
-  private background: sre.colorType = {color: 'blue', alpha: .2};
-  private highlighter: sre.Highlighter;
-
   protected nodeQuery = function(node: HTMLElement) {
     return true;
   };
@@ -463,10 +462,6 @@ export class HoverExplorer extends AbstractMouseExplorer {
               protected region: Region,
               protected node: HTMLElement) {
     super(document, region, node);
-    this.highlighter = sre.HighlighterFactory.highlighter(
-      this.background, this.foreground,
-      {renderer: this.document.outputJax.name}
-    );
   }
 
   /**

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -157,9 +157,20 @@ export abstract class AbstractRegion implements Region {
     this.div.classList.add(this.CLASS.className + '_Show');
   }
 
+
+  /**
+   * Computes the position where to place the element wrt. to the given node.
+   * @param {HTMLElement} node The reference node.
+   */
   protected abstract position(node: HTMLElement): void;
 
+
+  /**
+   * Highlights the region.
+   * @param {sre.Highlighter} highlighter The SRE highlighter.
+   */
   protected abstract highlight(highlighter: sre.Highlighter): void;
+
 
   /**
    * @override
@@ -188,49 +199,68 @@ export abstract class AbstractRegion implements Region {
   }
 
 
-}
-
-export class ToolTip extends AbstractRegion {
-
-  protected static className = 'MJX_ToolTip';
-  protected static style: CssStyles =
-    new CssStyles({['.' + ToolTip.className]: {
-      position: 'absolute',
-      display: 'inline-block',
-      height: '1px', width: '1px'
-    },
-                   ['.' + ToolTip.className + '_Show']: {
-                     width: 'auto', height: 'auto',
-                     opacity: 1,
-                     'text-align': 'center',
-                     'border-radius': '6px',
-                     padding: '0px 0px',
-                     'border-bottom': '1px dotted black',
-                     position: 'absolute',
-                     'z-index': 202
-                   }
-                  }
-                 );
-
-  protected position(node: HTMLElement) {
+  /**
+   * Auxiliary position method that stacks shown regions of the same type.
+   * @param {HTMLElement} node The reference node.
+   */
+  protected stackRegions(node: HTMLElement) {
+    // TODO: This could be made more efficient by caching regions of a class.
     const rect = node.getBoundingClientRect();
     let baseBottom = 0;
     let baseLeft = Number.POSITIVE_INFINITY;
-    let tooltips = this.document.adaptor.document.getElementsByClassName(this.CLASS.className + '_Show');
-    for (let i = 0, tooltip; tooltip = tooltips[i]; i++) {
-      if (tooltip !== this.div) {
-        baseBottom = Math.max(tooltip.getBoundingClientRect().bottom, baseBottom);
-        baseLeft = Math.min(tooltip.getBoundingClientRect().left, baseLeft);
+    let regions = this.document.adaptor.document.getElementsByClassName(
+      this.CLASS.className + '_Show');
+    // Get all the shown regions (one is this element!) and append at bottom. 
+    for (let i = 0, region; region = regions[i]; i++) {
+      if (region !== this.div) {
+        baseBottom = Math.max(region.getBoundingClientRect().bottom, baseBottom);
+        baseLeft = Math.min(region.getBoundingClientRect().left, baseLeft);
       }
     }
-    // Get all the shown tooltips and then put at the bottom. One of which is
-    // the element itself!
     const bot = (baseBottom ? baseBottom : rect.bottom + 10) + window.pageYOffset;
     const left = (baseLeft < Number.POSITIVE_INFINITY ? baseLeft : rect.left) + window.pageXOffset;
     this.div.style.top = bot + 'px';
     this.div.style.left = left + 'px';
   }
 
+}
+
+export class ToolTip extends AbstractRegion {
+
+  /**
+   * @override
+   */
+  protected static className = 'MJX_ToolTip';
+
+  /**
+   * @override
+   */
+  protected static style: CssStyles =
+    new CssStyles({
+      ['.' + ToolTip.className]: {
+        position: 'absolute', display: 'inline-block',
+        height: '1px', width: '1px'
+      },
+      ['.' + ToolTip.className + '_Show']: {
+        width: 'auto', height: 'auto', opacity: 1, 'text-align': 'center',
+        'border-radius': '6px', padding: '0px 0px',
+        'border-bottom': '1px dotted black', position: 'absolute',
+        'z-index': 202
+      }
+    });
+
+
+  /**
+   * @override
+   */
+  protected position(node: HTMLElement) {
+    this.stackRegions(node);
+  }
+
+
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
@@ -251,19 +281,19 @@ export class LiveRegion extends AbstractRegion {
    * @override
    */
   protected static style: CssStyles =
-    new CssStyles({['.' + LiveRegion.className]: {
-      position: 'absolute', top: '0', height: '1px', width: '1px',
-      padding: '1px', overflow: 'hidden'
-    },
-                   ['.' + LiveRegion.className + '_Show']:
-                   {
-                     top: '0', position: 'absolute', width: 'auto', height: 'auto',
-                     padding: '0px 0px', opacity: 1, 'z-index': '202',
-                     left: 0, right: 0, 'margin': '0 auto',
-                     'background-color': 'rgba(0, 0, 255, 0.2)', 'box-shadow': '0px 10px 20px #888',
-                     border: '2px solid #CCCCCC'
-                   }
-                  });
+    new CssStyles({
+      ['.' + LiveRegion.className]: {
+        position: 'absolute', top: '0', height: '1px', width: '1px',
+        padding: '1px', overflow: 'hidden'
+      },
+      ['.' + LiveRegion.className + '_Show']: {
+        top: '0', position: 'absolute', width: 'auto', height: 'auto',
+        padding: '0px 0px', opacity: 1, 'z-index': '202',
+        left: 0, right: 0, 'margin': '0 auto',
+        'background-color': 'rgba(0, 0, 255, 0.2)', 'box-shadow': '0px 10px 20px #888',
+        border: '2px solid #CCCCCC'
+      }
+    });
 
 
   /**
@@ -283,15 +313,16 @@ export class LiveRegion extends AbstractRegion {
     super.Show(node, highlighter);
   }
 
-
+  /**
+   * @override
+   */
   protected position(node: HTMLElement) {
-    const rect = node.getBoundingClientRect();
-    const bot = rect.bottom + 10 + window.pageYOffset;
-    const left = rect.left + window.pageXOffset;
-    this.div.style.top = bot + 'px';
-    this.div.style.left = left + 'px';
+    this.stackRegions(node);
   }
 
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
@@ -301,7 +332,7 @@ export class LiveRegion extends AbstractRegion {
 }
 
 
-// Regions that overlays the current element.
+// Region that overlays the current element.
 export class HoverRegion extends AbstractRegion {
 
   /**
@@ -313,20 +344,18 @@ export class HoverRegion extends AbstractRegion {
    * @override
    */
   protected static style: CssStyles =
-    new CssStyles({['.' + HoverRegion.className]: {
-      position: 'absolute', top: '0', height: '1px', width: '1px',
-      padding: '1px', overflow: 'hidden'
-    },
-                   ['.' + HoverRegion.className + '_Show']:
-                   {
-                     top: '0', position: 'absolute', width: 'max-content', height: 'auto',
-                     padding: '0px 0px', opacity: 1, 'z-index': '202',
-                     left: 0, right: 0, 'margin': '0 auto',
-                     'background-color': 'rgba(0, 0, 255, 0.2)',
-                     'box-shadow': '0px 10px 20px #888',
-                     border: '2px solid #CCCCCC'
-                   }
-                  });
+    new CssStyles({
+      ['.' + HoverRegion.className]: {
+        position: 'absolute', height: '1px', width: '1px',
+        padding: '1px', overflow: 'hidden'
+      },
+      ['.' + HoverRegion.className + '_Show']: {
+        position: 'absolute', width: 'max-content', height: 'auto',
+        padding: '0px 0px', opacity: 1, 'z-index': '202', 'margin': '0 auto',
+        'background-color': 'rgba(0, 0, 255, 0.2)',
+        'box-shadow': '0px 10px 20px #888', border: '2px solid #CCCCCC'
+      }
+    });
 
 
   /**
@@ -335,36 +364,97 @@ export class HoverRegion extends AbstractRegion {
    */
   constructor(public document: A11yDocument) {
     super(document);
-    this.div.style.fontSize = '800%';
-    this.inner.classList.add('MJX-TEX');
+    this.div.style.fontSize = document.options.a11y.magnify + '%';
+    this.inner.style.lineHeight = '0';
   }
 
   /**
-   * Shows the live region as a subtitle of a node.
-   * @override
+   * Sets the position of the region with respect to align parameter.  There are
+   * three options: top, bottom and center. Center is the default.
+   *
+   * @param {HTMLElement} node The node that is displayed.
    */
-  public Show(node: HTMLElement, highlighter: sre.Highlighter) {
-    super.Show(node, highlighter);
-  }
-
-
   protected position(node: HTMLElement) {
-    const rect = node.getBoundingClientRect();
-    const top = rect.top;
-    const left = rect.left;
+    const nodeRect = node.getBoundingClientRect();
+    const divRect = this.div.getBoundingClientRect();
+    const xCenter = nodeRect.left + (nodeRect.width / 2);
+    let left = xCenter - (divRect.width / 2);
+    left = (left < 0) ? 0 : left;
+    left = left + window.pageXOffset;
+    let top;
+    switch (this.document.options.a11y.align) {
+    case 'top':
+      top = nodeRect.top - divRect.height - 10 ;
+      break;
+    case 'bottom':
+      top = nodeRect.bottom + 10;
+      break;
+    case 'center':
+    default:
+      const yCenter = nodeRect.top + (nodeRect.height / 2);
+      top = yCenter - (divRect.height / 2);
+    }
+    top = top + window.pageYOffset;
+    top = (top < 0) ? 0 : top;
     this.div.style.top = top + 'px';
     this.div.style.left = left + 'px';
   }
 
+  /**
+   * @override
+   */
   protected highlight(highlighter: sre.Highlighter) {
-    // const color = highlighter.colorString();
-    // this.inner.style.backgroundColor = color.background;
-    // this.inner.style.color = color.foreground;
+    const color = highlighter.colorString();
+    this.inner.style.backgroundColor = color.background;
+    this.inner.style.color = color.foreground;
   }
 
-  public AddNode(node: HTMLElement): void {
+  /**
+   * @override
+   */
+  public Show(node: HTMLElement, highlighter: sre.Highlighter) {
+    this.AddNode(node);
+    super.Show(node, highlighter);
+  }
+
+  /**
+   * Adds a clone of the given node to the hover region.
+   * @param {HTMLElement} node The current HTML node.
+   */
+  public AddNode(node: HTMLElement) {
     this.Clear();
-    this.inner.appendChild(node);
+    let mjx = node.cloneNode(true) as HTMLElement;
+    if (mjx.nodeName !== 'MJX-CONTAINER') {
+      // remove element spacing (could be done in CSS)
+      if (mjx.nodeName !== 'g') {
+        mjx.style.marginLeft = mjx.style.marginRight = '0';
+      }
+      let container = node;
+      while (container && container.nodeName !== 'MJX-CONTAINER') {
+        container = container.parentNode as HTMLElement;
+      }
+      if (mjx.nodeName !== 'MJX-MATH' && mjx.nodeName !== 'svg') {
+        const child = container.firstChild;
+        mjx = child.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+        //
+        // SVG specific
+        //
+        if (mjx.nodeName === 'svg') {
+          (mjx.firstChild as HTMLElement).setAttribute('transform', 'matrix(1 0 0 -1 0 0)');
+          const W = parseFloat(mjx.getAttribute('viewBox').split(/ /)[2]);
+          const w = parseFloat(mjx.getAttribute('width'));
+          const {x, y, width, height} = (node as any).getBBox();
+          mjx.setAttribute('viewBox', [x, -(y + height), width, height].join(' '));
+          mjx.removeAttribute('style');
+          mjx.setAttribute('width', (w/W * width) + 'ex');
+          mjx.setAttribute('height', (w/W * height) + 'ex');
+        }
+      }
+      mjx = container.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+      //  remove displayed math margins (could be done in CSS)
+      mjx.style.margin = '0';
+    }
+    this.inner.appendChild(mjx);
   }
 
 }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -16,6 +16,8 @@ declare namespace sre {
   
   class DirectSpeechGenerator extends AbstractSpeechGenerator { }
   
+  class DummySpeechGenerator extends AbstractSpeechGenerator { }
+
 
   interface Highlighter {
     highlight(nodes: Node[]): void;

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -384,8 +384,10 @@ export class Menu {
                     this.variable<string> ('scale', (scale: string) => this.setScale(scale)),
                     this.variable<boolean>('explorer', (explore: boolean) => this.setExplorer(explore)),
                     this.variable<string> ('highlight'),
-                    this.variable<string> ('background'),
-                    this.variable<string> ('foreground'),
+                    this.variable<string> ('background', (background: string) =>
+                                           this.document.options.a11y.backgroundColor = background),
+                    this.variable<string> ('foreground', (foreground: string) =>
+                                           this.document.options.a11y.foregroundColor = foreground),
                     this.variable<boolean>('speech'),
                     this.variable<boolean>('subtitles', (subtitles: boolean) =>
                                            this.document.options.a11y.subtitles = subtitles),


### PR DESCRIPTION
Restores the customisation of highlighting.
* Adds appropriate `a11y` options.
* Refactors highlighting functionality common to explorers into the abstract superclass.
* Integrates with the Menu.