### PR TITLE
Support for additional output configuration options

### DIFF
--- a/mathjax3-ts/output/chtml/Wrappers.ts
+++ b/mathjax3-ts/output/chtml/Wrappers.ts
@@ -28,6 +28,7 @@ import {CHTMLmi} from './Wrappers/mi.js';
 import {CHTMLmo} from './Wrappers/mo.js';
 import {CHTMLmn} from './Wrappers/mn.js';
 import {CHTMLms} from './Wrappers/ms.js';
+import {CHTMLmtext} from './Wrappers/mtext.js';
 import {CHTMLmspace} from './Wrappers/mspace.js';
 import {CHTMLmpadded} from './Wrappers/mpadded.js';
 import {CHTMLmenclose} from './Wrappers/menclose.js';
@@ -56,6 +57,7 @@ export const CHTMLWrappers: {[kind: string]: WrapperConstructor}  = {
     [CHTMLmo.kind]: CHTMLmo,
     [CHTMLmn.kind]: CHTMLmn,
     [CHTMLms.kind]: CHTMLms,
+    [CHTMLmtext.kind]: CHTMLmtext,
     [CHTMLmspace.kind]: CHTMLmspace,
     [CHTMLmpadded.kind]: CHTMLmpadded,
     [CHTMLmenclose.kind]: CHTMLmenclose,

--- a/mathjax3-ts/output/chtml/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtext.ts
@@ -1,0 +1,40 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CHTMLmtext wrapper for the MmlMtext object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
+import {CommonMtext, CommonMtextMixin} from '../../common/Wrappers/mtext.js';
+import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
+
+/*****************************************************************/
+/**
+ * The CHTMLmtext wrapper for the MmlMtext object
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class CHTMLmtext<N, T, D> extends CommonMtextMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+
+    public static kind = MmlMtext.prototype.kind;
+
+}

--- a/mathjax3-ts/output/chtml/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtext.ts
@@ -33,7 +33,7 @@ import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class CHTMLmtext<N, T, D> extends CommonMtextMixin<CHTMLConstructor<N, T, D>>(CHTMLWrapper) {
+export class CHTMLmtext<N, T, D> extends CommonMtextMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
 
     public static kind = MmlMtext.prototype.kind;
 

--- a/mathjax3-ts/output/chtml/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtext.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2017 The MathJax Consortium
+ *  Copyright (c) 2019 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax3-ts/output/chtml/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/chtml/Wrappers/mtext.ts
@@ -22,7 +22,7 @@
  */
 
 import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
-import {CommonMtext, CommonMtextMixin} from '../../common/Wrappers/mtext.js';
+import {CommonMtextMixin} from '../../common/Wrappers/mtext.js';
 import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
 
 /*****************************************************************/

--- a/mathjax3-ts/output/common/OutputJax.ts
+++ b/mathjax3-ts/output/common/OutputJax.ts
@@ -76,7 +76,11 @@ export abstract class CommonOutputJax<
 
     public static OPTIONS: OptionList = {
         ...AbstractOutputJax.OPTIONS,
-        scale: 1,                      // Global scaling factor for all expressions
+        scale: 1,                      // global scaling factor for all expressions
+        minScale: .5,                  // smallest scaling factor to use
+        matchFontHeight: true,         // true to match ex-height of surrounding font
+        mtextInheritFont: false,       // true to make mtext elements use surrounding font
+        merrorInheritFont: true,       // true to make merror text use surrounding font
         mathmlSpacing: false,          // true for MathML spacing rules, false for TeX rules
         skipAttributes: {},            // RFDa and other attributes NOT to copy to the output
         exFactor: .5,                  // default size of ex in em units
@@ -379,7 +383,8 @@ export abstract class CommonOutputJax<
                                 adaptor.nodeSize(adaptor.lastChild(node) as N)[0] - 1 :
                                 adaptor.nodeBBox(adaptor.lastChild(node) as N).left -
                                 adaptor.nodeBBox(adaptor.firstChild(node) as N).left - 2);
-        const scale = ex / this.font.params.x_height / em;
+        const scale = Math.max(this.options.minScale,
+                               this.options.matchFontHeight ? ex / this.font.params.x_height / em : 1);
         const lineWidth = 1000000;      // no linebreaking (otherwise would be a percentage of cwidth)
         return {em, ex, containerWidth, lineWidth, scale} as Metrics;
     }

--- a/mathjax3-ts/output/common/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtext.ts
@@ -1,0 +1,89 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CommonMtext wrapper mixin for the MmlMtext object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {AnyWrapper, WrapperConstructor, Constructor} from '../Wrapper.js';
+import {BBox} from '../BBox.js';
+
+/*****************************************************************/
+/**
+ * The CommonMtext interface
+ */
+export interface CommonMtext extends AnyWrapper {
+}
+
+/**
+ * Shorthand for the CommonMtext constructor
+ */
+export type MtextConstructor = Constructor<CommonMtext>;
+
+/*****************************************************************/
+/**
+ *  The CommonMtext wrapper mixin for the MmlMtext object
+ *
+ * @template T  The Wrapper class constructor type
+ */
+export function CommonMtextMixin<T extends WrapperConstructor>(Base: T): MtextConstructor & T {
+    return class extends Base {
+
+        /**
+         * The font-family, weight, and style to use for the variants when mtextInheritFont
+         * is true.  If not in this list, then usual MathJax fonts are used instead.
+         */
+        public static INHERITFONTS = {
+            normal: ['', '', ''],
+            bold: ['', 'bold', ''],
+            italic: ['', '', 'italic'],
+            'bold-italic': ['', 'bold', 'italic'],
+            script: ['cursive', '', ''],
+            'bold-script': ['cursive', 'bold', ''],
+            'sans-serif': ['sans-serif', '', ''],
+            'bold-sans-serif': ['sans-serif', 'bold', ''],
+            'sans-serif-italic': ['sans-serif', '', 'italic'],
+            'bold-sans-serif-italic': ['sans-serif', 'bold', 'italic'],
+            monospace: ['monospace', '', '']
+        };
+
+        /**
+         * @override
+         */
+        protected getVariant() {
+            const options = this.jax.options;
+            //
+            //  If the font is to be inherited from the surrounding text, check the mathvariant
+            //  and see if it allows for inheritance. If so, set the variant appropriately,
+            //  otherwise get the usual variant.
+            //
+            if (options.mtextInheritFont || (options.merrorInheritFont && this.node.Parent.isKind('merror'))) {
+                const variant = this.node.attributes.get('mathvariant') as string;
+                const font = (this.constructor as any).INHERITFONTS[variant] as [string, string, string];
+                if (font) {
+                    this.variant = this.explicitVariant(...font);
+                    return;
+                }
+            }
+            super.getVariant();
+        }
+
+    };
+
+}

--- a/mathjax3-ts/output/common/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/common/Wrappers/mtext.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2017 The MathJax Consortium
+ *  Copyright (c) 2019 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax3-ts/output/svg/Wrappers.ts
+++ b/mathjax3-ts/output/svg/Wrappers.ts
@@ -29,6 +29,7 @@ import {SVGmi} from './Wrappers/mi.js';
 import {SVGmo} from './Wrappers/mo.js';
 import {SVGmn} from './Wrappers/mn.js';
 import {SVGms} from './Wrappers/ms.js';
+import {SVGmtext} from './Wrappers/mtext.js';
 import {SVGmerror} from './Wrappers/merror.js';
 import {SVGmspace} from './Wrappers/mspace.js';
 import {SVGmpadded} from './Wrappers/mpadded.js';
@@ -60,6 +61,7 @@ export const SVGWrappers: {[kind: string]: WrapperConstructor}  = {
     [SVGmo.kind]: SVGmo,
     [SVGmn.kind]: SVGmn,
     [SVGms.kind]: SVGms,
+    [SVGmtext.kind]: SVGmtext,
     [SVGmerror.kind]: SVGmerror,
     [SVGmspace.kind]: SVGmspace,
     [SVGmpadded.kind]: SVGmpadded,

--- a/mathjax3-ts/output/svg/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtext.ts
@@ -22,7 +22,7 @@
  */
 
 import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
-import {CommonMtext, CommonMtextMixin} from '../../common/Wrappers/mtext.js';
+import {CommonMtextMixin} from '../../common/Wrappers/mtext.js';
 import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
 
 /*****************************************************************/

--- a/mathjax3-ts/output/svg/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtext.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2018 The MathJax Consortium
+ *  Copyright (c) 2019 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/mathjax3-ts/output/svg/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtext.ts
@@ -1,0 +1,40 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the SVGmtext wrapper for the MmlMtext object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
+import {CommonMtext, CommonMtextMixin} from '../../common/Wrappers/mtext.js';
+import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
+
+/*****************************************************************/
+/**
+ * The SVGmtext wrapper for the MmlMtext object
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class SVGmtext<N, T, D> extends CommonMtextMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+
+    public static kind = MmlMtext.prototype.kind;
+
+}

--- a/mathjax3-ts/output/svg/Wrappers/mtext.ts
+++ b/mathjax3-ts/output/svg/Wrappers/mtext.ts
@@ -33,7 +33,7 @@ import {MmlMtext} from '../../../core/MmlTree/MmlNodes/mtext.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SVGmtext<N, T, D> extends CommonMtextMixin<SVGConstructor<N, T, D>>(SVGWrapper) {
+export class SVGmtext<N, T, D> extends CommonMtextMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
     public static kind = MmlMtext.prototype.kind;
 


### PR DESCRIPTION
Add support for missing `minScale` and `mtextInheritFont` configuration options, and add new `merrorInheritFont` option.  This required adding new `mtext` wrappers (since the default wrapper actions are no longer sufficient).