### PR TITLE
A11y explorer refactor

### DIFF
--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,9 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {EffectHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
+import {Explorer} from './explorer/Explorer.js';
+import {AbstractKeyExplorer, Magnifier, SpeechExplorer} from './explorer/KeyExplorer.js';
+import {FlameHoverer} from './explorer/MouseExplorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -119,7 +121,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
                 SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
                 Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
-                EffectHoverer.create(document, null, node)
+                FlameHoverer.create(document, null, node)
             );
             this.state(STATE.EXPLORER);
         }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -116,9 +116,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.savedId = null;
             }
             this.addExplorers(
-                // SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
+                SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
                 SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
-                // Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
+                Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
                 EffectHoverer.create(document, null, node)
             );
             this.state(STATE.EXPLORER);

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -127,8 +127,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                                 (node: HTMLElement) => node.getAttribute('data-semantic-role')),
                 ValueHoverer.create(document, document.explorerObjects.tooltip3, node,
                                     (x: HTMLElement) => !!x.tagName, (x: HTMLElement) => x.tagName),
-                EffectHoverer.create(document, null, node,
-                                     (node: HTMLElement) => node.tagName === 'MJX-MACTION')
+                EffectHoverer.create(document, null, node)
             );
             this.state(STATE.EXPLORER);
         }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {AbstractKeyExplorer, TypeExplorer, RoleExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
+import {ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -119,8 +119,14 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
                 SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
                 Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
-                TypeExplorer.create(document, document.explorerObjects.tooltip, node),
-                RoleExplorer.create(document, document.explorerObjects.tooltip2, node)
+                ValueHoverer.create(document, document.explorerObjects.tooltip, node,
+                                    (node: HTMLElement) => node.hasAttribute('data-semantic-type'),
+                                    (node: HTMLElement) => node.getAttribute('data-semantic-type')),
+                ValueHoverer.create(document, document.explorerObjects.tooltip2, node,
+                                (node: HTMLElement) => node.hasAttribute('data-semantic-role'),
+                                (node: HTMLElement) => node.getAttribute('data-semantic-role')),
+                ValueHoverer.create(document, document.explorerObjects.tooltip3, node,
+                                    (x: HTMLElement) => !!x.tagName, (x: HTMLElement) => x.tagName)
             );
             this.state(STATE.EXPLORER);
         }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {ContentHoverer, EffectHoverer, ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
+import {EffectHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -116,9 +116,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.savedId = null;
             }
             this.addExplorers(
-                SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
+                // SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
                 SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
-                Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
+                // Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
                 EffectHoverer.create(document, null, node)
             );
             this.state(STATE.EXPLORER);

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
+import {EffectHoverer, ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -126,7 +126,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                                 (node: HTMLElement) => node.hasAttribute('data-semantic-role'),
                                 (node: HTMLElement) => node.getAttribute('data-semantic-role')),
                 ValueHoverer.create(document, document.explorerObjects.tooltip3, node,
-                                    (x: HTMLElement) => !!x.tagName, (x: HTMLElement) => x.tagName)
+                                    (x: HTMLElement) => !!x.tagName, (x: HTMLElement) => x.tagName),
+                EffectHoverer.create(document, null, node,
+                                     (node: HTMLElement) => node.tagName === 'MJX-MACTION')
             );
             this.state(STATE.EXPLORER);
         }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -31,7 +31,7 @@ import {OptionList, expandable} from '../util/Options.js';
 import {BitField} from '../util/BitField.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 
-import {EffectHoverer, ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
+import {ContentHoverer, EffectHoverer, ValueHoverer, AbstractKeyExplorer, Magnifier, Explorer, SpeechExplorer} from './explorer/Explorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -119,14 +119,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 SpeechExplorer.create(document, document.explorerObjects.region, node, mml),
                 SpeechExplorer.create(document, document.explorerObjects.region2, node, mml),
                 Magnifier.create(document, document.explorerObjects.magnifier, node, mml),
-                ValueHoverer.create(document, document.explorerObjects.tooltip, node,
-                                    (node: HTMLElement) => node.hasAttribute('data-semantic-type'),
-                                    (node: HTMLElement) => node.getAttribute('data-semantic-type')),
-                ValueHoverer.create(document, document.explorerObjects.tooltip2, node,
-                                (node: HTMLElement) => node.hasAttribute('data-semantic-role'),
-                                (node: HTMLElement) => node.getAttribute('data-semantic-role')),
-                ValueHoverer.create(document, document.explorerObjects.tooltip3, node,
-                                    (x: HTMLElement) => !!x.tagName, (x: HTMLElement) => x.tagName),
                 EffectHoverer.create(document, null, node)
             );
             this.state(STATE.EXPLORER);
@@ -157,15 +149,12 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
         public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
             this.savedId = this.typesetRoot.getAttribute('sre-explorer-id');
             this.refocus = (window.document.activeElement === this.typesetRoot);
-            let savedExplorers = [];
             for (let explorer of this.explorers) {
                 if (explorer.active) {
                     this.restart = true;
                     explorer.Stop();
-                    savedExplorers.push(explorer);
                 }
             }
-            this.explorers = savedExplorers;
             super.rerender(document, start);
         }
 

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -133,7 +133,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
         private addExplorers(...explorers: Explorer[]) {
             this.explorers = explorers;
             if (explorers.length <= 1) return;
-            let lastKeyExplorer: AbstractKeyExplorer = null;
+            let lastKeyExplorer = null;
             for (let explorer of this.explorers) {
                 if (!(explorer instanceof AbstractKeyExplorer)) continue;
                 if (lastKeyExplorer) {

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -23,7 +23,7 @@
  */
 
 
-import {A11yDocument, DummyRegion, HoverRegion, Region, ToolTip} from './Region.js';
+import {A11yDocument, Region} from './Region.js';
 import {sreReady} from '../sre.js';
 
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -96,7 +96,7 @@ export interface Explorer {
  * @constructor
  * @implements {Explorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export class AbstractExplorer<T> implements Explorer {
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -124,12 +124,6 @@ export class AbstractExplorer<T> implements Explorer {
   private _active: boolean = false;
 
   /**
-   * The original tabindex value before explorer was attached.
-   * @type {boolean}
-   */
-  private oldIndex: number = null;
-
-  /**
    * Stops event bubbling.
    * @param {Event} event The event that is stopped.
    */
@@ -205,9 +199,6 @@ export class AbstractExplorer<T> implements Explorer {
    * @override
    */
   public Attach() {
-    this.oldIndex = this.node.tabIndex;
-    this.node.tabIndex = 1;
-    this.node.setAttribute('role', 'application');
     this.AddEvents();
   }
 
@@ -215,9 +206,6 @@ export class AbstractExplorer<T> implements Explorer {
    * @override
    */
   public Detach() {
-    this.node.tabIndex = this.oldIndex;
-    this.oldIndex = null;
-    this.node.removeAttribute('role');
     this.RemoveEvents();
   }
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -536,6 +536,12 @@ export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> imple
 export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
 
   /**
+   * Remember the last position to avoid flickering.
+   * @type {[number, number]}
+   */
+  protected coord: [number, number];
+
+  /**
    * @constructor
    * @extends {AbstractMouseExplorer<T>}
    *
@@ -568,6 +574,10 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
   public MouseUp(event: MouseEvent) {};
 
   public MouseOut(event: MouseEvent) {
+    if (event.clientX === this.coord[0] &&
+        event.clientY === this.coord[1]) {
+      return;
+    }
     this.highlighter.unhighlight();
     this.region.Hide();
     super.MouseOut(event);
@@ -576,14 +586,16 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
   public MouseOver(event: MouseEvent) {
     super.MouseOver(event);
     let target = event.target as HTMLElement;
+    this.coord = [event.clientX, event.clientY];
     let [node, kind] = this.getNode(target);
     if (!node) {
       return;
     }
+    this.posted === kind;
     this.highlighter.unhighlight();
     this.highlighter.highlight([node]);
-    this.region.Show(node, this.highlighter);
     this.region.Update(kind);
+    this.region.Show(node, this.highlighter);
   }
 
   public getNode(node: HTMLElement): [HTMLElement, T] {
@@ -610,6 +622,8 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
 
 
 export class ValueHoverer extends Hoverer<string> { }
+
+export class ContentHoverer extends Hoverer<HTMLElement> { }
 
 export class EffectHoverer extends Hoverer<void> {
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -445,11 +445,23 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
         this.node, new sre.DummySpeechGenerator(), this.highlighter, this.mml);
   }
 
+  /**
+   * @override
+   */
+  public Update(force: boolean = false) {
+    console.log('highlighting here');
+    if (!this.active && !force) return;
+    this.highlighter.unhighlight();
+    this.highlighter.highlight(this.walker.getFocus().getNodes());
+  }
+
+
 
   public Start() {
     super.Start();
     this.region.Show(this.node, this.highlighter);
     this.walker.activate();
+    this.Update();
     this.showFocus();
   }
 
@@ -461,6 +473,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
   public Move(key: number) {
     let result = this.walker.move(key);
     if (result) {
+      this.Update();
       this.showFocus();
     }
   }
@@ -483,6 +496,16 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
     }
   }
 
+  /**
+   * @override
+   */
+  public Stop() {
+    if (this.active) {
+      this.highlighter.unhighlight();
+      this.walker.deactivate();
+    }
+    super.Stop();
+  }
 }
 
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -228,7 +228,7 @@ export class AbstractExplorer<T> implements Explorer {
                       alpha: opts.backgroundOpacity};
     return sre.HighlighterFactory.highlighter(
       background, foreground,
-      {renderer: this.document.outputJax.name});
+      {renderer: this.document.outputJax.name, browser: 'v3'});
   }
 
   /**
@@ -599,7 +599,9 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
       if (this.nodeQuery(node)) {
         return [node, this.nodeAccess(node)];
       }
-      node = node.childNodes[0] as HTMLElement;
+      let child = node.childNodes[0] as HTMLElement;
+      node = (child && child.tagName === 'defs') ? // This is for SVG.
+        node.childNodes[1] as HTMLElement : child;
     }
     return [null, null];
   }
@@ -617,9 +619,10 @@ export class EffectHoverer extends Hoverer<void> {
   protected constructor(
     public document: A11yDocument,
     ignore: any,
-    protected node: HTMLElement,
-    protected nodeQuery: (node: HTMLElement) => boolean) {
-    super(document, new DummyRegion(document), node, nodeQuery, x => {});
+    protected node: HTMLElement) {
+    super(document, new DummyRegion(document), node,
+          x => this.highlighter.isMactionNode(x),
+          x => {});
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -358,7 +358,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> implements KeyEx
   public Update(force: boolean = false) {
     if (!this.active && !force) return;
     this.highlighter.unhighlight();
-    this.highlighter.highlight(this.walker.getFocus().getNodes());
+    this.highlighter.highlight(this.walker.getFocus(true).getNodes());
     this.region.Update(this.walker.speech());
   }
 
@@ -449,7 +449,6 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
    * @override
    */
   public Update(force: boolean = false) {
-    console.log('highlighting here');
     if (!this.active && !force) return;
     this.highlighter.unhighlight();
     this.highlighter.highlight(this.walker.getFocus().getNodes());

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -593,7 +593,6 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
     if (!node) {
       return;
     }
-    this.posted === kind;
     this.highlighter.unhighlight();
     this.highlighter.highlight([node]);
     this.region.Update(kind);

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -112,7 +112,7 @@ export class AbstractExplorer<T> implements Explorer {
 
   /**
    * Creator pattern for explorers.
-   * @param {A11yDocument} document The current document. 
+   * @param {A11yDocument} document The current document.
    * @param {Region<T>} region A region to display results.
    * @param {HTMLElement} node The node on which the explorer works.
    * @param {any[]} ...rest Remaining information.
@@ -535,15 +535,32 @@ export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> imple
 
 export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
 
-  protected nodeQuery: (node: HTMLElement) => boolean;
-  protected nodeAccess: (node: HTMLElement) => T;
-
+  /**
+   * @constructor
+   * @extends {AbstractMouseExplorer<T>}
+   *
+   * @param {A11yDocument} document The current document.
+   * @param {Region<T>} region A region to display results.
+   * @param {HTMLElement} node The node on which the explorer works.
+   * @param {(node: HTMLElement) => boolean} nodeQuery Predicate on nodes that
+   *    will fire the hoverer.
+   * @param {(node: HTMLElement) => T} nodeAccess Accessor to extract node value
+   *    that is passed to the region.
+   *
+   * @template T
+   */
+  protected constructor(public document: A11yDocument,
+              protected region: Region<T>,
+              protected node: HTMLElement,
+              protected nodeQuery: (node: HTMLElement) => boolean,
+              protected nodeAccess: (node: HTMLElement) => T) {
+    super(document, region, node);
+  }
 
   /**
    * @override
    */
   public MouseDown(event: MouseEvent) {};
-
 
   /**
    * @override
@@ -590,33 +607,18 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
 }
 
 
-export class TypeExplorer extends Hoverer<string> {
+export class ValueHoverer extends Hoverer<string> { }
 
-  protected nodeQuery = (node: HTMLElement) => {
-    return node.hasAttribute('data-semantic-type');
-  };
-  protected nodeAccess = (node: HTMLElement) => {
-    return node.getAttribute('data-semantic-type');
-  };
+export class EffectHoverer extends Hoverer<void> {
 
-}
-
-
-export class RoleExplorer extends Hoverer<string> {
-
-  protected nodeQuery = (node: HTMLElement) => {
-    return node.hasAttribute('data-semantic-role');
-  };
-  protected nodeAccess = (node: HTMLElement) => {
-    return node.getAttribute('data-semantic-role');
-  };
-
-}
-
-
-export class TagExplorer extends Hoverer<string> {
-
-  protected nodeQuery = (node: HTMLElement) => {return !!node.tagName; };
-  protected nodeAccess = (node: HTMLElement) => {return node.tagName; };
+  /**
+   * @override
+   */
+  protected constructor(
+    public document: A11yDocument,
+    protected node: HTMLElement,
+    protected nodeQuery: (node: HTMLElement) => boolean) {
+    super(document, null, node, nodeQuery, x => {});
+  }
 
 }

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -1,4 +1,4 @@
-import {A11yDocument, HoverRegion, Region, ToolTip} from './Region.js';
+import {A11yDocument, DummyRegion, HoverRegion, Region, ToolTip} from './Region.js';
 import {sreReady} from '../sre.js';
 
 
@@ -616,9 +616,10 @@ export class EffectHoverer extends Hoverer<void> {
    */
   protected constructor(
     public document: A11yDocument,
+    ignore: any,
     protected node: HTMLElement,
     protected nodeQuery: (node: HTMLElement) => boolean) {
-    super(document, null, node, nodeQuery, x => {});
+    super(document, new DummyRegion(document), node, nodeQuery, x => {});
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -1,0 +1,323 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2009-2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Explorers based on keyboard events.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+
+import {A11yDocument, Region} from './Region.js';
+import {Explorer, AbstractExplorer} from './Explorer.js';
+import {sreReady} from '../sre.js';
+
+
+/**
+ * Interface for keyboard explorers. Adds the necessary keyboard events.
+ * @interface
+ * @extends {Explorer}
+ */
+export interface KeyExplorer extends Explorer {
+
+  /**
+   * Function to be executed on key down.
+   * @param {KeyboardEvent} event The keyboard event.
+   */
+  KeyDown(event: KeyboardEvent): void;
+
+  /**
+   * Function to be executed on focus in.
+   * @param {KeyboardEvent} event The keyboard event.
+   */
+  FocusIn(event: FocusEvent): void;
+
+  /**
+   * Function to be executed on focus out.
+   * @param {KeyboardEvent} event The keyboard event.
+   */
+  FocusOut(event: FocusEvent): void;
+
+}
+
+
+/**
+ * @constructor
+ * @extends {AbstractExplorer}
+ *
+ * @template T  The type of the Region for this explorer.
+ */
+export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> implements KeyExplorer {
+
+  /**
+   * The attached SRE walker.
+   * @type {sre.Walker}
+   */
+  protected walker: sre.Walker;
+
+  /**
+   * @override
+   */
+  protected events: [string, (x: Event) => void][] =
+    super.Events().concat(
+      [['keydown', this.KeyDown.bind(this)],
+       ['focusin', this.FocusIn.bind(this)],
+       ['focusout', this.FocusOut.bind(this)]]);
+
+  /**
+   * @override
+   */
+  public abstract KeyDown(event: KeyboardEvent): void;
+
+  /**
+   * @override
+   */
+  public FocusIn(event: FocusEvent) {
+  }
+
+  /**
+   * @override
+   */
+  public FocusOut(event: FocusEvent) {
+    this.Stop();
+  }
+
+  /**
+   * @override
+   */
+  public Update(force: boolean = false) {
+    if (!this.active && !force) return;
+    this.highlighter.unhighlight();
+    this.highlighter.highlight(this.walker.getFocus(true).getNodes());
+  }
+
+  /**
+   * @override
+   */
+  public Stop() {
+    if (this.active) {
+      this.highlighter.unhighlight();
+      this.walker.deactivate();
+    }
+    super.Stop();
+  }
+
+}
+
+
+/**
+ * Explorer that pushes speech to live region.
+ * @constructor
+ * @extends {AbstractKeyExplorer}
+ */
+export class SpeechExplorer extends AbstractKeyExplorer<string> {
+
+  /**
+   * The SRE speech generator associated with the walker.
+   * @type {sre.SpeechGenerator}
+   */
+  protected speechGenerator: sre.SpeechGenerator;
+
+  /**
+   * Flag in case the start method is triggered before the walker is fully
+   * initialised. I.e., we have to wait for SRE. Then region is re-shown if
+   * necessary, as otherwise it leads to incorrect stacking.
+   * @type {boolean}
+   */
+  private restarted: boolean = false;
+
+  /**
+   * @constructor
+   * @extends {AbstractKeyExplorer}
+   */
+  constructor(public document: A11yDocument,
+              protected region: Region<string>,
+              protected node: HTMLElement,
+              private mml: HTMLElement) {
+    super(document, region, node);
+    this.initWalker();
+  }
+
+
+  /**
+   * @override
+   */
+  public Start() {
+    super.Start();
+    this.speechGenerator = new sre.DirectSpeechGenerator();
+    this.walker = new sre.TableWalker(
+      this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.walker.activate();
+    this.Update();
+    if (this.document.options.a11y.subtitles) {
+      this.region.Show(this.node, this.highlighter);
+    }
+    this.restarted = true;
+  }
+
+
+  /**
+   * @override
+   */
+  public Update(force: boolean = false) {
+    super.Update(force);
+    this.region.Update(this.walker.speech());
+  }
+
+
+  /**
+   * Computes the speech for the current expression once SRE is ready.
+   * @param {sre.Walker} walker The sre walker.
+   */
+  public Speech(walker: sre.Walker) {
+    sreReady.then(() => {
+      let speech = walker.speech();
+      this.node.setAttribute('hasspeech', 'true');
+      this.Update();
+      if (this.restarted && this.document.options.a11y.subtitles) {
+        this.region.Show(this.node, this.highlighter);
+      }
+    }).catch((error: Error) => console.log(error.message));
+  }
+
+
+  /**
+   * @override
+   */
+  public KeyDown(event: KeyboardEvent) {
+    const code = event.keyCode;
+    if (code === 27) {
+      this.Stop();
+      this.stopEvent(event);
+      return;
+    }
+    if (this.active) {
+      this.Move(code);
+      this.stopEvent(event);
+      return;
+    }
+    if (code === 32 && event.shiftKey) {
+      this.Start();
+      this.stopEvent(event);
+    }
+  }
+
+
+  /**
+   * @override
+   */
+  public Move(key: number) {
+    this.walker.move(key);
+    this.Update();
+  }
+
+  /**
+   * Initialises the SRE walker.
+   */
+  private initWalker() {
+    this.speechGenerator = new sre.TreeSpeechGenerator();
+    let dummy = new sre.DummyWalker(
+      this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.Speech(dummy);
+  }
+
+}
+
+
+/**
+ * Explorer that magnifies what is currently explored. Uses a hover region.
+ * @constructor
+ * @extends {AbstractKeyExplorer}
+ */
+export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
+
+  /**
+   * @constructor
+   * @extends {AbstractKeyExplorer}
+   */
+  constructor(public document: A11yDocument,
+              protected region: Region<HTMLElement>,
+              protected node: HTMLElement,
+              private mml: HTMLElement) {
+    super(document, region, node);
+    this.walker = new sre.TableWalker(
+        this.node, new sre.DummySpeechGenerator(), this.highlighter, this.mml);
+  }
+
+  /**
+   * @override
+   */
+  public Update(force: boolean = false) {
+    super.Update(force);
+    this.showFocus();
+  }
+
+
+  /**
+   * @override
+   */
+  public Start() {
+    super.Start();
+    this.region.Show(this.node, this.highlighter);
+    this.walker.activate();
+    this.Update();
+  }
+
+
+  /**
+   * Shows the nodes that are currently focused.
+   */
+  private showFocus() {
+    let node = this.walker.getFocus().getNodes()[0] as HTMLElement;
+    this.region.Show(node, this.highlighter);
+  }
+
+
+  /**
+   * @override
+   */
+  public Move(key: number) {
+    let result = this.walker.move(key);
+    if (result) {
+      this.Update();
+    }
+  }
+
+
+  /**
+   * @override
+   */
+  public KeyDown(event: KeyboardEvent) {
+    const code = event.keyCode;
+    if (code === 27) {
+      this.Stop();
+      this.stopEvent(event);
+      return;
+    }
+    if (this.active && code !== 13) {
+      this.Move(code);
+      this.stopEvent(event);
+      return;
+    }
+    if (code === 32 && event.shiftKey) {
+      this.Start();
+      this.stopEvent(event);
+    }
+  }
+
+}

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -80,6 +80,12 @@ export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> impleme
        ['focusout', this.FocusOut.bind(this)]]);
 
   /**
+   * The original tabindex value before explorer was attached.
+   * @type {boolean}
+   */
+  private oldIndex: number = null;
+
+  /**
    * @override
    */
   public abstract KeyDown(event: KeyboardEvent): void;
@@ -104,6 +110,26 @@ export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> impleme
     if (!this.active && !force) return;
     this.highlighter.unhighlight();
     this.highlighter.highlight(this.walker.getFocus(true).getNodes());
+  }
+
+  /**
+   * @override
+   */
+  public Attach() {
+    super.Attach();
+    this.oldIndex = this.node.tabIndex;
+    this.node.tabIndex = 1;
+    this.node.setAttribute('role', 'application');
+  }
+
+  /**
+   * @override
+   */
+  public Detach() {
+    this.node.tabIndex = this.oldIndex;
+    this.oldIndex = null;
+    this.node.removeAttribute('role');
+    super.Detach();
   }
 
   /**

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -160,7 +160,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
   public Start() {
     super.Start();
     this.speechGenerator = new sre.DirectSpeechGenerator();
-    this.walker = new sre.TableWalker(
+    this.walker = sre.WalkerFactory.walker('table',
       this.node, this.speechGenerator, this.highlighter, this.mml);
     this.walker.activate();
     this.Update();
@@ -231,7 +231,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    */
   private initWalker() {
     this.speechGenerator = new sre.TreeSpeechGenerator();
-    let dummy = new sre.DummyWalker(
+    let dummy = sre.WalkerFactory.walker('dummy',
       this.node, this.speechGenerator, this.highlighter, this.mml);
     this.Speech(dummy);
   }
@@ -255,7 +255,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
               protected node: HTMLElement,
               private mml: HTMLElement) {
     super(document, region, node);
-    this.walker = new sre.TableWalker(
+    this.walker = sre.WalkerFactory.walker('table',
         this.node, new sre.DummySpeechGenerator(), this.highlighter, this.mml);
   }
 

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -60,7 +60,7 @@ export interface KeyExplorer extends Explorer {
  * @constructor
  * @extends {AbstractExplorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> implements KeyExplorer {
 

--- a/mathjax3-ts/a11y/explorer/MouseExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/MouseExplorer.ts
@@ -54,7 +54,7 @@ export interface MouseExplorer extends Explorer {
  * @constructor
  * @extends {AbstractExplorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> implements MouseExplorer {
 

--- a/mathjax3-ts/a11y/explorer/MouseExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/MouseExplorer.ts
@@ -1,0 +1,224 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2009-2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Explorers based on mouse events.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+
+import {A11yDocument, DummyRegion, Region} from './Region.js';
+import {Explorer, AbstractExplorer} from './Explorer.js';
+import {sreReady} from '../sre.js';
+
+
+/**
+ * Interface for mouse explorers. Adds the necessary mouse events.
+ * @interface
+ * @extends {Explorer}
+ */
+export interface MouseExplorer extends Explorer {
+
+  /**
+   * Function to be executed on mouse over.
+   * @param {MouseEvent} event The mouse event.
+   */
+  MouseOver(event: MouseEvent): void;
+
+  /**
+   * Function to be executed on mouse out.
+   * @param {MouseEvent} event The mouse event.
+   */
+  MouseOut(event: MouseEvent): void;
+
+}
+
+
+/**
+ * @constructor
+ * @extends {AbstractExplorer}
+ *
+ * @template T  The type of the Region for this explorer.
+ */
+export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> implements MouseExplorer {
+
+  /**
+   * @override
+   */
+  protected events: [string, (x: Event) => void][] =
+    super.Events().concat([
+      ['mouseover', this.MouseOver.bind(this)],
+      ['mouseout', this.MouseOut.bind(this)]
+    ]);
+
+  /**
+   * @override
+   */
+  public MouseOver(event: MouseEvent) {
+    this.Start();
+  }
+
+
+  /**
+   * @override
+   */
+  public MouseOut(event: MouseEvent) {
+    this.Stop();
+  }
+
+}
+
+
+/**
+ * Exploration via hovering.
+ * @constructor
+ * @extends {AbstractMouseExplorer}
+ */
+export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
+
+  /**
+   * Remember the last position to avoid flickering.
+   * @type {[number, number]}
+   */
+  protected coord: [number, number];
+
+  /**
+   * @constructor
+   * @extends {AbstractMouseExplorer<T>}
+   *
+   * @param {A11yDocument} document The current document.
+   * @param {Region<T>} region A region to display results.
+   * @param {HTMLElement} node The node on which the explorer works.
+   * @param {(node: HTMLElement) => boolean} nodeQuery Predicate on nodes that
+   *    will fire the hoverer.
+   * @param {(node: HTMLElement) => T} nodeAccess Accessor to extract node value
+   *    that is passed to the region.
+   *
+   * @template T
+   */
+  protected constructor(public document: A11yDocument,
+              protected region: Region<T>,
+              protected node: HTMLElement,
+              protected nodeQuery: (node: HTMLElement) => boolean,
+              protected nodeAccess: (node: HTMLElement) => T) {
+    super(document, region, node);
+  }
+
+
+  /**
+   * @override
+   */
+  public MouseOut(event: MouseEvent) {
+    if (event.clientX === this.coord[0] &&
+        event.clientY === this.coord[1]) {
+      return;
+    }
+    this.highlighter.unhighlight();
+    this.region.Hide();
+    super.MouseOut(event);
+  }
+
+
+  /**
+   * @override
+   */
+  public MouseOver(event: MouseEvent) {
+    super.MouseOver(event);
+    let target = event.target as HTMLElement;
+    this.coord = [event.clientX, event.clientY];
+    let [node, kind] = this.getNode(target);
+    if (!node) {
+      return;
+    }
+    this.highlighter.unhighlight();
+    this.highlighter.highlight([node]);
+    this.region.Update(kind);
+    this.region.Show(node, this.highlighter);
+  }
+
+
+  /**
+   * Retrieves the closest node on which the node query fires. Thereby closest
+   * is defined as:
+   * 1. The node or its ancestor on which the query is true.
+   * 2. In case 1 does not exist the left-most child on which query is true.
+   * 3. Otherwise fails.
+   *
+   * @param {HTMLElement} node The node on which the mouse event fired.
+   * @return {[HTMLElement, T]} Node and output pair if successful.
+   */
+  public getNode(node: HTMLElement): [HTMLElement, T] {
+    let original = node;
+    while (node && node !== this.node) {
+      if (this.nodeQuery(node)) {
+        return [node, this.nodeAccess(node)];
+      }
+      node = node.parentNode as HTMLElement;
+    }
+    node = original;
+    while (node) {
+      if (this.nodeQuery(node)) {
+        return [node, this.nodeAccess(node)];
+      }
+      let child = node.childNodes[0] as HTMLElement;
+      node = (child && child.tagName === 'defs') ? // This is for SVG.
+        node.childNodes[1] as HTMLElement : child;
+    }
+    return [null, null];
+  }
+
+}
+
+
+/**
+ * Hoverer that displays information on nodes (e.g., as tooltips).
+ * @constructor
+ * @extends {Hoverer}
+ */
+export class ValueHoverer extends Hoverer<string> { }
+
+
+/**
+ * Hoverer that displays node content (e.g., for magnification).
+ * @constructor
+ * @extends {Hoverer}
+ */
+export class ContentHoverer extends Hoverer<HTMLElement> { }
+
+
+/**
+ * Highlights maction nodes on hovering.
+ * @constructor
+ * @extends {Hoverer}
+ */
+export class FlameHoverer extends Hoverer<void> {
+
+  /**
+   * @override
+   */
+  protected constructor(
+    public document: A11yDocument,
+    ignore: any,
+    protected node: HTMLElement) {
+    super(document, new DummyRegion(document), node,
+          x => this.highlighter.isMactionNode(x),
+          x => {});
+  }
+
+}

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -448,6 +448,16 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    */
   public Update(node: HTMLElement) {
     this.Clear();
+    let mjx = this.cloneNode(node);
+    this.inner.appendChild(mjx);
+  }
+
+  /**
+   * Clones the node to put into the hover region.
+   * @param {HTMLElement} node The original node.
+   * @return {HTMLElement} The cloned node.
+   */
+  private cloneNode(node: HTMLElement): HTMLElement {
     let mjx = node.cloneNode(true) as HTMLElement;
     if (mjx.nodeName !== 'MJX-CONTAINER') {
       // remove element spacing (could be done in CSS)
@@ -480,7 +490,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
       //  remove displayed math margins (could be done in CSS)
       mjx.style.margin = '0';
     }
-    this.inner.appendChild(mjx);
+    return mjx;
   }
 
 }

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -229,7 +229,7 @@ export class DummyRegion extends AbstractRegion<void> {
 
   public Show() {}
 
-  public AddClasses() {}
+  public AddElement() {}
 
   public AddStyles() {}
 

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2009-2018 The MathJax Consortium
+ *  Copyright (c) 2009-2019 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -219,6 +219,25 @@ export abstract class AbstractRegion<T> implements Region<T> {
 
 }
 
+export class DummyRegion extends AbstractRegion<void> {
+
+  public Clear() {}
+
+  public Update() {}
+
+  public Hide() {}
+
+  public Show() {}
+
+  public AddClasses() {}
+
+  public AddStyles() {}
+
+  public position() {}
+
+  public highlight(highlighter: sre.Highlighter) {}
+}
+
 
 export class StringRegion extends AbstractRegion<string> {
 

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -38,26 +38,15 @@ declare namespace sre {
     getFocus(update?: boolean): Focus;
   }
 
-  class AbstractWalker implements Walker {
-    constructor(node: Node, generator: SpeechGenerator, highlighter: Highlighter, mml: Node);
-    activate(): void;
-    deactivate(): void;
-    speech(): string;
-    move(key: number): void;
-    getFocus(): Focus;
-  }
+}
 
-  class DummyWalker extends AbstractWalker { }
+declare namespace sre.WalkerFactory {
+  export function walker(kind: string,
+                         node: Node,
+                         generator: SpeechGenerator,
+                         highlighter: Highlighter,
+                         mml: Node): Walker;
   
-  class TableWalker extends AbstractWalker { }
-  
-  // class AbstractHighlighter implements Highlighter {
-  //   highlight(nodes: Node[]): void;
-  //   unhighlight(): void;
-  // }
-
-  // class 
-
 }
 
 declare namespace sre.Engine {
@@ -66,13 +55,9 @@ declare namespace sre.Engine {
 
 declare namespace sre.HighlighterFactory {
 
-  export function highlighter(fore: sre.colorType,
-                              back: sre.colorType,
+  export function highlighter(fore: colorType,
+                              back: colorType,
                               info: {renderer: string, browser?: string}
                              ): Highlighter;
 
 }
-
-// export interface SpeechGenerator {
-//   speech(): string;
-// }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -35,7 +35,7 @@ declare namespace sre {
     deactivate(): void;
     speech(): string;
     move(key: number): void;
-    getFocus(): Focus;
+    getFocus(update?: boolean): Focus;
   }
 
   class AbstractWalker implements Walker {

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -23,6 +23,7 @@ declare namespace sre {
     highlight(nodes: Node[]): void;
     unhighlight(): void;
     colorString(): colorString;
+    isMactionNode(node: Node): boolean;
   }
 
   interface Focus {
@@ -69,7 +70,7 @@ declare namespace sre.HighlighterFactory {
                               back: sre.colorType,
                               info: {renderer: string, browser?: string}
                              ): Highlighter;
-  
+
 }
 
 // export interface SpeechGenerator {


### PR DESCRIPTION
Major refactoring of `Explorer` and `Region` module:
* Introduces type template for regions of explorers.
* Separates mouse and keyboard explorers into their own files.
* Introduces a number of explorers (including the old hover highlighter).
* Cleans up use of `sre` methods and the type file.
* Adds all missing comments. 
* SVG/CHTML works well together without extra cases with the exception of the magnification. 

Missing bits are now listed in Issue #303 