### PR TITLE
Fix size of SVG viewBox for magnifier.

### DIFF
--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -404,19 +404,6 @@ export class HoverRegion extends AbstractRegion {
    * @override
    */
   protected highlight(highlighter: sre.Highlighter) {
-    let child = this.inner;
-    while (child) {
-      if (child.hasAttribute('sre-highlight')) {
-        return;
-      }
-      // This is SVG specific.
-      if (child.nodeName === 'svg') {
-        (child.firstChild as HTMLElement).
-          setAttribute('transform', 'matrix(1 0 0 -1 0 0)');
-        break;
-      };
-      child = child.childNodes[0] as HTMLElement;
-    }
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
     this.inner.style.color = color.foreground;
@@ -439,13 +426,29 @@ export class HoverRegion extends AbstractRegion {
     let mjx = node.cloneNode(true) as HTMLElement;
     if (mjx.nodeName !== 'MJX-CONTAINER') {
       // remove element spacing (could be done in CSS)
-      mjx.style.marginLeft = mjx.style.marginRight = '0';
+      if (mjx.nodeName !== 'g') {
+        mjx.style.marginLeft = mjx.style.marginRight = '0';
+      }
       let container = node;
       while (container && container.nodeName !== 'MJX-CONTAINER') {
         container = container.parentNode as HTMLElement;
       }
-      if (mjx.nodeName !== 'MJX-MATH') {
-        mjx = container.firstChild.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+      if (mjx.nodeName !== 'MJX-MATH' && mjx.nodeName !== 'svg') {
+        const child = container.firstChild;
+        mjx = child.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
+        //
+        // SVG specific
+        //
+        if (mjx.nodeName === 'svg') {
+          (mjx.firstChild as HTMLElement).setAttribute('transform', 'matrix(1 0 0 -1 0 0)');
+          const W = parseFloat(mjx.getAttribute('viewBox').split(/ /)[2]);
+          const w = parseFloat(mjx.getAttribute('width'));
+          const {x, y, width, height} = (node as any).getBBox();
+          mjx.setAttribute('viewBox', [x, -(y + height), width, height].join(' '));
+          mjx.removeAttribute('style');
+          mjx.setAttribute('width', (w/W * width) + 'ex');
+          mjx.setAttribute('height', (w/W * height) + 'ex');
+        }
       }
       mjx = container.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;
       //  remove displayed math margins (could be done in CSS)


### PR DESCRIPTION
This PR fixes the magnifier for SVG elements to have the proper bounding box.

Both the SVG and HTML magnifier doesn't get the scaling factor correct when there is scaling caused by container elements that have been removed (e.g., contents of superscripts).  Perhaps that is OK, but it does mean the magnified result may be too big (or too small in some cases) compared to the original size.

It might be possible to walk up the tree and take transformations into account.  Alternatively, the output could be modified to include scaling information (which is already being computed by both output jax) as attributes so that the explorer could pick that up.  The explorer could turn on/off an output option that controls that, for example.

Also, SVG expressions with tags don't work properly.  This is probably due to the fact that the SVG structure for these in v3 is quite different from the structure for v2, and that isn't being taken into account by the explorer.

Despite these limitations, I think this is an improvement over the current version.