### PR TITLE
Add start number parameter to MathJax.texReset()

### DIFF
--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -409,7 +409,7 @@ export namespace Startup {
      */
     export function makeResetMethod(name: string, input: INPUTJAX) {
         if (name === 'tex') {
-            MathJax.texReset = () => (input as TEX).parseOptions.tags.reset();
+            MathJax.texReset = (start: number = 0) => (input as TEX).parseOptions.tags.reset(start);
         }
     };
 


### PR DESCRIPTION
The `texReset()` command should have a parameter that allows it to set the starting equation number.  This PR adds one.