### PR TITLE
Fixes mispelled typesetPromise method.

### DIFF
--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -195,7 +195,7 @@ const Lab = window.Lab = {
         //
         // Typeset the math, and output the MathML
         //
-        MathJax.TypesetPromise().then(() => {
+        MathJax.typesetPromise().then(() => {
             this.doc = MathJax.startup.document;
             this.outputMML(Array.from(this.doc.math)[0]);
         }).catch(err => {

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -267,8 +267,8 @@ export namespace Startup {
             //
             pagePromise = pagePromise.then(CONFIG.pageReady);
         }
-        promise = (CONFIG.typeset && MathJax.TypesetPromise ?
-                   pagePromise.then(MathJax.TypesetPromise) : pagePromise);
+        promise = (CONFIG.typeset && MathJax.typesetPromise ?
+                   pagePromise.then(MathJax.typesetPromise) : pagePromise);
     };
 
     /**


### PR DESCRIPTION
Replaces `TypesetPromise` by `typesetPromise` in two places:
* Fixes the spelling in the lab.
* Fixes spelling in `startup.ts`, although I could not produce an error with the old cap spelling.