### PR TITLE
Fix isEmbellished() to properly locate the core element in an mrow

### DIFF
--- a/mathjax3-ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/mathjax3-ts/core/MmlTree/MmlNodes/mrow.ts
@@ -81,6 +81,7 @@ export class MmlMrow extends AbstractMmlNode {
                     return false;
                 }
             }
+            i++;
         }
         return embellished;
     }


### PR DESCRIPTION
The index wasn't being incremented, so the core element was not being properly located.  Argh!