### PR TITLE
Update names of some options

### DIFF
--- a/mathjax3-ts/input/tex/Tags.ts
+++ b/mathjax3-ts/input/tex/Tags.ts
@@ -447,8 +447,8 @@ export class AbstractTags implements Tags {
     let cell = nf.create('node', 'mtd', [node]);
     let row = nf.create('node', 'mlabeledtr', [tag, cell]);
     let table = nf.create('node', 'mtable', [row], {
-      side: this.configuration.options['TagSide'],
-      minlabelspacing: this.configuration.options['TagIndent'],
+      side: this.configuration.options['tagSide'],
+      minlabelspacing: this.configuration.options['tagIndent'],
       displaystyle: true
     });
     return table;
@@ -554,11 +554,11 @@ export namespace TagsFactory {
     tags: defaultTags,
     //  This specifies the side on which \tag{} macros will place the tags.
     //  Set to 'left' to place on the left-hand side.
-    TagSide: 'right',
+    tagSide: 'right',
     //  This is the amound of indentation (from right or left) for the tags.
-    TagIndent: '0.8em',
+    tagIndent: '0.8em',
     //  This is the width to use for the multline environment
-    MultLineWidth: '85%',
+    multlineWidth: '85%',
     // make element ID's use \label name rather than equation number
     // MJ puts in an equation prefix: mjx-eqn
     // When true it uses the label name XXX as mjx-eqn-XXX

--- a/mathjax3-ts/input/tex/ams/AmsConfiguration.ts
+++ b/mathjax3-ts/input/tex/ams/AmsConfiguration.ts
@@ -56,7 +56,7 @@ export const AmsConfiguration = Configuration.create(
     environment: ['AMSmath-environment']
   },
    items: {[MultlineItem.prototype.kind]: MultlineItem},
-   tags: {'AMS': AmsTags},
+   tags: {'ams': AmsTags},
    init: init
   }
 );

--- a/mathjax3-ts/input/tex/ams/AmsMethods.ts
+++ b/mathjax3-ts/input/tex/ams/AmsMethods.ts
@@ -122,9 +122,9 @@ AmsMethods.Multline = function (parser: TexParser, begin: StackItem, numbered: b
     displaystyle: true,
     rowspacing: '.5em',
     columnwidth: '100%',
-    width: parser.options['MultLineWidth'],
-    side: parser.options['TagSide'],
-    minlabelspacing: parser.options['TagIndent']
+    width: parser.options['multlineWidth'],
+    side: parser.options['tagSide'],
+    minlabelspacing: parser.options['tagIndent']
   };
   return item;
 };

--- a/mathjax3-ts/input/tex/base/BaseMethods.ts
+++ b/mathjax3-ts/input/tex/base/BaseMethods.ts
@@ -1477,8 +1477,8 @@ BaseMethods.EqnArray = function(parser: TexParser, begin: StackItem,
     columnalign: align,
     columnspacing: (spacing || '1em'),
     rowspacing: '3pt',
-    side: parser.options['TagSide'],
-    minlabelspacing: parser.options['TagIndent']
+    side: parser.options['tagSide'],
+    minlabelspacing: parser.options['tagIndent']
   };
   return newItem;
 };


### PR DESCRIPTION
As per our face-to-face discussion, this PR normalizes the case of several TeX input options, includes `Html` in the names of `skipTags`, and other FindMath options, and changes the default values of `ignoreHtmlClass` and `processHtmlClass`.