### PR TITLE
Slim down the startup component

### DIFF
--- a/components/src/startup/webpack.config.js
+++ b/components/src/startup/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require("webpack");
 const PACKAGE = require('../../webpack.common.js');
 
 module.exports = PACKAGE(
@@ -5,4 +6,18 @@ module.exports = PACKAGE(
     '../../../mathjax3',                // location of the mathjax3 library
     [],                                 // packages to link to
     __dirname                           // our directory
+);
+
+//
+//  Force linking to core/MathItem.js from the core package, since
+//  that is not needed until after core is loaded (can't link to all
+//  of core, as we need PrioritizedList.js and global.js before that)
+//
+module.exports.plugins.push(
+    new webpack.NormalModuleReplacementPlugin(
+        /\/core\/MathItem\.js$/,
+        function (resource) {
+            resource.request = '../../components/src/core/lib/core/MathItem.js';
+        }
+    )
 );

--- a/mathjax3-ts/components/startup.ts
+++ b/mathjax3-ts/components/startup.ts
@@ -28,7 +28,7 @@ import {MathJax as MJGlobal, MathJaxObject as MJObject,
         MathJaxConfig as MJConfig, combineWithMathJax, combineDefaults} from './global.js';
 
 import {MathDocument} from '../core/MathDocument.js';
-import {MathItem, STATE} from '../core/MathItem.js';
+import {STATE} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {Handler} from '../core/Handler.js';
 import {InputJax, AbstractInputJax} from '../core/InputJax.js';
@@ -63,7 +63,6 @@ export interface MathJaxConfig extends MJConfig {
  * Generic types for the standard MathJax objects
  */
 export type MATHDOCUMENT = MathDocument<any, any, any>;
-export type MATHITEM = MathItem<any, any, any>;
 export type HANDLER = Handler<any, any, any>;
 export type DOMADAPTOR = DOMAdaptor<any, any, any>;
 export type INPUTJAX = InputJax<any, any, any>;
@@ -366,7 +365,7 @@ export namespace Startup {
                 return mathjax.handleRetriesFor(() => document.convert(math, options));
             };
         MathJax[oname + 'Stylesheet'] = () => output.styleSheet(document);
-        if (output instanceof CommonOutputJax) {
+        if ('getMetricsFor' in output) {
             MathJax.getMetricsFor = (node: any, display: boolean) => {
                 return (output as COMMONJAX).getMetricsFor(node, display);
             }


### PR DESCRIPTION
This PR updates `mathjax3-ts/components/startup.js` to have fewer dependencies (i.e., not rely on `output/common/OutputJax.js`), and to link to the core library for `core/MathItem.js` (since it is not needed until after core will be loaded).  This reduces the component size from 47KB to 18KB.
