### PR TITLE
Refactor startup ready() and pageReady() calls

### DIFF
--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -90,7 +90,6 @@ export interface MathJaxObject extends MJObject {
         elements: any[];
         document: MATHDOCUMENT;
         promise: Promise<void>;
-        pagePromise: Promise<void>;
         registerConstructor(name: string, constructor: any): void;
         useHander(name: string, force?: boolean): void;
         useAdaptor(name: string, force?: boolean): void;
@@ -167,14 +166,11 @@ export namespace Startup {
     export let document: MATHDOCUMENT = null;
 
     /**
-     * The promise for the default typesetting, if one is performed
+     * The promise for the startup process (the initial typesetting).
+     * Initially, it is resolved when the page is loaded and ready to be processed,
+     *   but it is replaced by the pageReady() action in the ready() function.
      */
-    export let promise: Promise<void> = null;
-
-    /**
-     * A promise that is resolved when the page is loaded and ready to be processed
-     */
-    export let pagePromise: Promise<void> = new Promise<void>((resolve, reject) => {
+    export let promise: Promise<void> = new Promise<void>((resolve, reject) => {
         const doc = global.document;
         if (!doc || !doc.readyState || doc.readyState === 'complete' || doc.readyState === 'interactive') {
             resolve();
@@ -251,24 +247,30 @@ export namespace Startup {
     };
 
     /**
-     * The default ready() function called when all the packages have been loaded
-     *   (setting MathJax.startup.ready in the configuration will override this,
-     *    but you can call MathJax.startup.defaultReady() within your own ready function
-     *    if needed, or can use the individual methods below to perform portions
-     *    of the default startup actions.)
+     * The default ready() function called when all the packages have been loaded,
+     * which creates the various objects needed by MathJax, creates the methods
+     * based on the loaded components, and does the initial typesetting.
+     *
+     * Setting MathJax.startup.ready in the configuration will
+     * override this, but you can call MathJax.startup.defaultReady()
+     * within your own ready function if needed, or can use the
+     * individual methods below to perform portions of the default
+     * startup actions.
      */
     export function defaultReady() {
         getComponents();
         makeMethods();
-        if (CONFIG.pageReady) {
-            //
-            //  Add in the user's pageReady function, which runs when the page content is
-            //    ready, but before the initial typesetting call.
-            //
-            pagePromise = pagePromise.then(CONFIG.pageReady);
-        }
-        promise = (CONFIG.typeset && MathJax.typesetPromise ?
-                   pagePromise.then(MathJax.typesetPromise) : pagePromise);
+        promise = promise.then(() => CONFIG.pageReady());  // usually the initial typesetting call
+    };
+
+    /**
+     * The default pageReady() function called when the page is ready to be processed,
+     * which returns the function that performs the initial typesetting, if needed.
+     *
+     * Setting Mathjax.startup.pageReady in the configuration will override this.
+     */
+    export function defaultPageReady() {
+        return (CONFIG.typeset && MathJax.typesetPromise ? MathJax.typesetPromise() : null);
     };
 
     /**
@@ -504,7 +506,8 @@ if (typeof MathJax._.startup === 'undefined') {
         document: (typeof document === 'undefined' ? '' : document),
         elements: null,
         typeset: true,
-        ready: Startup.defaultReady.bind(Startup)
+        ready: Startup.defaultReady.bind(Startup),
+        pageReady: Startup.defaultPageReady.bind(Startup)
     });
     combineWithMathJax({
         startup: Startup,


### PR DESCRIPTION
Move the initial typeset call into `pageReady()` (since that is when the typeset occurs), and make a default version of it, so it is parallel to the `ready()` function.  This is a better separation of duties, and makes it easier to use the `ready()` and `pageReady()` functions.  It also removes the `pagePromise`, since it is not really necessary to have two promises, and `promise` already waits on `pagePromise`.