### PR TITLE
Rename components/dist to es5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ mathjax3
 components/src/**/lib
 components/samples/**/lib
 components/samples/**/*.min.js
-components/dist
+es5

--- a/components/bin/makeAll
+++ b/components/bin/makeAll
@@ -40,8 +40,8 @@ if (dirs.length === 0) {
 /**
  * The path to the bin/build executable
  */
-const build = path.join(__dirname, 'build');
-const copy = path.join(__dirname, 'copy');
+const build = 'node ' + path.join(__dirname, 'build');
+const copy = 'node ' + path.join(__dirname, 'copy');
 
 /**
  * Regular expressions for the components directory and the mathjax3 .js location

--- a/components/bin/makeAll
+++ b/components/bin/makeAll
@@ -38,7 +38,9 @@ if (dirs.length === 0) {
 }
 
 /**
- * The path to the bin/build executable
+ * The commads to runb the bin/build scripts
+ *  (on Unix, could be done without the 'node ' prefix, but
+ *   for Windows, these are needed.)
  */
 const build = 'node ' + path.join(__dirname, 'build');
 const copy = 'node ' + path.join(__dirname, 'copy');

--- a/components/src/mml-chtml/test.html
+++ b/components/src/mml-chtml/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/mml-chtml.js"></script>
+<script src="../../../es5/mml-chtml.js"></script>
 </head>
 <body>
 

--- a/components/src/mml-chtml/test.js
+++ b/components/src/mml-chtml/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/mml-chtml.js');
+require('../../../es5/mml-chtml.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.startup.adaptor.outerHTML(MathJax.mathml2chtml('<math><mi>x</mi></math>')));

--- a/components/src/mml-svg/test.html
+++ b/components/src/mml-svg/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/mml-svg.js"></script>
+<script src="../../../es5/mml-svg.js"></script>
 </head>
 <body>
 

--- a/components/src/mml-svg/test.js
+++ b/components/src/mml-svg/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/mml-svg.js');
+require('../../../es5/mml-svg.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.startup.adaptor.outerHTML(MathJax.mathml2svg('<math><mi>x</mi></math>')));

--- a/components/src/output/chtml/fonts/tex/copy.json
+++ b/components/src/output/chtml/fonts/tex/copy.json
@@ -1,5 +1,5 @@
 {
-    "to": "../../../../../dist/output/chtml/fonts/woff-v2",
+    "to": "../../../../../../es5/output/chtml/fonts/woff-v2",
     "from": "../../../../../../mathjax3-ts/output/chtml/fonts/tex-woff-v2",
     "copy": [
         "MathJax_AMS-Regular.woff",

--- a/components/src/sre/copy.json
+++ b/components/src/sre/copy.json
@@ -1,5 +1,5 @@
 {
-    "to": "../../dist/sre",
+    "to": "../../../es5/sre",
     "from": "[node]/speech-rule-engine/lib",
     "copy": [
         "sre_browser.js",

--- a/components/src/tex-chtml/test.html
+++ b/components/src/tex-chtml/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/tex-chtml.js"></script>
+<script src="../../../es5/tex-chtml.js"></script>
 </head>
 <body>
 

--- a/components/src/tex-chtml/test.js
+++ b/components/src/tex-chtml/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/tex-chtml.js');
+require('../../../es5/tex-chtml.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.tex2mml('x+1'));

--- a/components/src/tex-mml-chtml/test.html
+++ b/components/src/tex-mml-chtml/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/tex-mml-chtml.js"></script>
+<script src="../../../es5/tex-mml-chtml.js"></script>
 </head>
 <body>
 

--- a/components/src/tex-mml-chtml/test.js
+++ b/components/src/tex-mml-chtml/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/tex-mml-chtml.js');
+require('../../../es5/tex-mml-chtml.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.tex2mml('x+1'));

--- a/components/src/tex-mml-svg/test.html
+++ b/components/src/tex-mml-svg/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/tex-mml-svg.js"></script>
+<script src="../../../es5/tex-mml-svg.js"></script>
 </head>
 <body>
 

--- a/components/src/tex-mml-svg/test.js
+++ b/components/src/tex-mml-svg/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/tex-mml-svg.js');
+require('../../../es5/tex-mml-svg.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.startup.adaptor.outerHTML(MathJax.tex2svg('x+1')));

--- a/components/src/tex-svg/test.html
+++ b/components/src/tex-svg/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test combined file</title>
-<script src="../../dist/tex-svg.js"></script>
+<script src="../../../es5/tex-svg.js"></script>
 </head>
 <body>
 

--- a/components/src/tex-svg/test.js
+++ b/components/src/tex-svg/test.js
@@ -2,13 +2,13 @@ MathJax = {
     loader: {
         load: ['adaptors/liteDom.js'],
         paths: {
-            mathjax: '../../dist'
+            mathjax: '../../../es5'
         },
         require: require,
         ready: () => {}
     }
 }
-require('../../dist/tex-svg.js');
+require('../../../es5/tex-svg.js');
 MathJax.loader.defaultReady();
 
 console.log(MathJax.startup.adaptor.outerHTML(MathJax.tex2svg('x+1')));

--- a/components/webpack.common.js
+++ b/components/webpack.common.js
@@ -108,7 +108,7 @@ const MODULE = function (dir) {
         // NOTE: for babel transpilation
         rules: [{
             test: new RegExp(dirRE + '\\/.*\\.js$'),
-            exclude: new RegExp(quoteRE(__dirname) + '\\/dist\\/'),
+            exclude: new RegExp(quoteRE(path.dirname(__dirname)) + '\\/es5\\/'),
             use: {
                 loader: 'babel-loader',
                 options: {
@@ -127,11 +127,11 @@ const MODULE = function (dir) {
  * @param {string[]} libs     Array of paths to component lib directories to link against
  * @param {string} dir        The directory of the component buing built
  * @param {string} dist       The path to the directory where the component .js file will be placed
- *                              (defaults to components/dist)
+ *                              (defaults to mathjax3/es5)
  */
 const PACKAGE = function (name, mathjax3, libs, dir, dist) {
     const distDir = dist ? path.resolve(dir, dist) :
-                           path.resolve(path.dirname(mathjax3), 'components', 'dist', path.dirname(name));
+                           path.resolve(path.dirname(mathjax3), 'es5', path.dirname(name));
     name = path.basename(name);
     return {
         name: name,

--- a/lib/v3-lab.js
+++ b/lib/v3-lab.js
@@ -100,7 +100,7 @@ window.MathJax = {
             'output/chtml'
         ],
         paths: {
-            mathjax: './components/dist'
+            mathjax: './es5'
         },
         source: source,
         require: (url) => System.import(url)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mathjax3",
   "version": "0.1.0",
   "description": "MathJax version 3 testbed",
+  "scripts": {
+    "make-components": "cd components && node bin/makeAll src"
+  },
   "main": "load.js",
   "devDependencies": {
     "typescript": "2.3.*",


### PR DESCRIPTION
This PR moves the `components/dist` folder to the top-level `es5` directory, as per our face-to-face yesterday.  Most of the fixes are in the various test files, which eventually will be moved to the separate development repository.  

In addition, I added an npm script for creating the components, and fixed the `makeAll` command to work on windows (see mathjax/mj3-demos-node#2).