### PR TITLE
Fix problem with SVG serialization in WebKit.  #306.

### DIFF
--- a/mathjax3-ts/output/svg/Wrapper.ts
+++ b/mathjax3-ts/output/svg/Wrapper.ts
@@ -316,7 +316,7 @@ CommonWrapper<
     protected useNode(variant: string, C: string, path: string) {
         const use = this.svg('use');
         const id = '#' + this.jax.fontCache.cachePath(variant, C, path);
-        this.adaptor.setAttribute(use, 'href', id, XLINKNS);
+        this.adaptor.setAttribute(use, 'xlink:href', id, XLINKNS);
         return use;
     }
 


### PR DESCRIPTION
Make `xlink:href` attribute work properly in WebKit serialization.

Resolves issue #306