### PR TITLE
A11y tree explorer

### DIFF
--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -233,26 +233,26 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
                 explorable: [STATE.EXPLORER]
             }),
             a11y: {
-                speech: true,
-                subtitles: true,
-                braille: true,
-                viewbraille: false,
-                foregroundColor: 'Black',
-                foregroundOpacity: 1,
+                align: 'top',
                 backgroundColor: 'Blue',
                 backgroundOpacity: .2,
-                align: 'top',
-                magnify: 500,
-                magnification: 'None',
-                keymagnifier: false,
-                mousemagnifier: false,
-                highlight: 'None',
+                braille: true,
                 flame: true,
+                foregroundColor: 'Black',
+                foregroundOpacity: 1,
+                highlight: 'None',
                 hover: false,
+                infoPrefix: false,
+                infoRole: false,
+                infoType: false,
+                keymagnifier: false,
+                magnification: 'None',
+                magnify: 500,
+                mousemagnifier: false,
+                speech: true,
+                subtitles: true,
                 treecoloring: true,
-                typetip: false,
-                roletip: false,
-                prefixtip: false
+                viewbraille: false
           }
         };
 
@@ -389,15 +389,15 @@ let allExplorers: {[options: string]: ExplorerInit} = {
                                  (x: HTMLElement) => x),
     hover: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.FlameHoverer.create(doc, null, node),
-    typetip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+    infoType: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip1, node,
                                (x: HTMLElement) => x.hasAttribute('data-semantic-type'),
                                (x: HTMLElement) => x.getAttribute('data-semantic-type')),
-    roletip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+    infoRole: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip2, node,
                                (x: HTMLElement) => x.hasAttribute('data-semantic-role'),
                                (x: HTMLElement) => x.getAttribute('data-semantic-role')),
-    prefixtip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+    infoPrefix: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip3, node,
                                (x: HTMLElement) => x.hasAttribute('data-semantic-prefix'),
                                (x: HTMLElement) => x.getAttribute('data-semantic-prefix')),

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -34,6 +34,7 @@ import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 import {Explorer} from './explorer/Explorer.js';
 import * as ke from './explorer/KeyExplorer.js';
 import * as me from './explorer/MouseExplorer.js';
+import {FlameColorer} from './explorer/TreeExplorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -224,8 +225,9 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
                 keymagnifier: false,
                 mousemagnifier: false,
                 highlight: 'None',
-                flame: false,
+                flame: true,
                 hover: false,
+                treecoloring: true,
                 typetip: false,
                 roletip: false,
                 prefixtip: false
@@ -334,11 +336,13 @@ function initExplorerRegions(document: ExplorerMathDocument) {
 // Each explorer has a name, an option and a region associated.
 
 
+type ExplorerInit = (doc: ExplorerMathDocument,
+                     node: HTMLElement, ...rest: any[]) => Explorer;
+
 /**
  *  Generation methods for all MathJax explorers available via option settings.
  */
-let allExplorers: {[options: string]: (doc: ExplorerMathDocument,
-                                       node: HTMLElement, ...rest: any[]) => Explorer} = {
+let allExplorers: {[options: string]: ExplorerInit} = {
     speech: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) => {
         let explorer = ke.SpeechExplorer.create(
             doc, doc.explorerRegions.speechRegion, node, ...rest) as ke.SpeechExplorer;
@@ -361,7 +365,6 @@ let allExplorers: {[options: string]: (doc: ExplorerMathDocument,
         me.ContentHoverer.create(doc, doc.explorerRegions.magnifier, node,
                                  (x: HTMLElement) => x.hasAttribute('data-semantic-type'),
                                  (x: HTMLElement) => x),
-    // Missing: FlameHighlighter, TreeHighlighter
     hover: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.FlameHoverer.create(doc, null, node),
     typetip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
@@ -370,12 +373,17 @@ let allExplorers: {[options: string]: (doc: ExplorerMathDocument,
                                (x: HTMLElement) => x.getAttribute('data-semantic-type')),
     roletip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip2, node,
-                                          (x: HTMLElement) => x.hasAttribute('data-semantic-role'),
-                                          (x: HTMLElement) => x.getAttribute('data-semantic-role')),
+                               (x: HTMLElement) => x.hasAttribute('data-semantic-role'),
+                               (x: HTMLElement) => x.getAttribute('data-semantic-role')),
     prefixtip: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip3, node,
-                                          (x: HTMLElement) => x.hasAttribute('data-semantic-prefix'),
-                                          (x: HTMLElement) => x.getAttribute('data-semantic-prefix'))
+                               (x: HTMLElement) => x.hasAttribute('data-semantic-prefix'),
+                               (x: HTMLElement) => x.getAttribute('data-semantic-prefix')),
+    // Missing: FlameHighlighter, TreeHighlighter
+    flame: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+        FlameColorer.create(doc, null, node)
+    // treecoloring: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+    //     TreeColorer.create(doc, null, node, ...rest)
 };
 
 

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -487,7 +487,9 @@ export function setA11yOption(document: HTMLDOCUMENT, option: string, value: str
             break;
         }
         break;
-        // TODO: magnify, similar to zscale.
+    case 'magnify':
+        document.options.a11y.magnify = parseFloat(value as string);
+        break;
     default:
         document.options.a11y[option] = value;
     }

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -313,3 +313,80 @@ export function ExplorerHandler(handler: HANDLER, MmlJax: MATHML = null) {
     handler.documentClass = ExplorerMathDocumentMixin(handler.documentClass as any);
     return handler;
 }
+
+
+/**
+ * Map for names of menu variables to option variables.
+ * @type {Map<string, string>}
+ */
+const menuMap: Map<string, string> = new Map<string, string>([
+  ['explorer', 'explorer'],
+  ['highlight', 'highlight'],
+  ['background', 'backgroundColor'],
+  ['foreground', 'foregroundColor'],
+  ['speech', 'speech'],
+  ['subtitles', 'subtitles'],
+  ['braille', 'braille'],
+  ['viewbraille', 'viewbraille'],
+  ['speechrules', 'speechrules'],
+  ['autocollapse', 'autocollapse'],
+  ['collapsible', 'collapsible'],
+  ['inTabOrder', 'inTabOrder']
+]);
+
+const optionsMap: Map<string, string> = new Map<string, string>(
+  [...menuMap].map(([x, y]) => [y, x]) as [string, string][]
+);
+
+
+/**
+ * Copies options from the explorer option names into menu variable names.
+ * @param {[key: string]: string} src Source structure.
+ * @param {[key: string]: string} dst Destination structure.
+ */
+export function optionSettings(src: {[key: string]: string}, dst: {[key: string]: string}) {
+  copySettings(optionsMap, src, dst);
+};
+
+
+/**
+ * Copies options from the menu variable names into explorer option names.
+ * @param {[key: string]: string} src Source structure.
+ * @param {[key: string]: string} dst Destination structure.
+ */
+export function menuSettings(src: {[key: string]: string}, dst: {[key: string]: string}) {
+  copySettings(menuMap, src, dst);
+};
+
+
+/**
+ * Sets a single a11y option for a menu name.
+ * @param {HTMLDOCUMENT} document The current document.
+ * @param {string} option The option name in the menu.
+ * @param {string|boolean} value The new value.
+ */
+export function setA11yOption(document: HTMLDOCUMENT, option: string, value: string|boolean) {
+  let key = menuMap.get(option);
+  if (key) {
+    document.options.a11y[key] = value;
+  }
+}
+
+
+/**
+ * Copies options from one name set into another.
+ * @param {Map<string, string>} map The name map.
+ * @param {[key: string]: string} src Source structure.
+ * @param {[key: string]: string} dst Destination structure.
+ * @private
+ */
+function copySettings(map: Map<string, string>,
+                      src: {[key: string]: string},
+                      dst: {[key: string]: string}) {
+  for (let key of map.keys()) {
+    let option = src[key];
+    if (src[key] !== undefined) {
+      dst[map.get(key)] = option;
+    }
+  }
+};

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -125,14 +125,16 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
                 this.savedId = null;
             }
             // Init explorers:
-            // Make these part of the explorer.
             this.explorers = initExplorers(document, node, mml);
             this.attachExplorers(document);
-            // Attach explorers, returns the ones that need to be reactivated.
             this.state(STATE.EXPLORER);
         }
 
-
+        /**
+         * Attaches the explorers that are currently meant to be active given
+         * the document options. Detaches all others.
+         * @param {ExplorerMathDocument} document The current document.
+         */
         public attachExplorers(document: ExplorerMathDocument) {
             this.attached = [];
             for (let key of Object.keys(this.explorers)) {
@@ -146,7 +148,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
             }
             this.addExplorers(this.attached);
         }
-
 
         /**
          * @override
@@ -172,7 +173,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
             this.restart && this.attached.forEach(x => x.Start());
             this.refocus = this.restart = false;
         }
-
 
         /**
          * Adds a list of explorers and makes sure the right one stops propagating.
@@ -331,7 +331,7 @@ export function ExplorerHandler(handler: HANDLER, MmlJax: MATHML = null) {
 /*==========================================================================*/
 
 /**
- * The objects needed for the explorer
+ * The regions objects needed for the explorers.
  */
 export type ExplorerRegions = {
     speechRegion?: LiveRegion,
@@ -343,6 +343,10 @@ export type ExplorerRegions = {
 }
 
 
+/**
+ * Initializes the regions needed for a document.
+ * @param {ExplorerMathDocument} document The current document.
+ */
 function initExplorerRegions(document: ExplorerMathDocument) {
     return {
         speechRegion: new LiveRegion(document),
@@ -355,9 +359,11 @@ function initExplorerRegions(document: ExplorerMathDocument) {
 }
 
 
-// Each explorer has a name, an option and a region associated.
 
-
+/**
+ * Type of explorer initialization methods.
+ * @type {(ExplorerMathDocument, HTMLElement, any[]): Explorer}
+*/
 type ExplorerInit = (doc: ExplorerMathDocument,
                      node: HTMLElement, ...rest: any[]) => Explorer;
 
@@ -401,7 +407,6 @@ let allExplorers: {[options: string]: ExplorerInit} = {
         me.ValueHoverer.create(doc, doc.explorerRegions.tooltip3, node,
                                (x: HTMLElement) => x.hasAttribute('data-semantic-prefix'),
                                (x: HTMLElement) => x.getAttribute('data-semantic-prefix')),
-    // Missing: FlameHighlighter, TreeHighlighter
     flame: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
         FlameColorer.create(doc, null, node),
     treecoloring: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
@@ -427,7 +432,11 @@ function initExplorers(document: ExplorerMathDocument, node: HTMLElement, mml: s
 
 /* Context Menu Interactions */
 
-
+/**
+ * Sets a list of a11y options for a given document.
+ * @param {HTMLDOCUMENT} document The current document.
+ * @param {{[key: string]: any}} options Association list for a11y option value pairs.
+ */
 export function setA11yOptions(document: HTMLDOCUMENT, options: {[key: string]: any}) {
     for (let key in options) {
         if (document.options.a11y[key] !== undefined) {

--- a/mathjax3-ts/a11y/explorer.ts
+++ b/mathjax3-ts/a11y/explorer.ts
@@ -34,7 +34,7 @@ import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 import {Explorer} from './explorer/Explorer.js';
 import * as ke from './explorer/KeyExplorer.js';
 import * as me from './explorer/MouseExplorer.js';
-import {FlameColorer} from './explorer/TreeExplorer.js';
+import {TreeColorer, FlameColorer} from './explorer/TreeExplorer.js';
 import {LiveRegion, ToolTip, HoverRegion} from './explorer/Region.js';
 
 /**
@@ -381,9 +381,9 @@ let allExplorers: {[options: string]: ExplorerInit} = {
                                (x: HTMLElement) => x.getAttribute('data-semantic-prefix')),
     // Missing: FlameHighlighter, TreeHighlighter
     flame: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
-        FlameColorer.create(doc, null, node)
-    // treecoloring: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
-    //     TreeColorer.create(doc, null, node, ...rest)
+        FlameColorer.create(doc, null, node),
+    treecoloring: (doc: ExplorerMathDocument, node: HTMLElement, ...rest: any[]) =>
+        TreeColorer.create(doc, null, node, ...rest)
 };
 
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -96,7 +96,7 @@ export interface Explorer {
  * @constructor
  * @implements {Explorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export class AbstractExplorer<T> implements Explorer {
 

--- a/mathjax3-ts/a11y/explorer/Explorer.ts
+++ b/mathjax3-ts/a11y/explorer/Explorer.ts
@@ -155,7 +155,6 @@ export class AbstractExplorer<T> implements Explorer {
                 region: Region<T>,
                 node: HTMLElement, ...rest: any[]): Explorer {
     let explorer = new this(document, region, node, ...rest);
-    explorer.Attach();
     return explorer;
   }
 

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -188,7 +188,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
   public Start() {
     super.Start();
     let options = this.speechGenerator.getOptions();
-    this.speechGenerator = new sre.DirectSpeechGenerator();
+    this.speechGenerator = sre.SpeechGeneratorFactory.generator('Direct');
     this.speechGenerator.setOptions(options);
     this.walker = sre.WalkerFactory.walker('table',
       this.node, this.speechGenerator, this.highlighter, this.mml);
@@ -260,9 +260,10 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    * Initialises the SRE walker.
    */
   private initWalker() {
-    this.speechGenerator = new sre.TreeSpeechGenerator();
-    let dummy = sre.WalkerFactory.walker('dummy',
-      this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.speechGenerator = sre.SpeechGeneratorFactory.generator('Tree');
+    let dummy = sre.WalkerFactory.walker(
+      'dummy', this.node, this.speechGenerator, this.highlighter, this.mml);
+    this.walker = dummy;
     this.Speech(dummy);
   }
 
@@ -285,8 +286,9 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
               protected node: HTMLElement,
               private mml: HTMLElement) {
     super(document, region, node);
-    this.walker = sre.WalkerFactory.walker('table',
-        this.node, new sre.DummySpeechGenerator(), this.highlighter, this.mml);
+    this.walker = sre.WalkerFactory.walker(
+      'table', this.node, sre.SpeechGeneratorFactory.generator('Dummy'),
+      this.highlighter, this.mml);
   }
 
   /**

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -131,7 +131,9 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    * The SRE speech generator associated with the walker.
    * @type {sre.SpeechGenerator}
    */
-  protected speechGenerator: sre.SpeechGenerator;
+  public speechGenerator: sre.SpeechGenerator;
+
+  public showRegion: string = 'subtitles';
 
   /**
    * Flag in case the start method is triggered before the walker is fully
@@ -159,12 +161,14 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    */
   public Start() {
     super.Start();
+    let options = this.speechGenerator.getOptions();
     this.speechGenerator = new sre.DirectSpeechGenerator();
+    this.speechGenerator.setOptions(options);
     this.walker = sre.WalkerFactory.walker('table',
       this.node, this.speechGenerator, this.highlighter, this.mml);
     this.walker.activate();
     this.Update();
-    if (this.document.options.a11y.subtitles) {
+    if (this.document.options.a11y[this.showRegion]) {
       this.region.Show(this.node, this.highlighter);
     }
     this.restarted = true;
@@ -189,7 +193,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
       let speech = walker.speech();
       this.node.setAttribute('hasspeech', 'true');
       this.Update();
-      if (this.restarted && this.document.options.a11y.subtitles) {
+      if (this.restarted && this.document.options.a11y[this.showRegion]) {
         this.region.Show(this.node, this.highlighter);
       }
     }).catch((error: Error) => console.log(error.message));

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -241,7 +241,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
       this.stopEvent(event);
       return;
     }
-    if (code === 32 && event.shiftKey) {
+    if (code === 32 && event.shiftKey || code === 13) {
       this.Start();
       this.stopEvent(event);
     }
@@ -346,7 +346,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
       this.stopEvent(event);
       return;
     }
-    if (code === 32 && event.shiftKey) {
+    if (code === 32 && event.shiftKey || code === 13) {
       this.Start();
       this.stopEvent(event);
     }

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -60,7 +60,7 @@ export interface KeyExplorer extends Explorer {
  * @constructor
  * @extends {AbstractExplorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> implements KeyExplorer {
 

--- a/mathjax3-ts/a11y/explorer/MouseExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/MouseExplorer.ts
@@ -54,7 +54,7 @@ export interface MouseExplorer extends Explorer {
  * @constructor
  * @extends {AbstractExplorer}
  *
- * @template T  The type of the Region for this explorer.
+ * @template T  The type that is consumed by the Region of this explorer.
  */
 export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> implements MouseExplorer {
 

--- a/mathjax3-ts/a11y/explorer/Region.ts
+++ b/mathjax3-ts/a11y/explorer/Region.ts
@@ -376,7 +376,6 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    */
   constructor(public document: A11yDocument) {
     super(document);
-    this.div.style.fontSize = document.options.a11y.magnify + '%';
     this.inner.style.lineHeight = '0';
   }
 
@@ -430,6 +429,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    * @override
    */
   public Show(node: HTMLElement, highlighter: sre.Highlighter) {
+    this.div.style.fontSize = this.document.options.a11y.magnify + '%';
     this.Update(node);
     super.Show(node, highlighter);
   }

--- a/mathjax3-ts/a11y/explorer/TreeExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/TreeExplorer.ts
@@ -30,12 +30,12 @@ import {sreReady} from '../sre.js';
 
 
 export interface TreeExplorer extends Explorer {
-  
+
 }
 
 
 export class AbstractTreeExplorer extends AbstractExplorer<void> {
-  
+
   /**
    * @override
    */
@@ -67,25 +67,31 @@ export class AbstractTreeExplorer extends AbstractExplorer<void> {
     this.Stop();
     super.Detach();
   }
-  
+
 }
 
 
 export class FlameColorer extends AbstractTreeExplorer {
 
+  /**
+   * @override
+   */
   public Start() {
     if (this.active) return;
     this.active = true;
     this.highlighter.highlightAll(this.node);
   }
 
+  /**
+   * @override
+   */
   public Stop() {
     if (this.active) {
       this.highlighter.unhighlightAll(this.node);
     }
     this.active = false;
   }
-  
+
 }
 
 

--- a/mathjax3-ts/a11y/explorer/TreeExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/TreeExplorer.ts
@@ -76,3 +76,27 @@ export class FlameColorer extends AbstractTreeExplorer {
   }
   
 }
+
+
+export class TreeColorer extends AbstractTreeExplorer {
+
+  /**
+   * @override
+   */
+  public Start() {
+    let generator = sre.SpeechGeneratorFactory.generator('Color');
+    if (!this.node.hasAttribute('hasforegroundcolor')) {
+      generator.generateSpeech(this.node, this.mml);
+      this.node.setAttribute('hasforegroundcolor', 'true');
+    }
+    this.highlighter.colorizeAll(this.node);
+  }
+
+  /**
+   * @override
+   */
+  public Stop() {
+    this.highlighter.uncolorizeAll(this.node);
+  }
+
+}

--- a/mathjax3-ts/a11y/explorer/TreeExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/TreeExplorer.ts
@@ -1,0 +1,78 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2009-2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Tree Explorers allow to switch on effects on the entire
+ *     expression tree.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+
+import {A11yDocument, Region} from './Region.js';
+import {Explorer, AbstractExplorer} from './Explorer.js';
+import {sreReady} from '../sre.js';
+
+
+export interface TreeExplorer extends Explorer {
+  
+}
+
+
+export class AbstractTreeExplorer extends AbstractExplorer<void> {
+  
+  /**
+   * @override
+   */
+  protected constructor(public document: A11yDocument,
+              protected region: Region<void>,
+                        protected node: HTMLElement,
+                        protected mml: HTMLElement) {
+    super(document, null, node);
+    this.Start();
+  }
+
+  /**
+   * @override
+   */
+  readonly stoppable = false;
+
+  /**
+   * @override
+   */
+  public AddEvents() { }
+
+  /**
+   * @override
+   */
+  public RemoveEvents() { }
+  
+}
+
+
+export class FlameColorer extends AbstractTreeExplorer {
+
+  public Start() {
+    this.highlighter.highlightAll(this.node);
+  }
+
+  public Stop() {
+    this.highlighter.unhighlightAll(this.node);
+  }
+  
+}

--- a/mathjax3-ts/a11y/explorer/TreeExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/TreeExplorer.ts
@@ -44,7 +44,6 @@ export class AbstractTreeExplorer extends AbstractExplorer<void> {
                         protected node: HTMLElement,
                         protected mml: HTMLElement) {
     super(document, null, node);
-    this.Start();
   }
 
   /**
@@ -52,15 +51,22 @@ export class AbstractTreeExplorer extends AbstractExplorer<void> {
    */
   readonly stoppable = false;
 
-  /**
-   * @override
-   */
-  public AddEvents() { }
 
   /**
    * @override
    */
-  public RemoveEvents() { }
+  public Attach() {
+    super.Attach();
+    this.Start();
+  }
+
+  /**
+   * @override
+   */
+  public Detach() {
+    this.Stop();
+    super.Detach();
+  }
   
 }
 
@@ -68,11 +74,16 @@ export class AbstractTreeExplorer extends AbstractExplorer<void> {
 export class FlameColorer extends AbstractTreeExplorer {
 
   public Start() {
+    if (this.active) return;
+    this.active = true;
     this.highlighter.highlightAll(this.node);
   }
 
   public Stop() {
-    this.highlighter.unhighlightAll(this.node);
+    if (this.active) {
+      this.highlighter.unhighlightAll(this.node);
+    }
+    this.active = false;
   }
   
 }
@@ -84,6 +95,8 @@ export class TreeColorer extends AbstractTreeExplorer {
    * @override
    */
   public Start() {
+    if (this.active) return;
+    this.active = true;
     let generator = sre.SpeechGeneratorFactory.generator('Color');
     if (!this.node.hasAttribute('hasforegroundcolor')) {
       generator.generateSpeech(this.node, this.mml);
@@ -96,7 +109,10 @@ export class TreeColorer extends AbstractTreeExplorer {
    * @override
    */
   public Stop() {
-    this.highlighter.uncolorizeAll(this.node);
+    if (this.active) {
+      this.highlighter.uncolorizeAll(this.node);
+    }
+    this.active = false;
   }
 
 }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -1,27 +1,14 @@
-
 declare namespace sre {
 
   export type colorType = {color: string, alpha: number};
   export type colorString = {foreground: string, background: string};
 
   interface SpeechGenerator {
+    generateSpeech(node: HTMLElement, xml: HTMLElement): string;
     speech(): string;
     setOptions(options: Object): void;
     getOptions(): Object;
   }
-
-  class AbstractSpeechGenerator implements SpeechGenerator {
-    speech(): string;
-    setOptions(options: Object): void;
-    getOptions(): Object;
-  }
-
-  class TreeSpeechGenerator extends AbstractSpeechGenerator { }
-  
-  class DirectSpeechGenerator extends AbstractSpeechGenerator { }
-  
-  class DummySpeechGenerator extends AbstractSpeechGenerator { }
-
 
   interface Highlighter {
     highlight(nodes: Node[]): void;
@@ -30,12 +17,14 @@ declare namespace sre {
     unhighlightAll(node: Node): void;
     colorString(): colorString;
     isMactionNode(node: Node): boolean;
+    colorizeAll(node: Node): void;
+    uncolorizeAll(node: Node): void;
   }
 
   interface Focus {
     getNodes(): Node[];
   }
-  
+
   interface Walker {
     activate(): void;
     deactivate(): void;
@@ -52,7 +41,10 @@ declare namespace sre.WalkerFactory {
                          generator: SpeechGenerator,
                          highlighter: Highlighter,
                          mml: Node): Walker;
-  
+}
+
+declare namespace sre.SpeechGeneratorFactory {
+  export function generator(kind: string): sre.SpeechGenerator;
 }
 
 declare namespace sre.Engine {

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -26,6 +26,8 @@ declare namespace sre {
   interface Highlighter {
     highlight(nodes: Node[]): void;
     unhighlight(): void;
+    highlightAll(node: Node): void;
+    unhighlightAll(node: Node): void;
     colorString(): colorString;
     isMactionNode(node: Node): boolean;
   }

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -6,10 +6,14 @@ declare namespace sre {
 
   interface SpeechGenerator {
     speech(): string;
+    setOptions(options: Object): void;
+    getOptions(): Object;
   }
 
   class AbstractSpeechGenerator implements SpeechGenerator {
     speech(): string;
+    setOptions(options: Object): void;
+    getOptions(): Object;
   }
 
   class TreeSpeechGenerator extends AbstractSpeechGenerator { }

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -389,7 +389,8 @@ export class Menu {
                     this.variable<boolean>('shift'),
                     this.variable<string> ('scale', (scale: string) => this.setScale(scale)),
                     this.variable<boolean>('explorer', (explore: boolean) => this.setExplorer(explore)),
-                    this.variable<string> ('highlight'),
+                    this.variable<string> ('highlight', (highlight: string) =>
+                                           this.setA11y({'highlight': highlight})),
                     this.variable<string> ('backgroundColor', (background: string) =>
                                            this.setA11y({'backgroundColor': background})),
                     this.variable<string> ('foregroundColor', (foreground: string) =>
@@ -600,9 +601,7 @@ export class Menu {
      * Save any non-default menu settings in localStorage
      */
     protected saveUserSettings() {
-        console.log('Saving user settings');
         const settings = {} as {[key: string]: any};
-        console.log(this.defaultSettings);
         for (const name of Object.keys(this.settings) as (keyof MenuSettings)[]) {
             if (this.settings[name] !== this.defaultSettings[name]) {
                 settings[name] = this.settings[name];

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -66,21 +66,25 @@ export interface MenuSettings {
     ctrl: boolean;
     shift: boolean;
     scale: string;
-    explorer: boolean;
-    highlight: string;
-    backgroundColor: string;
-    foregroundColor: string;
-    speech: boolean;
-    subtitles: boolean;
-    braille: boolean;
-    viewbraille: boolean;
-    speechrules: string;
-    magnify: string;
-    magnification: string;
-    treecoloring: boolean;
     autocollapse: boolean;
     collapsible: boolean;
     inTabOrder: boolean;
+    // A11y settings
+    backgroundColor: string;
+    braille: boolean;
+    explorer: boolean;
+    foregroundColor: string;
+    highlight: string;
+    infoPrefix: boolean;
+    infoRole: boolean;
+    infoType: boolean;
+    magnification: string;
+    magnify: string;
+    speech: boolean;
+    speechrules: string;
+    subtitles: boolean;
+    treecoloring: boolean;
+    viewbraille: boolean;
 }
 
 export type HTMLMATHITEM = MathItem<HTMLElement, Text, Document>;
@@ -113,22 +117,10 @@ export class Menu {
             ctrl: false,
             shift: false,
             scale: 1,
-            // A11y options
-            explorer: false,
-            highlight: 'None',
-            backgroundColor: 'Blue',
-            foregroundColor: 'Black',
-            speech: true,
-            subtitles: false,
-            braille: true,
-            viewbraille: false,
-            speechrules: 'mathspeak-default',
-            magnification: 'None',
-            magnify: false,
-            treecoloring: false,
             autocollapse: false,
             collapsible: false,
-            inTabOrder: true,
+            inTabOrder: true
+            explorer: false,
         },
         jax: {
             CHTML: null,
@@ -418,6 +410,12 @@ export class Menu {
                                            this.setA11y({'magnify': magnify})),
                     this.variable<boolean>('treecoloring', (treecoloring: boolean) =>
                                            this.setA11y({'treecoloring': treecoloring})),
+                    this.variable<boolean>('infoType', (infoType: boolean) =>
+                                           this.setA11y({'infoType': infoType})),
+                    this.variable<boolean>('infoRole', (infoRole: boolean) =>
+                                           this.setA11y({'infoRole': infoRole})),
+                    this.variable<boolean>('infoPrefix', (infoPrefix: boolean) =>
+                                           this.setA11y({'infoPrefix': infoPrefix})),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),
                     this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab))
@@ -507,9 +505,9 @@ export class Menu {
                             ])
                         ]),
                         this.submenu('Semantic Info', 'Semantic Info', [
-                            // this.checkbox('Type', 'Type', 'type'),
-                            // this.checkbox('Role', 'Role', 'role'),
-                            // this.checkbox('Prefix', 'Prefix', 'prefix'),
+                            this.checkbox('Type', 'Type', 'infoType'),
+                            this.checkbox('Role', 'Role', 'infoRole'),
+                            this.checkbox('Prefix', 'Prefix', 'infoPrefix')
                         ], true),
                         this.rule(),
                         this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
@@ -602,7 +600,9 @@ export class Menu {
      * Save any non-default menu settings in localStorage
      */
     protected saveUserSettings() {
+        console.log('Saving user settings');
         const settings = {} as {[key: string]: any};
+        console.log(this.defaultSettings);
         for (const name of Object.keys(this.settings) as (keyof MenuSettings)[]) {
             if (this.settings[name] !== this.defaultSettings[name]) {
                 settings[name] = this.settings[name];

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -77,7 +77,7 @@ export interface MenuSettings {
     speechrules: string;
     magnify: string;
     magnification: string;
-    treehighlight: boolean;
+    treecoloring: boolean;
     autocollapse: boolean;
     collapsible: boolean;
     inTabOrder: boolean;
@@ -125,7 +125,7 @@ export class Menu {
             speechrules: 'mathspeak-default',
             magnification: 'None',
             magnify: false,
-            treehighlight: false,
+            treecoloring: false,
             autocollapse: false,
             collapsible: false,
             inTabOrder: true,
@@ -416,8 +416,8 @@ export class Menu {
                                            this.setA11y('magnification', magnification)),
                     this.variable<string> ('magnify', (magnify: string) =>
                                            this.setA11y('magnify', magnify)),
-                    this.variable<boolean>('treehighlight', (treehighlight: boolean) =>
-                                           this.setA11y('treehighlight', treehighlight)),
+                    this.variable<boolean>('treecoloring', (treecoloring: boolean) =>
+                                           this.setA11y('treecoloring', treecoloring)),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),
                     this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab))
@@ -497,7 +497,7 @@ export class Menu {
                                     ['None'], ['Hover'], ['Flame']
                                 ]),
                                 this.rule(),
-                                this.checkbox('TreeHihighlighter', 'Tree Highlighting', 'treehighlight')
+                                this.checkbox('TreeColoring', 'Tree Coloring', 'treecoloring')
                             ]),
                             this.submenu('Magnification', 'Magnification', [
                                 this.radioGroup('magnification', [
@@ -631,7 +631,8 @@ export class Menu {
         if (!window.MathJax._.a11y || !window.MathJax._.a11y.explorer) return;
         ['explorer', 'highlight', 'backgroundColor', 'foregroundColor',
          'speech', 'subtitles', 'braille', 'viewbraille', 'speechrules',
-         'magnification'].forEach(x => this.setA11y(x, this.settings[x]));
+         'magnification'].forEach(
+           x => this.setA11y(x, (this.settings as {[key: string]: any})[x]));
     }
 
 

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -399,25 +399,25 @@ export class Menu {
                     this.variable<boolean>('explorer', (explore: boolean) => this.setExplorer(explore)),
                     this.variable<string> ('highlight'),
                     this.variable<string> ('backgroundColor', (background: string) =>
-                                           this.setA11y('backgroundColor', background)),
+                                           this.setA11y({'backgroundColor': background})),
                     this.variable<string> ('foregroundColor', (foreground: string) =>
-                                           this.setA11y('foregroundColor', foreground)),
+                                           this.setA11y({'foregroundColor': foreground})),
                     this.variable<boolean>('speech', (speech: boolean) =>
-                                           this.setA11y('speech', speech)),
+                                           this.setA11y({'speech': speech})),
                     this.variable<boolean>('subtitles', (subtitles: boolean) =>
-                                           this.setA11y('subtitles', subtitles)),
+                                           this.setA11y({'subtitles': subtitles})),
                     this.variable<boolean>('braille', (braille: boolean) =>
-                                           this.setA11y('braille', braille)),
+                                           this.setA11y({'braille': braille})),
                     this.variable<boolean>('viewbraille', (viewbraille: boolean) =>
-                                           this.setA11y('viewbraille', viewbraille)),
+                                           this.setA11y({'viewbraille': viewbraille})),
                     this.variable<string> ('speechrules', (speechrules: string) =>
-                                           this.setA11y('speechrules', speechrules)),
+                                           this.setA11y({'speechrules': speechrules})),
                     this.variable<string> ('magnification', (magnification: string) =>
-                                           this.setA11y('magnification', magnification)),
+                                           this.setA11y({'magnification': magnification})),
                     this.variable<string> ('magnify', (magnify: string) =>
-                                           this.setA11y('magnify', magnify)),
+                                           this.setA11y({'magnify': magnify})),
                     this.variable<boolean>('treecoloring', (treecoloring: boolean) =>
-                                           this.setA11y('treecoloring', treecoloring)),
+                                           this.setA11y({'treecoloring': treecoloring})),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),
                     this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab))
@@ -596,7 +596,7 @@ export class Menu {
             const settings = localStorage.getItem(Menu.MENU_STORAGE);
             if (!settings) return;
             Object.assign(this.settings, JSON.parse(settings));
-            this.mergeA11ySettings();
+            this.setA11y(this.settings);
         } catch (err) {
             console.log('MathJax localStorage error: ' + err.message);
         }
@@ -623,27 +623,13 @@ export class Menu {
         }
     }
 
-
     /**
-     * Merge the menu settings into the a11y document options.
+     * Merge menu settings into the a11y document options.
+     * @param {[key: string]: any} options The options.
      */
-    protected mergeA11ySettings() {
-        if (!window.MathJax._.a11y || !window.MathJax._.a11y.explorer) return;
-        ['explorer', 'highlight', 'backgroundColor', 'foregroundColor',
-         'speech', 'subtitles', 'braille', 'viewbraille', 'speechrules',
-         'magnification'].forEach(
-           x => this.setA11y(x, (this.settings as {[key: string]: any})[x]));
-    }
-
-
-    /**
-     * Sets a single a11y document option.
-     * @param {string} option The option.
-     * @param {string|boolean} value Its new value.
-     */
-    protected setA11y(option: string, value: string|boolean) {
+    protected setA11y(options: {[key: string]: any}) {
         if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
-          window.MathJax._.a11y.explorer_ts.setA11yOption(this.document, option, value);
+          window.MathJax._.a11y.explorer_ts.setA11yOptions(this.document, options);
         }
     }
 

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -68,13 +68,16 @@ export interface MenuSettings {
     scale: string;
     explorer: boolean;
     highlight: string;
-    background: string;
-    foreground: string;
+    backgroundColor: string;
+    foregroundColor: string;
     speech: boolean;
     subtitles: boolean;
     braille: boolean;
     viewbraille: boolean;
     speechrules: string;
+    magnify: string;
+    magnification: string;
+    treehighlight: boolean;
     autocollapse: boolean;
     collapsible: boolean;
     inTabOrder: boolean;
@@ -110,16 +113,19 @@ export class Menu {
             ctrl: false,
             shift: false,
             scale: 1,
-	    // A11y options
+            // A11y options
             explorer: false,
             highlight: 'None',
-            background: 'Blue',
-            foreground: 'Black',
+            backgroundColor: 'Blue',
+            foregroundColor: 'Black',
             speech: true,
             subtitles: false,
             braille: true,
             viewbraille: false,
             speechrules: 'mathspeak-default',
+            magnification: 'None',
+            magnify: false,
+            treehighlight: false,
             autocollapse: false,
             collapsible: false,
             inTabOrder: true,
@@ -366,8 +372,7 @@ export class Menu {
         this.jax[jax.name] = jax;
         this.settings.renderer = jax.name;
         if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
-	    window.MathJax._.a11y.explorer_ts.optionSettings(
-		this.document.options.a11y, this.settings);
+            Object.assign(this.settings, this.document.options.a11y);
         }
         this.settings.scale = jax.options.scale;
         this.defaultSettings = Object.assign({}, this.settings);
@@ -393,10 +398,10 @@ export class Menu {
                     this.variable<string> ('scale', (scale: string) => this.setScale(scale)),
                     this.variable<boolean>('explorer', (explore: boolean) => this.setExplorer(explore)),
                     this.variable<string> ('highlight'),
-                    this.variable<string> ('background', (background: string) =>
-					   this.setA11y('background', background)),
-                    this.variable<string> ('foreground', (foreground: string) =>
-                                           this.setA11y('foreground', foreground)),
+                    this.variable<string> ('backgroundColor', (background: string) =>
+                                           this.setA11y('backgroundColor', background)),
+                    this.variable<string> ('foregroundColor', (foreground: string) =>
+                                           this.setA11y('foregroundColor', foreground)),
                     this.variable<boolean>('speech', (speech: boolean) =>
                                            this.setA11y('speech', speech)),
                     this.variable<boolean>('subtitles', (subtitles: boolean) =>
@@ -405,8 +410,14 @@ export class Menu {
                                            this.setA11y('braille', braille)),
                     this.variable<boolean>('viewbraille', (viewbraille: boolean) =>
                                            this.setA11y('viewbraille', viewbraille)),
-                    this.variable<string> ('speechrules', (speechrules: boolean) =>
+                    this.variable<string> ('speechrules', (speechrules: string) =>
                                            this.setA11y('speechrules', speechrules)),
+                    this.variable<string> ('magnification', (magnification: string) =>
+                                           this.setA11y('magnification', magnification)),
+                    this.variable<string> ('magnify', (magnify: string) =>
+                                           this.setA11y('magnify', magnify)),
+                    this.variable<boolean>('treehighlight', (treehighlight: boolean) =>
+                                           this.setA11y('treehighlight', treehighlight)),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),
                     this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab))
@@ -454,31 +465,54 @@ export class Menu {
                         this.submenu('Explorer', 'Explorer', [
                             this.checkbox('Active', 'Active', 'explorer'),
                             this.rule(),
-                            this.submenu('Highlight', 'Highlight', this.radioGroup('highlight', [
-                                ['None'], ['Hover'], ['Flame']
-                            ]), true),
-                            this.submenu('Background', 'Background', this.radioGroup('background', [
-                                ['Blue'], ['Red'], ['Green'], ['Yellow'], ['Cyan'], ['Magenta'], ['White'], ['Black']
-                            ])),
-                            this.submenu('Foreground', 'Foreground', this.radioGroup('foreground', [
-                                ['Black'], ['White'], ['Magenta'], ['Cyan'], ['Yellow'], ['Green'], ['Red'], ['Blue']
-                            ])),
-                            this.rule(),
-                            this.checkbox('Speech', 'Speech Output', 'speech'),
-                            this.checkbox('Subtitles', 'Subtities', 'subtitles'),
-                            this.checkbox('Braille', 'Braille', 'braille'),
-                            this.checkbox('View Braille', 'View Braille', 'viewbraille'),
-                            this.rule(),
-                            this.submenu('Mathspeak', 'Mathspeak Rules', this.radioGroup('speechrules', [
-                                ['mathspeak-default', 'Verbose'],
-                                ['mathspeak-brief', 'Brief'],
-                                ['mathspeak-sbrief', 'Superbrief']
-                            ])),
-                            this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechrules', [
-                                ['chromvox-default', 'Verbose'],
-                                ['chromevox-short', 'Short'],
-                                ['chromevox-alternative', 'Alternative']
-                            ]))
+                            this.submenu('Speech', 'Speech', [
+                                this.checkbox('Speech', 'Speech Output', 'speech'),
+                                this.checkbox('Subtitles', 'Subtities', 'subtitles'),
+                                this.checkbox('Braille', 'Braille', 'braille'),
+                                this.checkbox('View Braille', 'View Braille', 'viewbraille'),
+                                this.rule(),
+                                this.submenu('Mathspeak', 'Mathspeak Rules', this.radioGroup('speechrules', [
+                                    ['mathspeak-default', 'Verbose'],
+                                    ['mathspeak-brief', 'Brief'],
+                                    ['mathspeak-sbrief', 'Superbrief']
+                                ])),
+                                this.submenu('Clearspeak', 'Clearspeak Rules', this.radioGroup('speechrules', [
+                                    ['clearspeak-default', 'Standard']
+                                ])),
+                                this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechrules', [
+                                    ['chromvox-default', 'Verbose'],
+                                    ['chromevox-short', 'Short'],
+                                    ['chromevox-alternative', 'Alternative']
+                                ]))
+                            ]),
+                            this.submenu('Highlight', 'Highlight', [
+                                this.submenu('Background', 'Background', this.radioGroup('backgroundColor', [
+                                    ['Blue'], ['Red'], ['Green'], ['Yellow'], ['Cyan'], ['Magenta'], ['White'], ['Black']
+                                ])),
+                                this.submenu('Foreground', 'Foreground', this.radioGroup('foregroundColor', [
+                                    ['Black'], ['White'], ['Magenta'], ['Cyan'], ['Yellow'], ['Green'], ['Red'], ['Blue']
+                                ])),
+                                this.rule(),
+                                this.radioGroup('highlight', [
+                                    ['None'], ['Hover'], ['Flame']
+                                ]),
+                                this.rule(),
+                                this.checkbox('TreeHihighlighter', 'Tree Highlighting', 'treehighlight')
+                            ]),
+                            this.submenu('Magnification', 'Magnification', [
+                                this.radioGroup('magnification', [
+                                    ['None'], ['Keyboard'], ['Mouse']
+                                ]),
+                                this.rule(),
+                                this.radioGroup('magnify', [
+                                    ['200%'], ['300%'], ['400%'], ['500%']
+                                ])
+                            ]),
+                            this.submenu('Semantic Info', 'Semantic Info', [
+                                // this.checkbox('Type', 'Type', 'type'),
+                                // this.checkbox('Role', 'Role', 'role'),
+                                // this.checkbox('Prefix', 'Prefix', 'prefix'),
+                            ], true),
                         ]),
                         this.rule(),
                         this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
@@ -562,10 +596,7 @@ export class Menu {
             const settings = localStorage.getItem(Menu.MENU_STORAGE);
             if (!settings) return;
             Object.assign(this.settings, JSON.parse(settings));
-            if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
-		window.MathJax._.a11y.explorer_ts.menuSettings(
-		    this.settings, this.document.options.a11y);
-            }
+            this.mergeA11ySettings();
         } catch (err) {
             console.log('MathJax localStorage error: ' + err.message);
         }
@@ -589,6 +620,29 @@ export class Menu {
             }
         } catch (err) {
             console.log('MathJax localStorage error: ' + err.message);
+        }
+    }
+
+
+    /**
+     * Merge the menu settings into the a11y document options.
+     */
+    protected mergeA11ySettings() {
+        if (!window.MathJax._.a11y || !window.MathJax._.a11y.explorer) return;
+        ['explorer', 'highlight', 'backgroundColor', 'foregroundColor',
+         'speech', 'subtitles', 'braille', 'viewbraille', 'speechrules',
+         'magnification'].forEach(x => this.setA11y(x, this.settings[x]));
+    }
+
+
+    /**
+     * Sets a single a11y document option.
+     * @param {string} option The option.
+     * @param {string|boolean} value Its new value.
+     */
+    protected setA11y(option: string, value: string|boolean) {
+        if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
+            window.MathJax._.a11y.explorer_ts.setA11yOption(this.document, option, value);
         }
     }
 
@@ -781,10 +835,6 @@ export class Menu {
         });
     }
 
-    protected setA11y(option: string, value: string|boolean) {
-        if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
-	    window.MathJax._.a11y.explorer_ts.setA11yOption(this.document, option, value);
-    }
 
     /**
      * @param {MenuMathDocument} document  The original document whose list is to be transferred
@@ -1001,7 +1051,7 @@ export class Menu {
      *
      * @param {string} variable     The (pool) variable to attach to each radio button
      * @param {string[][]} radios   An array of [string] or [string, string], giving the id and content
-     *                                for each radio button (if only one string is given it is ued for both)
+     *                                for each radio button (if only one string is given it is used for both)
      * @returns {Object[]}          An array of JSON objects for radion buttons
      */
     public radioGroup(variable: string, radios: string[][]) {
@@ -1044,4 +1094,3 @@ export class Menu {
     /*======================================================================*/
 
 }
-

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -643,7 +643,7 @@ export class Menu {
      */
     protected setA11y(option: string, value: string|boolean) {
         if (window.MathJax._.a11y && window.MathJax._.a11y.explorer) {
-            window.MathJax._.a11y.explorer_ts.setA11yOption(this.document, option, value);
+          window.MathJax._.a11y.explorer_ts.setA11yOption(this.document, option, value);
         }
     }
 

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -462,58 +462,55 @@ export class Menu {
                         this.command('Reset', 'Reset to defaults', () => this.resetDefaults())
                     ]),
                     this.submenu('Accessibility', 'Accessibility', [
-                        this.submenu('Explorer', 'Explorer', [
-                            this.checkbox('Active', 'Active', 'explorer'),
+                        this.checkbox('Activate', 'Activate', 'explorer'),
+                        this.submenu('Speech', 'Speech', [
+                            this.checkbox('Speech', 'Speech Output', 'speech'),
+                            this.checkbox('Subtitles', 'Subtities', 'subtitles'),
+                            this.checkbox('Braille', 'Braille', 'braille'),
+                            this.checkbox('View Braille', 'View Braille', 'viewbraille'),
                             this.rule(),
-                            this.submenu('Speech', 'Speech', [
-                                this.checkbox('Speech', 'Speech Output', 'speech'),
-                                this.checkbox('Subtitles', 'Subtities', 'subtitles'),
-                                this.checkbox('Braille', 'Braille', 'braille'),
-                                this.checkbox('View Braille', 'View Braille', 'viewbraille'),
-                                this.rule(),
-                                this.submenu('Mathspeak', 'Mathspeak Rules', this.radioGroup('speechrules', [
-                                    ['mathspeak-default', 'Verbose'],
-                                    ['mathspeak-brief', 'Brief'],
-                                    ['mathspeak-sbrief', 'Superbrief']
-                                ])),
-                                this.submenu('Clearspeak', 'Clearspeak Rules', this.radioGroup('speechrules', [
-                                    ['clearspeak-default', 'Standard']
-                                ])),
-                                this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechrules', [
-                                    ['chromvox-default', 'Verbose'],
-                                    ['chromevox-short', 'Short'],
-                                    ['chromevox-alternative', 'Alternative']
-                                ]))
-                            ]),
-                            this.submenu('Highlight', 'Highlight', [
-                                this.submenu('Background', 'Background', this.radioGroup('backgroundColor', [
-                                    ['Blue'], ['Red'], ['Green'], ['Yellow'], ['Cyan'], ['Magenta'], ['White'], ['Black']
-                                ])),
-                                this.submenu('Foreground', 'Foreground', this.radioGroup('foregroundColor', [
-                                    ['Black'], ['White'], ['Magenta'], ['Cyan'], ['Yellow'], ['Green'], ['Red'], ['Blue']
-                                ])),
-                                this.rule(),
-                                this.radioGroup('highlight', [
-                                    ['None'], ['Hover'], ['Flame']
-                                ]),
-                                this.rule(),
-                                this.checkbox('TreeColoring', 'Tree Coloring', 'treecoloring')
-                            ]),
-                            this.submenu('Magnification', 'Magnification', [
-                                this.radioGroup('magnification', [
-                                    ['None'], ['Keyboard'], ['Mouse']
-                                ]),
-                                this.rule(),
-                                this.radioGroup('magnify', [
-                                    ['200%'], ['300%'], ['400%'], ['500%']
-                                ])
-                            ]),
-                            this.submenu('Semantic Info', 'Semantic Info', [
-                                // this.checkbox('Type', 'Type', 'type'),
-                                // this.checkbox('Role', 'Role', 'role'),
-                                // this.checkbox('Prefix', 'Prefix', 'prefix'),
-                            ], true),
+                            this.submenu('Mathspeak', 'Mathspeak Rules', this.radioGroup('speechrules', [
+                                ['mathspeak-default', 'Verbose'],
+                                ['mathspeak-brief', 'Brief'],
+                                ['mathspeak-sbrief', 'Superbrief']
+                            ])),
+                            this.submenu('Clearspeak', 'Clearspeak Rules', this.radioGroup('speechrules', [
+                                ['clearspeak-default', 'Standard']
+                            ])),
+                            this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechrules', [
+                                ['chromvox-default', 'Verbose'],
+                                ['chromevox-short', 'Short'],
+                                ['chromevox-alternative', 'Alternative']
+                            ]))
                         ]),
+                        this.submenu('Highlight', 'Highlight', [
+                            this.submenu('Background', 'Background', this.radioGroup('backgroundColor', [
+                                ['Blue'], ['Red'], ['Green'], ['Yellow'], ['Cyan'], ['Magenta'], ['White'], ['Black']
+                            ])),
+                            this.submenu('Foreground', 'Foreground', this.radioGroup('foregroundColor', [
+                                ['Black'], ['White'], ['Magenta'], ['Cyan'], ['Yellow'], ['Green'], ['Red'], ['Blue']
+                            ])),
+                            this.rule(),
+                            this.radioGroup('highlight', [
+                                ['None'], ['Hover'], ['Flame']
+                            ]),
+                            this.rule(),
+                            this.checkbox('TreeColoring', 'Tree Coloring', 'treecoloring')
+                        ]),
+                        this.submenu('Magnification', 'Magnification', [
+                            this.radioGroup('magnification', [
+                                ['None'], ['Keyboard'], ['Mouse']
+                            ]),
+                            this.rule(),
+                            this.radioGroup('magnify', [
+                                ['200%'], ['300%'], ['400%'], ['500%']
+                            ])
+                        ]),
+                        this.submenu('Semantic Info', 'Semantic Info', [
+                            // this.checkbox('Type', 'Type', 'type'),
+                            // this.checkbox('Role', 'Role', 'role'),
+                            // this.checkbox('Prefix', 'Prefix', 'prefix'),
+                        ], true),
                         this.rule(),
                         this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
                         this.checkbox('AutoCollapse', 'Auto Collapse', 'autocollapse', {disabled: true}),
@@ -577,11 +574,10 @@ export class Menu {
      * @param {boolean} enable  True to enable, false to disable
      */
     protected enableExplorerItems(enable: boolean) {
-        const menu = (this.menu.findID('Accessibility', 'Explorer') as ContextMenu.Submenu).getSubmenu();
-        for (const item of menu.getItems().slice(3)) {
-            if (!(item instanceof ContextMenu.Rule)) {
-                enable ? item.enable() : item.disable();
-            }
+        const menu = (this.menu.findID('Accessibility', 'Activate') as ContextMenu.Submenu).getMenu();
+        for (const item of menu.getItems().slice(1)) {
+            if (item instanceof ContextMenu.Rule) break;
+            enable ? item.enable() : item.disable();
         }
 
     }


### PR DESCRIPTION
PR takes care of a number of points in issue #303 
* Implements tree explorers: Instances are the Tree-coloring and the old Flamer.
* Integrates all explorers fully with the menu.
* Moves the A11y menu elements to the position we had already discussed.
* A11y options are fully set in the a11y code only.

There are still some restart issues in particular on collapse/expand actions, which will be done with custom events as discussed.