### PR TITLE
Add an AsciiMath component (using legacy v2 code)

### DIFF
--- a/components/src/input/asciimath/asciimath.js
+++ b/components/src/input/asciimath/asciimath.js
@@ -1,0 +1,8 @@
+import './lib/asciimath.js';
+
+import {AsciiMath} from '../../../../mathjax3/input/asciimath.js';
+
+if (MathJax.startup) {
+    MathJax.startup.registerConstructor('asciimath', AsciiMath);
+    MathJax.startup.useInput('asciimath');
+}

--- a/components/src/input/asciimath/asciimath.js
+++ b/components/src/input/asciimath/asciimath.js
@@ -3,6 +3,7 @@ import './lib/asciimath.js';
 import {AsciiMath} from '../../../../mathjax3/input/asciimath.js';
 
 if (MathJax.startup) {
+    MathJax.Hub.Config({AsciiMath: MathJax.config.asciimath || {}});
     MathJax.startup.registerConstructor('asciimath', AsciiMath);
     MathJax.startup.useInput('asciimath');
 }

--- a/components/src/input/asciimath/build.json
+++ b/components/src/input/asciimath/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "inpu/asciimath",
+    "targets": ["input/asciimath.ts", "input/asciimath"]
+}
+

--- a/components/src/input/asciimath/webpack.config.js
+++ b/components/src/input/asciimath/webpack.config.js
@@ -1,0 +1,8 @@
+const PACKAGE = require('../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'input/asciimath',                  // the package to build
+    '../../../../mathjax3',             // location of the mathjax3 library
+    ['components/src/core/lib'],        // packages to link to
+    __dirname                           // our directory
+);

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -31,6 +31,7 @@ exports.source = {
     '[tex]/unicode': `${src}/input/tex/extensions/unicode/unicode.js`,
     '[tex]/verb': `${src}/input/tex/extensions/verb/verb.js`,
     'input/mml': `${src}/input/mml/mml.js`,
+    'input/asciimath': `${src}/input/asciimath/asciimath.js`,
     'output/chtml': `${src}/output/chtml/chtml.js`,
     'output/chtml/fonts/tex': `${src}/output/chtml/fonts/tex/tex.js`,
     'output/svg': `${src}/output/svg/svg.js`,

--- a/mathjax2/input/AsciiMath.js
+++ b/mathjax2/input/AsciiMath.js
@@ -1,4 +1,4 @@
-MathJax = require("../legacy/MathJax.js").MathJax;
+MathJax = Object.assign(global.MathJax || {}, require("../legacy/MathJax.js").MathJax);
 
 MathJax.Ajax.Preloading(
   "[MathJax]/jax/input/AsciiMath/config.js",

--- a/mathjax2/legacy/MathJax.js
+++ b/mathjax2/legacy/MathJax.js
@@ -773,7 +773,11 @@ exports.MathJax = MathJax;
 	//  when loading the initial localization file (before loading messsage is available)
 	//
 	this.loading[file].message = BASE.Message.File(name);
-        System.import(file).catch(timeout);
+        if (window.System) {
+          window.System.import(file).catch(timeout);
+        } else {
+          timeout();  // indicate a load failure
+        }
       },
       //
       //  Create a LINK tag to load the style sheet

--- a/samples/asciimath2mml.js
+++ b/samples/asciimath2mml.js
@@ -1,0 +1,23 @@
+import {mathjax} from '../mathjax3/mathjax.js';
+
+import {AsciiMath} from '../mathjax3/input/asciimath.js';
+import {RegisterHTMLHandler} from '../mathjax3/handlers/html.js';
+import {chooseAdaptor} from '../mathjax3/adaptors/chooseAdaptor.js';
+import {STATE} from '../mathjax3/core/MathItem.js';
+
+RegisterHTMLHandler(chooseAdaptor());
+
+let html = mathjax.document('<html></html>', {
+  InputJax: new AsciiMath()
+});
+
+import {SerializedMmlVisitor as MmlVisitor} from '../mathjax3/core/MmlTree/SerializedMmlVisitor.js';
+let visitor = new MmlVisitor();
+let toMml = (node => visitor.visitTree(node, html.document));
+
+mathjax.handleRetriesFor(() => {
+
+    let math = html.convert(process.argv[3] || '', {end: STATE.CONVERT});
+    console.log(toMml(math));
+
+}).catch(err => console.log(err.stack));


### PR DESCRIPTION
This PR creates an `input/asciimath` component (using the legacy v2 AsciiMath input jax).  It adjusts the legacy code in a couple of places to allow it to webpack properly.  The component is fairly large, since it includes a lot of Mathjax v2 in it, so I'm not making any combined input-output components that use it.  Authors will have to load the AsciiMath component by hand if they want to use it.

I did some (minimal) performance testing, and using a test file with 22 expressions, mathjax-node-page takes 1.4 seconds, while version 3 with this component is about .45 seconds, so I think that even with the v2 glue, it is still faster over all.