### PR TITLE
Add combined components that contain tex-full

### DIFF
--- a/components/src/tex-chtml-full/preload.js
+++ b/components/src/tex-chtml-full/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex-full',
+    'output/chtml', 'output/chtml/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-chtml-full/tex-chtml-full.js
+++ b/components/src/tex-chtml-full/tex-chtml-full.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex-full/tex-full.js';
+import '../output/chtml/chtml.js';
+import '../output/chtml/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-chtml-full/webpack.config.js
+++ b/components/src/tex-chtml-full/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-chtml-full',                   // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/tex-svg-full/preload.js
+++ b/components/src/tex-svg-full/preload.js
@@ -1,0 +1,9 @@
+import {Loader} from '../../../mathjax3/components/loader.js';
+
+Loader.preLoad(
+    'loader', 'startup',
+    'core',
+    'input/tex-full',
+    'output/svg', 'output/svg/fonts/tex.js',
+    'ui/menu'
+);

--- a/components/src/tex-svg-full/tex-svg-full.js
+++ b/components/src/tex-svg-full/tex-svg-full.js
@@ -1,0 +1,8 @@
+import '../startup/lib/startup.js';
+import './preload.js';
+import '../core/core.js';
+import '../input/tex-full/tex-full.js';
+import '../output/svg/svg.js';
+import '../output/svg/fonts/tex/tex.js';
+import '../ui/menu/menu.js';
+import '../startup/startup.js';

--- a/components/src/tex-svg-full/webpack.config.js
+++ b/components/src/tex-svg-full/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'tex-svg-full',                     // the package to build
+    '../../../mathjax3',                // location of the mathjax3 library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);


### PR DESCRIPTION
This adds two new components, `tex-chtml-full` and `tex-svg-full` that include the `tex-full` components (i.e., contain all the extensions).  This makes them about 120K larger than the `tex-chtml` and `tex-svg` versions, which use `\require` or `autoload` to obtain extensions that aren't included.

I didn't include full versions of `tex-mml-chtml` or `tex-mml-svg`.  Should I?