### PR TITLE
Startup document

### DIFF
--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -480,7 +480,7 @@ export namespace Startup {
     /**
      * Create the document with the given input and output jax
      *
-     * @param {any=} root        The Document to use as the root document (or null to use the cofigured document)
+     * @param {any=} root        The Document to use as the root document (or null to use the configured document)
      * @returns {MathDocument}   The MathDocument with the configured input and output jax
      */
     export function getDocument(root: any = null) {

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -280,6 +280,9 @@ export namespace Startup {
         input = getInputJax();
         output = getOutputJax();
         adaptor = getAdaptor();
+        if (handler) {
+            mathjax.handlers.unregister(handler);
+        }
         handler = getHandler();
         if (handler) {
             mathjax.handlers.register(handler);

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -281,6 +281,10 @@ export namespace Startup {
         output = getOutputJax();
         adaptor = getAdaptor();
         handler = getHandler();
+        if (handler) {
+            mathjax.handlers.register(handler);
+            document = getDocument();
+        }
     };
 
     /**
@@ -295,9 +299,6 @@ export namespace Startup {
      *     Make input2output() and input2outputPromise conversion methods and outputStylesheet() method
      */
     export function makeMethods() {
-        if (!handler) return;
-        mathjax.handlers.register(handler);
-        getDocument();
         if (input && output) {
             makeTypesetMethods();
         }
@@ -476,11 +477,15 @@ export namespace Startup {
     /**
      * Create the document with the given input and output jax
      *
+     * @param {any=} root        The Document to use as the root document (or null to use the cofigured document)
      * @returns {MathDocument}   The MathDocument with the configured input and output jax
      */
-    export function getDocument() {
-        document = mathjax.document(CONFIG.document, {...MathJax.config.options, InputJax: input, OutputJax: output});
-        return document;
+    export function getDocument(root: any = null) {
+        return mathjax.document(root || CONFIG.document, {
+            ...MathJax.config.options,
+            InputJax: input,
+            OutputJax: output
+        });
     }
 };
 

--- a/mathjax3-ts/ui/menu/Menu.ts
+++ b/mathjax3-ts/ui/menu/Menu.ts
@@ -751,7 +751,7 @@ export class Menu {
             //   updated document (from the new handler)
             //
             const document = this.document;
-            this.document = startup.getDocument();
+            this.document = startup.document = startup.getDocument();
             this.document.menu = this;
             this.transferMathList(document);
             if (!Menu._loadingPromise) {


### PR DESCRIPTION
This PR makes `getDocument()` return the document (so that it can be used to create additional documents, if needed, e.g., for multiple iframes or web components).  It also moves the creation of the original document into the `getComponents()` function rather than the `makeMethods()` function, since that seems more natural.