### PR TITLE
Support for typescript 3.5

### DIFF
--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -318,7 +318,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
    * @override
    */
   public Move(key: number) {
-    let result = this.walker.move(key);
+    let result = this.walker.move(key) as any;
     if (result) {
       this.Update();
     }

--- a/mathjax3-ts/a11y/explorer/KeyExplorer.ts
+++ b/mathjax3-ts/a11y/explorer/KeyExplorer.ts
@@ -318,7 +318,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
    * @override
    */
   public Move(key: number) {
-    let result = this.walker.move(key) as any;
+    let result = this.walker.move(key);
     if (result) {
       this.Update();
     }

--- a/mathjax3-ts/a11y/semantic-enrich.ts
+++ b/mathjax3-ts/a11y/semantic-enrich.ts
@@ -120,7 +120,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
             }
             const math = new document.options.MathItem('', MmlJax);
             const enriched = SRE.toEnriched(toMathML(this.root));
-            math.math = ('outerHTML' in enriched ? enriched.outerHTML : enriched.toString());
+            math.math = ('outerHTML' in enriched ? enriched.outerHTML : (enriched as any).toString());
             math.display = this.display;
             math.compile(document);
             this.root = math.root;

--- a/mathjax3-ts/a11y/sre_browser.d.ts
+++ b/mathjax3-ts/a11y/sre_browser.d.ts
@@ -34,7 +34,7 @@ declare namespace sre {
     activate(): void;
     deactivate(): void;
     speech(): string;
-    move(key: number): void;
+    move(key: number): boolean;
     getFocus(update?: boolean): Focus;
   }
 

--- a/mathjax3-ts/adaptors/HTMLAdaptor.ts
+++ b/mathjax3-ts/adaptors/HTMLAdaptor.ts
@@ -39,7 +39,7 @@ export interface MinDocument<N, T> {
     createElement(kind: string): N;
     createElementNS(ns: string, kind: string): N;
     createTextNode(text: string): T;
-    querySelectorAll(selector: string): N[];
+    querySelectorAll(selector: string): ArrayLike<N>;
 }
 
 /*****************************************************************/

--- a/mathjax3-ts/components/package.ts
+++ b/mathjax3-ts/components/package.ts
@@ -48,7 +48,7 @@ export class PackageError extends Error {
 /**
  * Types for ready() and failed() functions and for promises
  */
-export type PackageReady = (name: string) => string;
+export type PackageReady = (name: string) => string | void;
 export type PackageFailed = (message: PackageError) => void;
 export type PackagePromise = (resolve: PackageReady, reject: PackageFailed) => void;
 
@@ -58,7 +58,7 @@ export type PackagePromise = (resolve: PackageReady, reject: PackageFailed) => v
 export interface PackageConfig {
     ready?: PackageReady,                // Function to call when package is loaded successfully
     failed?: PackageFailed,              // Function to call when package fails to load
-    checkReady?: () => Promise<void>;    // Function called to see if package is fully loaded
+    checkReady?: () => Promise<void>     // Function called to see if package is fully loaded
                                          //   (may cause additional packages to load, for example)
 };
 
@@ -244,7 +244,7 @@ export class Package {
         //
         const config = (CONFIG[this.name] || {}) as PackageConfig;
         if (config.ready) {
-            promise = promise.then((name: string) => config.ready(this.name));
+            promise = promise.then((name: string) => config.ready(this.name)) as Promise<string>;
         }
         //
         //  If there are promises for dependencies,
@@ -359,7 +359,7 @@ export class Package {
      */
     protected checkLoad() {
         const config = (CONFIG[this.name] || {}) as PackageConfig;
-        const checkReady = config.checkReady || (() => Promise.resolve());
+        const checkReady = (config.checkReady || (() => Promise.resolve()));
         checkReady().then(() => this.loaded())
                     .catch((message) => this.failed(message));
     }

--- a/mathjax3-ts/components/package.ts
+++ b/mathjax3-ts/components/package.ts
@@ -359,7 +359,7 @@ export class Package {
      */
     protected checkLoad() {
         const config = (CONFIG[this.name] || {}) as PackageConfig;
-        const checkReady = (config.checkReady || (() => Promise.resolve()));
+        const checkReady = config.checkReady || (() => Promise.resolve());
         checkReady().then(() => this.loaded())
                     .catch((message) => this.failed(message));
     }

--- a/mathjax3-ts/output/chtml.ts
+++ b/mathjax3-ts/output/chtml.ts
@@ -22,6 +22,7 @@
  */
 
 import {CommonOutputJax} from './common/OutputJax.js';
+import {CommonWrapper} from './common/Wrapper.js';
 import {StyleList, Styles} from '../util/Styles.js';
 import {StyleList as CssStyleList} from './common/CssStyles.js';
 import {OptionList} from '../util/Options.js';
@@ -118,7 +119,7 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
      * @constructor
      */
     constructor(options: OptionList = null) {
-        super(options, CHTMLWrapperFactory, TeXFont);
+        super(options, CHTMLWrapperFactory as any, TeXFont);
         this.font.adaptiveCSS(this.options.adaptiveCSS);
     }
 
@@ -142,9 +143,9 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
     /**
      * @override
      */
-    protected addClassStyles(CLASS: typeof CHTMLWrapper) {
-        if (!this.options.adaptiveCSS || CLASS.used) {
-            if (CLASS.autoStyle && CLASS.kind !== 'unknown') {
+    protected addClassStyles(CLASS: typeof CommonWrapper) {
+        if (!this.options.adaptiveCSS || (CLASS as typeof CHTMLWrapper).used) {
+            if ((CLASS as typeof CHTMLWrapper).autoStyle && CLASS.kind !== 'unknown') {
                 this.cssStyles.addStyles({
                     ['mjx-' + CLASS.kind]: {
                         display: 'inline-block',

--- a/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TeXAtom.ts
@@ -34,7 +34,7 @@ import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLTeXAtom<N, T, D> extends CommonTeXAtomMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLTeXAtom<N, T, D> extends CommonTeXAtomMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = TeXAtom.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/TextNode.ts
@@ -35,7 +35,7 @@ import {OptionList} from '../../../util/Options.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLTextNode<N, T, D> extends CommonTextNodeMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLTextNode<N, T, D> extends CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = TextNode.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/maction.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/maction.ts
@@ -38,7 +38,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class CHTMLmaction<N, T, D> extends
-CommonMactionMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+CommonMactionMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMaction.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/math.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/math.ts
@@ -36,7 +36,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     public static kind = MmlMath.prototype.kind;
 
     public static styles: StyleList = {

--- a/mathjax3-ts/output/chtml/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/menclose.ts
@@ -51,7 +51,7 @@ const ANGLE = Angle(Notation.ARROWDX, Notation.ARROWY);
  * @template D  The Document class
  */
 export class CHTMLmenclose<N, T, D> extends
-CommonMencloseMixin<CHTMLWrapper<N, T, D>, CHTMLmsqrt<N, T, D>, N, CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+CommonMencloseMixin<CHTMLWrapper<any, any, any>, CHTMLmsqrt<any, any, any>, any, CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMenclose.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfenced.ts
@@ -34,7 +34,7 @@ import {CHTMLinferredMrow} from './mrow.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmfenced<N, T, D> extends CommonMfencedMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmfenced<N, T, D> extends CommonMfencedMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMfenced.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mfrac.ts
@@ -37,7 +37,7 @@ import {DIRECTION} from '../FontData.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMfrac.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mglyph.ts
@@ -34,7 +34,7 @@ import {StyleList, StyleData} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmglyph<N, T, D> extends CommonMglyphMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmglyph<N, T, D> extends CommonMglyphMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMglyph.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mi.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mi.ts
@@ -33,7 +33,7 @@ import {MmlMi} from '../../../core/MmlTree/MmlNodes/mi.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmi<N, T, D> extends CommonMiMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmi<N, T, D> extends CommonMiMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMi.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -37,7 +37,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class CHTMLmmultiscripts<N, T, D> extends
-CommonMmultiscriptsMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsubsup<N, T, D>>>(CHTMLmsubsup) {
+CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any, any, any>>>(CHTMLmsubsup) {
 
     public static kind = MmlMmultiscripts.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mn.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mn.ts
@@ -33,7 +33,7 @@ import {MmlMn} from '../../../core/MmlTree/MmlNodes/mn.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmn<N, T, D> extends CommonMnMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmn<N, T, D> extends CommonMnMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMn.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mo.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mo.ts
@@ -36,7 +36,7 @@ import {DIRECTION, NOSTRETCH} from '../FontData.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMo.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mpadded.ts
@@ -34,7 +34,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmpadded<N, T, D> extends CommonMpaddedMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmpadded<N, T, D> extends CommonMpaddedMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMpadded.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mrow.ts
@@ -34,7 +34,7 @@ import {MmlMrow, MmlInferredMrow} from '../../../core/MmlTree/MmlNodes/mrow.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmrow<N, T, D> extends CommonMrowMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmrow<N, T, D> extends CommonMrowMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMrow.prototype.kind;
 
@@ -72,7 +72,7 @@ export class CHTMLmrow<N, T, D> extends CommonMrowMixin<CHTMLConstructor<N, T, D
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLinferredMrow<N, T, D> extends CommonInferredMrowMixin<Constructor<CHTMLmrow<N, T, D>>>(CHTMLmrow) {
+export class CHTMLinferredMrow<N, T, D> extends CommonInferredMrowMixin<Constructor<CHTMLmrow<any, any, any>>>(CHTMLmrow) {
 
     public static kind = MmlInferredMrow.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/ms.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/ms.ts
@@ -33,7 +33,7 @@ import {MmlMs} from '../../../core/MmlTree/MmlNodes/ms.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLms<N, T, D> extends CommonMsMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLms<N, T, D> extends CommonMsMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMs.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mspace.ts
@@ -33,7 +33,7 @@ import {MmlMspace} from '../../../core/MmlTree/MmlNodes/mspace.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmspace<N, T, D> extends CommonMspaceMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmspace<N, T, D> extends CommonMspaceMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMspace.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msqrt.ts
@@ -36,7 +36,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmsqrt<N, T, D> extends CommonMsqrtMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmsqrt<N, T, D> extends CommonMsqrtMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMsqrt.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/msubsup.ts
@@ -39,7 +39,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class CHTMLmsub<N, T, D> extends
-CommonMsubMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLscriptbase<N, T, D>>>(CHTMLscriptbase)  {
+CommonMsubMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any, any, any>>>(CHTMLscriptbase)  {
 
     public static kind = MmlMsub.prototype.kind;
 
@@ -56,7 +56,7 @@ CommonMsubMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLscriptbase<N, T, D>>>(CH
  * @template D  The Document class
  */
 export class CHTMLmsup<N, T, D> extends
-CommonMsupMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLscriptbase<N, T, D>>>(CHTMLscriptbase)  {
+CommonMsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any, any, any>>>(CHTMLscriptbase)  {
 
     public static kind = MmlMsup.prototype.kind;
 
@@ -73,7 +73,7 @@ CommonMsupMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLscriptbase<N, T, D>>>(CH
  * @template D  The Document class
  */
 export class CHTMLmsubsup<N, T, D> extends
-CommonMsubsupMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLscriptbase<N, T, D>>>(CHTMLscriptbase)  {
+CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any, any, any>>>(CHTMLscriptbase)  {
 
     public static kind = MmlMsubsup.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtable.ts
@@ -42,7 +42,7 @@ import {BBox} from '../BBox.js';
  * @template D  The Document class
  */
 export class CHTMLmtable<N, T, D> extends
-CommonMtableMixin<CHTMLmtd<N, T, D>, CHTMLmtr<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMtable.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtd.ts
@@ -34,7 +34,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmtd<N, T, D> extends CommonMtdMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmtd<N, T, D> extends CommonMtdMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMtd.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtr.ts
@@ -38,7 +38,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmtr<N, T, D> extends CommonMtrMixin<CHTMLmtd<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmtr<N, T, D> extends CommonMtrMixin<CHTMLmtd<any, any, any>, CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMtr.prototype.kind;
 
@@ -85,7 +85,7 @@ export class CHTMLmtr<N, T, D> extends CommonMtrMixin<CHTMLmtd<N, T, D>, CHTMLCo
  * @template D  The Document class
  */
 export class CHTMLmlabeledtr<N, T, D> extends
-CommonMlabeledtrMixin<CHTMLmtd<N, T, D>, Constructor<CHTMLmtr<N, T, D>>>(CHTMLmtr) {
+CommonMlabeledtrMixin<CHTMLmtd<any, any, any>, Constructor<CHTMLmtr<any, any, any>>>(CHTMLmtr) {
 
     public static kind = MmlMlabeledtr.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/munderover.ts
@@ -40,7 +40,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class CHTMLmunder<N, T, D> extends
-CommonMunderMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsub<N, T, D>>>(CHTMLmsub)  {
+CommonMunderMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsub<any, any, any>>>(CHTMLmsub)  {
 
     public static kind = MmlMunder.prototype.kind;
 
@@ -101,7 +101,7 @@ CommonMunderMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsub<N, T, D>>>(CHTMLm
  * @template D  The Document class
  */
 export class CHTMLmover<N, T, D> extends
-CommonMoverMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsup<N, T, D>>>(CHTMLmsup)  {
+CommonMoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsup<any, any, any>>>(CHTMLmsup)  {
 
     public static kind = MmlMover.prototype.kind;
 
@@ -151,7 +151,7 @@ CommonMoverMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsup<N, T, D>>>(CHTMLms
  * @template D  The Document class
  */
 export class CHTMLmunderover<N, T, D> extends
-CommonMunderoverMixin<CHTMLWrapper<N, T, D>, Constructor<CHTMLmsubsup<N, T, D>>>(CHTMLmsubsup)  {
+CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any, any, any>>>(CHTMLmsubsup)  {
 
     public static kind = MmlMunderover.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/scriptbase.ts
@@ -40,7 +40,7 @@ import {StyleData, StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class CHTMLscriptbase<N, T, D> extends
-CommonScriptbaseMixin<CHTMLWrapper<N, T, D>, CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = 'scriptbase';
 

--- a/mathjax3-ts/output/chtml/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/semantics.ts
@@ -36,7 +36,7 @@ import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLsemantics<N, T, D> extends CommonSemanticsMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLsemantics<N, T, D> extends CommonSemanticsMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlSemantics.prototype.kind;
 

--- a/mathjax3-ts/output/common/FontData.ts
+++ b/mathjax3-ts/output/common/FontData.ts
@@ -360,9 +360,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     public static charOptions(font: CharMap<CharOptions>, n: number) {
         const char = font[n];
         if (char.length === 3) {
-            char[3] = {} as CharOptions;
+            (char as any)[3] = {};
         }
-        return char[3] as CharOptions;
+        return char[3];
     }
 
     /**

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -757,7 +757,7 @@ export class CommonWrapper<
      * @return {CharData}        The full CharData object, with CharOptions guaranteed to be defined
      */
     protected getVariantChar(variant: string, n: number) {
-        let char = this.font.getChar(variant, n) || [0, 0, 0, {unknown: true} as CC];
+        const char = this.font.getChar(variant, n) || [0, 0, 0, {unknown: true} as CC];
         if (char.length === 3) {
             (char as any)[3] = {};
         }

--- a/mathjax3-ts/output/common/Wrapper.ts
+++ b/mathjax3-ts/output/common/Wrapper.ts
@@ -115,7 +115,7 @@ export class CommonWrapper<
     /**
      * Styles that should not be passed on from style attribute
      */
-    public static removeStyles: [string] = [
+    public static removeStyles: string[] = [
         'fontSize', 'fontFamily', 'fontWeight',
         'fontStyle', 'fontVariant', 'font'
     ];
@@ -757,9 +757,9 @@ export class CommonWrapper<
      * @return {CharData}        The full CharData object, with CharOptions guaranteed to be defined
      */
     protected getVariantChar(variant: string, n: number) {
-        const char = this.font.getChar(variant, n) || [0, 0, 0, {unknown: true}];
+        let char = this.font.getChar(variant, n) || [0, 0, 0, {unknown: true} as CC];
         if (char.length === 3) {
-            char[3] = {} as CC;
+            (char as any)[3] = {};
         }
         return char as [number, number, number, CC];
     }

--- a/mathjax3-ts/output/common/WrapperFactory.ts
+++ b/mathjax3-ts/output/common/WrapperFactory.ts
@@ -38,7 +38,7 @@ import {MmlNode} from '../../core/MmlTree/MmlNode.js';
  * @template FD The FontData type
  */
 export class CommonWrapperFactory<
-    J extends CommonOutputJax<any, any, any, W, CommonWrapperFactory<J, W, C, CC, DD, FD>, any, any>,
+    J extends CommonOutputJax<any, any, any, W, CommonWrapperFactory<J, W, C, CC, DD, FD>, FD, any>,
     W extends CommonWrapper<J, W, C, CC, DD, FD>,
     C extends CommonWrapperClass<J, W, C, CC, DD, FD>,
     CC extends CharOptions,

--- a/mathjax3-ts/output/svg.ts
+++ b/mathjax3-ts/output/svg.ts
@@ -105,7 +105,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      * @constructor
      */
     constructor(options: OptionList = null) {
-        super(options, SVGWrapperFactory, TeXFont);
+        super(options, SVGWrapperFactory as any, TeXFont);
         this.fontCache = new FontCache(this);
     }
 
@@ -149,13 +149,6 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         const sheet = super.styleSheet(html);
         this.adaptor.setAttribute(sheet, 'id', SVG.STYLESHEETID);
         return sheet;
-    }
-
-    /**
-     * @override
-     */
-    protected addClassStyles(CLASS: typeof SVGWrapper) {
-        super.addClassStyles(CLASS);
     }
 
     /**

--- a/mathjax3-ts/output/svg/Wrappers/TeXAtom.ts
+++ b/mathjax3-ts/output/svg/Wrappers/TeXAtom.ts
@@ -34,7 +34,7 @@ import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGTeXAtom<N, T, D> extends CommonTeXAtomMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGTeXAtom<N, T, D> extends CommonTeXAtomMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = TeXAtom.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/TextNode.ts
+++ b/mathjax3-ts/output/svg/Wrappers/TextNode.ts
@@ -34,7 +34,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGTextNode<N, T, D> extends CommonTextNodeMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGTextNode<N, T, D> extends CommonTextNodeMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = TextNode.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/maction.ts
+++ b/mathjax3-ts/output/svg/Wrappers/maction.ts
@@ -38,7 +38,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template D  The Document class
  */
 export class SVGmaction<N, T, D> extends
-CommonMactionMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
+CommonMactionMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMaction.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/math.ts
+++ b/mathjax3-ts/output/svg/Wrappers/math.ts
@@ -34,7 +34,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMath.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/menclose.ts
+++ b/mathjax3-ts/output/svg/Wrappers/menclose.ts
@@ -38,7 +38,7 @@ import {OptionList} from '../../../util/Options.js';
  * @template D  The Document class
  */
 export class SVGmenclose<N, T, D> extends
-CommonMencloseMixin<SVGWrapper<N, T, D>, SVGmsqrt<N, T, D>, N, SVGConstructor<N, T, D>>(SVGWrapper) {
+CommonMencloseMixin<SVGWrapper<any, any, any>, SVGmsqrt<any, any, any>, any, SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMenclose.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mfenced.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mfenced.ts
@@ -34,7 +34,7 @@ import {SVGinferredMrow} from './mrow.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmfenced<N, T, D> extends CommonMfencedMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmfenced<N, T, D> extends CommonMfencedMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMfenced.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mfrac.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mfrac.ts
@@ -34,7 +34,7 @@ import {SVGmo} from './mo.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMfrac.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mglyph.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mglyph.ts
@@ -34,7 +34,7 @@ import {OptionList} from '../../../util/Options.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmglyph<N, T, D> extends CommonMglyphMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmglyph<N, T, D> extends CommonMglyphMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMglyph.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mi.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mi.ts
@@ -33,7 +33,7 @@ import {MmlMi} from '../../../core/MmlTree/MmlNodes/mi.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmi<N, T, D> extends CommonMiMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmi<N, T, D> extends CommonMiMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMi.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mmultiscripts.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mmultiscripts.ts
@@ -36,7 +36,7 @@ import {BBox} from '../BBox.js';
  * @template D  The Document class
  */
 export class SVGmmultiscripts<N, T, D> extends
-CommonMmultiscriptsMixin<SVGWrapper<N, T, D>, Constructor<SVGmsubsup<N, T, D>>>(SVGmsubsup) {
+CommonMmultiscriptsMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, any, any>>>(SVGmsubsup) {
 
     public static kind = MmlMmultiscripts.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mn.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mn.ts
@@ -33,7 +33,7 @@ import {MmlMn} from '../../../core/MmlTree/MmlNodes/mn.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmn<N, T, D> extends CommonMnMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmn<N, T, D> extends CommonMnMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMn.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mo.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mo.ts
@@ -41,7 +41,7 @@ const HFUZZ = 0.1;       // overlap for horizontal stretchy glyphs
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmo<N, T, D> extends CommonMoMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmo<N, T, D> extends CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMo.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mpadded.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mpadded.ts
@@ -33,7 +33,7 @@ import {MmlMpadded} from '../../../core/MmlTree/MmlNodes/mpadded.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmpadded<N, T, D> extends CommonMpaddedMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmpadded<N, T, D> extends CommonMpaddedMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMpadded.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mroot.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mroot.ts
@@ -35,7 +35,7 @@ import {MmlMroot} from '../../../core/MmlTree/MmlNodes/mroot.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmroot<N, T, D> extends CommonMrootMixin<Constructor<SVGmsqrt<N, T, D>>>(SVGmsqrt) {
+export class SVGmroot<N, T, D> extends CommonMrootMixin<Constructor<SVGmsqrt<any, any, any>>>(SVGmsqrt) {
 
     public static kind = MmlMroot.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mrow.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mrow.ts
@@ -34,7 +34,7 @@ import {MmlMrow, MmlInferredMrow} from '../../../core/MmlTree/MmlNodes/mrow.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmrow<N, T, D> extends CommonMrowMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmrow<N, T, D> extends CommonMrowMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMrow.prototype.kind;
 
@@ -57,7 +57,7 @@ export class SVGmrow<N, T, D> extends CommonMrowMixin<SVGConstructor<N, T, D>>(S
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGinferredMrow<N, T, D> extends CommonInferredMrowMixin<Constructor<SVGmrow<N, T, D>>>(SVGmrow) {
+export class SVGinferredMrow<N, T, D> extends CommonInferredMrowMixin<Constructor<SVGmrow<any, any, any>>>(SVGmrow) {
 
     public static kind = MmlInferredMrow.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/ms.ts
+++ b/mathjax3-ts/output/svg/Wrappers/ms.ts
@@ -33,7 +33,7 @@ import {MmlMs} from '../../../core/MmlTree/MmlNodes/ms.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGms<N, T, D> extends CommonMsMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGms<N, T, D> extends CommonMsMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMs.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mspace.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mspace.ts
@@ -33,7 +33,7 @@ import {MmlMspace} from '../../../core/MmlTree/MmlNodes/mspace.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmspace<N, T, D> extends CommonMspaceMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmspace<N, T, D> extends CommonMspaceMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMspace.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/msqrt.ts
+++ b/mathjax3-ts/output/svg/Wrappers/msqrt.ts
@@ -36,7 +36,7 @@ import {StyleList} from '../../common/CssStyles.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMsqrt.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/msubsup.ts
+++ b/mathjax3-ts/output/svg/Wrappers/msubsup.ts
@@ -38,7 +38,7 @@ import {MmlMsubsup, MmlMsub, MmlMsup} from '../../../core/MmlTree/MmlNodes/msubs
  * @template D  The Document class
  */
 export class SVGmsub<N, T, D> extends
-CommonMsubMixin<SVGWrapper<N, T, D>, Constructor<SVGscriptbase<N, T, D>>>(SVGscriptbase)  {
+CommonMsubMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any, any>>>(SVGscriptbase)  {
 
     public static kind = MmlMsub.prototype.kind;
 
@@ -55,7 +55,7 @@ CommonMsubMixin<SVGWrapper<N, T, D>, Constructor<SVGscriptbase<N, T, D>>>(SVGscr
  * @template D  The Document class
  */
 export class SVGmsup<N, T, D> extends
-CommonMsupMixin<SVGWrapper<N, T, D>, Constructor<SVGscriptbase<N, T, D>>>(SVGscriptbase)  {
+CommonMsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any, any>>>(SVGscriptbase)  {
 
     public static kind = MmlMsup.prototype.kind;
 
@@ -72,7 +72,7 @@ CommonMsupMixin<SVGWrapper<N, T, D>, Constructor<SVGscriptbase<N, T, D>>>(SVGscr
  * @template D  The Document class
  */
 export class SVGmsubsup<N, T, D> extends
-CommonMsubsupMixin<SVGWrapper<N, T, D>, Constructor<SVGscriptbase<N, T, D>>>(SVGscriptbase)  {
+CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any, any>>>(SVGscriptbase)  {
 
     public static kind = MmlMsubsup.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mtable.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtable.ts
@@ -46,7 +46,7 @@ const CLASSPREFIX = 'mjx-';
  * @template D  The Document class
  */
 export class SVGmtable<N, T, D> extends
-CommonMtableMixin<SVGmtd<N, T, D>, SVGmtr<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
+CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMtable.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mtd.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtd.ts
@@ -33,7 +33,7 @@ import {MmlMtd} from '../../../core/MmlTree/MmlNodes/mtd.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmtd<N, T, D> extends CommonMtdMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmtd<N, T, D> extends CommonMtdMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMtd.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/mtr.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtr.ts
@@ -51,7 +51,7 @@ export type SizeData = {
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmtr<N, T, D> extends CommonMtrMixin<SVGmtd<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmtr<N, T, D> extends CommonMtrMixin<SVGmtd<any, any, any>, SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMtr.prototype.kind;
 
@@ -138,7 +138,7 @@ export class SVGmtr<N, T, D> extends CommonMtrMixin<SVGmtd<N, T, D>, SVGConstruc
  * @template D  The Document class
  */
 export class SVGmlabeledtr<N, T, D> extends
-CommonMlabeledtrMixin<SVGmtd<N, T, D>, Constructor<SVGmtr<N, T, D>>>(SVGmtr) {
+CommonMlabeledtrMixin<SVGmtd<any, any, any>, Constructor<SVGmtr<any, any, any>>>(SVGmtr) {
 
     public static kind = MmlMlabeledtr.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/munderover.ts
+++ b/mathjax3-ts/output/svg/Wrappers/munderover.ts
@@ -39,7 +39,7 @@ import {MmlMunderover, MmlMunder, MmlMover} from '../../../core/MmlTree/MmlNodes
  * @template D  The Document class
  */
 export class SVGmunder<N, T, D> extends
-CommonMunderMixin<SVGWrapper<N, T, D>, Constructor<SVGmsub<N, T, D>>>(SVGmsub)  {
+CommonMunderMixin<SVGWrapper<any, any, any>, Constructor<SVGmsub<any, any, any>>>(SVGmsub)  {
 
     public static kind = MmlMunder.prototype.kind;
 
@@ -80,7 +80,7 @@ CommonMunderMixin<SVGWrapper<N, T, D>, Constructor<SVGmsub<N, T, D>>>(SVGmsub)  
  * @template D  The Document class
  */
 export class SVGmover<N, T, D> extends
-CommonMoverMixin<SVGWrapper<N, T, D>, Constructor<SVGmsup<N, T, D>>>(SVGmsup)  {
+CommonMoverMixin<SVGWrapper<any, any, any>, Constructor<SVGmsup<any, any, any>>>(SVGmsup)  {
 
     public static kind = MmlMover.prototype.kind;
 
@@ -120,7 +120,7 @@ CommonMoverMixin<SVGWrapper<N, T, D>, Constructor<SVGmsup<N, T, D>>>(SVGmsup)  {
  * @template D  The Document class
  */
 export class SVGmunderover<N, T, D> extends
-CommonMunderoverMixin<SVGWrapper<N, T, D>, Constructor<SVGmsubsup<N, T, D>>>(SVGmsubsup)  {
+CommonMunderoverMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, any, any>>>(SVGmsubsup)  {
 
     public static kind = MmlMunderover.prototype.kind;
 

--- a/mathjax3-ts/output/svg/Wrappers/scriptbase.ts
+++ b/mathjax3-ts/output/svg/Wrappers/scriptbase.ts
@@ -37,7 +37,7 @@ import {CommonScriptbase, CommonScriptbaseMixin} from '../../common/Wrappers/scr
  * @template D  The Document class
  */
 export class SVGscriptbase<N, T, D> extends
-CommonScriptbaseMixin<SVGWrapper<N, T, D>, SVGConstructor<N, T, D>>(SVGWrapper) {
+CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = 'scriptbase';
 

--- a/mathjax3-ts/output/svg/Wrappers/semantics.ts
+++ b/mathjax3-ts/output/svg/Wrappers/semantics.ts
@@ -36,7 +36,7 @@ import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGsemantics<N, T, D> extends CommonSemanticsMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGsemantics<N, T, D> extends CommonSemanticsMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlSemantics.prototype.kind;
 

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -680,7 +680,7 @@ export class Menu {
                     item.executeCallbacks_();
                 }
             } else {
-                this.settings[name] = settings[name];
+                (this.settings as any)[name] = settings[name];
             }
         }
         Menu.loading--;
@@ -916,7 +916,7 @@ export class Menu {
             name: name,
             getter: () => this.settings[name],
             setter: (value: T) => {
-                this.settings[name] = value;
+                (this.settings as any)[name] = value;
                 action && action(value);
                 this.saveUserSettings();
             }

--- a/mathjax3-ts/util/Options.ts
+++ b/mathjax3-ts/util/Options.ts
@@ -136,7 +136,7 @@ export function copy(def: OptionList): OptionList {
             prop.value = copy(value);
         }
         if (prop.enumerable) {
-            props[key] = prop;
+            props[key as string] = prop;
         }
     }
     return Object.defineProperties({}, props);
@@ -153,13 +153,13 @@ export function copy(def: OptionList): OptionList {
  * @return {OptionList}     The modified destination option list (dst)
  */
 export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
-    for (let key of keys(src)) {
+    for (let key of keys(src) as string[]) {
         //
         // Check if the key is valid (i.e., is in the defaults or in an expandable block)
         //
         if (warn && dst[key] === undefined && !(dst instanceof Expandable)) {
             if (typeof key === 'symbol') {
-                key = key.toString();
+                key = (key as symbol).toString();
             }
             throw new Error('Invalid option "' + key + '" (no default value).');
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4905,10 +4905,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
-      "dev": true
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
     },
     "typescript-tools": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "description": "MathJax version 3 testbed",
   "main": "load.js",
   "devDependencies": {
-    "typescript": "2.3.*",
-    "tape": "^4.8.0",
-    "diff": "^3.5.0",
-    "tslint": "^3.15.0",
-    "tslint-jsdoc-rules": "*",
-    "tslint-unix-formatter": "*",
-    "typescript-tools": "^0.3.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
+    "diff": "^3.5.0",
+    "tape": "^4.8.0",
+    "tslint": "^3.15.0",
+    "tslint-jsdoc-rules": "*",
+    "tslint-unix-formatter": "*",
+    "typescript": "^3.5.2",
+    "typescript-tools": "^0.3.1",
+    "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack": "4.19.0",
-    "webpack-cli": "^3.2.3",
-    "uglifyjs-webpack-plugin": "^2.1.2"
+    "webpack-cli": "^3.2.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR makes adjustments to accommodate `tsc` version 3.5.2 and its stronger checking of some types.  In particular, the mix-in code had to be modified to not use the generics for the subclass as generics for the base class.  For now, this is done by using `any` in place of the generics, but that should be changed after v3 is released to be a more robust approach.