### PR TITLE
Fix use of isType() for msubsup and munderover. #314

### DIFF
--- a/mathjax3-ts/input/tex/base/BaseItems.ts
+++ b/mathjax3-ts/input/tex/base/BaseItems.ts
@@ -192,7 +192,7 @@ export class PrimeItem extends BaseItem {
    */
   public checkItem(item: StackItem): CheckType {
     let [top0, top1] = this.Peek(2);
-    if (!NodeUtil.isType(top0, 'msubsup')) {
+    if (!NodeUtil.isType(top0, 'msubsup') || NodeUtil.isType(top0, 'msup')) {
       // @test Prime, Double Prime
       const node = this.create('node', 'msup', [top0, top1]);
       return [[node, item], true];

--- a/mathjax3-ts/input/tex/base/BaseMethods.ts
+++ b/mathjax3-ts/input/tex/base/BaseMethods.ts
@@ -125,16 +125,19 @@ BaseMethods.Superscript = function(parser: TexParser, c: string) {
   const movesupsub = NodeUtil.getProperty(base, 'movesupsub');
   let position = NodeUtil.isType(base, 'msubsup') ? (base as MmlMsubsup).sup :
     (base as MmlMunderover).over;
-  if ((NodeUtil.isType(base, 'msubsup') && NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
-      (NodeUtil.isType(base, 'munderover') && NodeUtil.getChildAt(base, (base as MmlMunderover).over) &&
+  if ((NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
+       NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
+      (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
+       NodeUtil.getChildAt(base, (base as MmlMunderover).over) &&
        !NodeUtil.getProperty(base, 'subsupOK'))) {
     // @test Double-super-error, Double-over-error
     throw new TexError('DoubleExponent', 'Double exponent: use braces to clarify');
   }
-  if (!NodeUtil.isType(base, 'msubsup')) {
+  if (!NodeUtil.isType(base, 'msubsup') || NodeUtil.isType(base, 'msup')) {
     if (movesupsub) {
       // @test Move Superscript, Large Operator
-      if (!NodeUtil.isType(base, 'munderover') || NodeUtil.getChildAt(base, (base as MmlMunderover).over)) {
+      if (!NodeUtil.isType(base, 'munderover') || NodeUtil.isType(base, 'mover') ||
+          NodeUtil.getChildAt(base, (base as MmlMunderover).over)) {
         if (NodeUtil.getProperty(base, 'movablelimits') && NodeUtil.isType(base, 'mi')) {
           // @test Mathop Super
           base = ParseUtil.mi2mo(parser, base);
@@ -184,16 +187,19 @@ BaseMethods.Subscript = function(parser: TexParser, c: string) {
   const movesupsub = NodeUtil.getProperty(base, 'movesupsub');
   let position = NodeUtil.isType(base, 'msubsup') ?
     (base as MmlMsubsup).sub : (base as MmlMunderover).under;
-  if ((NodeUtil.isType(base, 'msubsup') && NodeUtil.getChildAt(base, (base as MmlMsubsup).sub)) ||
-      (NodeUtil.isType(base, 'munderover') && NodeUtil.getChildAt(base, (base as MmlMunderover).under) &&
+  if ((NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
+       NodeUtil.getChildAt(base, (base as MmlMsubsup).sub)) ||
+      (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
+       NodeUtil.getChildAt(base, (base as MmlMunderover).under) &&
        !NodeUtil.getProperty(base, 'subsupOK'))) {
     // @test Double-sub-error, Double-under-error
     throw new TexError('DoubleSubscripts', 'Double subscripts: use braces to clarify');
   }
-  if (!NodeUtil.isType(base, 'msubsup')) {
+  if (!NodeUtil.isType(base, 'msubsup') || NodeUtil.isType(base, 'msup')) {
     if (movesupsub) {
       // @test Large Operator, Move Superscript
-      if (!NodeUtil.isType(base, 'munderover') || NodeUtil.getChildAt(base, (base as MmlMunderover).under)) {
+      if (!NodeUtil.isType(base, 'munderover') || NodeUtil.isType(base, 'mover') ||
+          NodeUtil.getChildAt(base, (base as MmlMunderover).under)) {
         if (NodeUtil.getProperty(base, 'movablelimits') && NodeUtil.isType(base, 'mi')) {
           // @test Mathop Sub
           base = ParseUtil.mi2mo(parser, base);
@@ -227,7 +233,7 @@ BaseMethods.Prime = function(parser: TexParser, c: string) {
     // @test PrimeSup, PrePrime, Prime on Sup
     base = parser.create('node', 'mi');
   }
-  if (NodeUtil.isType(base, 'msubsup') &&
+  if (NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
       NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) {
     // @test Double Prime Error
     throw new TexError('DoubleExponentPrime',


### PR DESCRIPTION
The `NodeUtil.isType(node, type)` function uses `node.isKind(type)`, which in turn tests if node is an instance of the class for the given type, or one of its subclasses.  Since `MmlMsup` is a subclass of `MmlMsubsup`, that means `NodeUtil.isType(node, 'msubsup')` will be true when `node` is an `MmlMsup`.  This call is replacing a version 2 test of `node.type === 'msubsup'`, which fails when `node` is an `msup` node.  So the version 3 code doesn't act the same as the version 2 code.  This caused `\boldsymbol{c'}^2` to incorrectly report a double exponent.

This PR fixes the test to exclude `msup` nodes in this case, and the similar case with double primes, e.g. `\boldsymbol{c'}'`.

Resolves issue #314.