### PR TITLE
Fixes problem with double highlighting in CHTML magnifier.

### DIFF
--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -404,6 +404,11 @@ export class HoverRegion extends AbstractRegion {
    * @override
    */
   protected highlight(highlighter: sre.Highlighter) {
+    // TODO Do this with styles to avoid the interaction of SVG/CHTML.
+    if (this.inner.firstChild &&
+        !(this.inner.firstChild as HTMLElement).hasAttribute('sre-highlight')) {
+      return;
+    }
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
     this.inner.style.color = color.foreground;
@@ -446,8 +451,9 @@ export class HoverRegion extends AbstractRegion {
           const {x, y, width, height} = (node as any).getBBox();
           mjx.setAttribute('viewBox', [x, -(y + height), width, height].join(' '));
           mjx.removeAttribute('style');
-          mjx.setAttribute('width', (w/W * width) + 'ex');
-          mjx.setAttribute('height', (w/W * height) + 'ex');
+          mjx.setAttribute('width', (w / W * width) + 'ex');
+          mjx.setAttribute('height', (w / W * height) + 'ex');
+          container.setAttribute('sre-highlight', 'false');
         }
       }
       mjx = container.cloneNode(false).appendChild(mjx).parentNode as HTMLElement;


### PR DESCRIPTION
Fixes the problem that the magnification region is highlighted twice in CHTML that was reintroduced in PR #297. 