### PR TITLE
Make tags work for starred environments.  #316

### DIFF
--- a/mathjax3-ts/input/tex/Tags.ts
+++ b/mathjax3-ts/input/tex/Tags.ts
@@ -399,10 +399,10 @@ export class AbstractTags implements Tags {
     if (ct.taggable && !ct.noTag) {
       if (ct.defaultTags) {
         this.autoTag();
-      } else {
-        return null;
       }
-      return this.makeTag();
+      if (ct.tag) {
+        return this.makeTag();
+      }
     }
     return null;
   }


### PR DESCRIPTION
Tags are not being applied to starred environments.  This PR fixes that.  The file diff is a bit awkward; the new code is

https://github.com/mathjax/mathjax-v3/blob/ffb3591a6402817b197466b71f28ae0d91d4bc5a/mathjax3-ts/input/tex/Tags.ts#L399-L406

The old code returned `null` if there was no automatic numbering rather than checking if there was an explicit tag and returning that.

Resolves issue #316