### PR TITLE
Add node-main component

### DIFF
--- a/components/src/node-main/node-main.js
+++ b/components/src/node-main/node-main.js
@@ -1,0 +1,49 @@
+const path = require('path');
+
+/*
+ * Load the needed MathJax components
+ */
+require('../startup/lib/startup.js');
+const {Loader, CONFIG} = require('../../../js/components/loader.js');
+const {combineDefaults, combineConfig} = require('../../../js/components/global.js');
+const {dependencies, paths, provides} = require('../dependencies.js');
+
+/*
+ * Set up the initial configuration
+ */
+combineDefaults(MathJax.config, 'loader', {
+  require: global.require,       // use node's require() to load files
+  failed: (err) => {throw err}   // pass on error message to init()'s catch function
+});
+combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
+combineDefaults(MathJax.config.loader, 'paths', paths);
+combineDefaults(MathJax.config.loader, 'provides', provides);
+
+/*
+ * Preload core and liteDOM adaptor (needed for node)
+ */
+Loader.preLoad('loader', 'startup', 'core', 'adaptors/liteDOM');
+require('../core/core.js');
+require('../adaptors/liteDOM/liteDOM.js');
+
+/*
+ * The initialization function.  Use as:
+ *
+ *   require('mathjax').init({ ... }).then((MathJax) => { ... });
+ *
+ * where the argument to init() is a MathJax configuration (what would be set as MathJax = {...}).
+ * The init() function returns a promise that is resolved when MathJax is loaded and ready, and that
+ * is passed the MathJax global variable when it is called.
+ */
+const init = (config = {}) => {
+  combineConfig(MathJax.config, config);
+  return Loader.load(...CONFIG.load)
+    .then(() => CONFIG.ready())
+    .then(() => MathJax)                    // Pass MathJax global as argument to subsequent .then() calls
+    .catch(error => CONFIG.failed(error));
+}
+
+/*
+ * Export the init() function
+ */
+export {init};

--- a/components/src/node-main/webpack.config.js
+++ b/components/src/node-main/webpack.config.js
@@ -1,0 +1,12 @@
+const PACKAGE = require('../../webpack.common.js');
+
+const package = PACKAGE(
+    'node-main',                        // the package to build
+    '../../../js',                      // location of the MathJax js library
+    [],                                 // packages to link to
+    __dirname                           // our directory
+);
+
+package.output.libraryTarget = 'this';  // make node-main.js exports available to caller
+
+module.exports = package;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Beautiful math in all browsers. MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all browsers. This package includes the source code as well as the packaged components.",
   "license": "Apache-2.0",
-  "main": "es5/node-main.js",
+  "main": "components/src/node-main.js",
   "files": [
     "/es5",
     "/js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Beautiful math in all browsers. MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all browsers. This package includes the source code as well as the packaged components.",
   "license": "Apache-2.0",
-  "main": "components/src/node-main.js",
+  "main": "components/src/node-main/node-main.js",
   "files": [
     "/es5",
     "/js",


### PR DESCRIPTION
This PR adds a `node-main` component and makes it the default for node `require('mathjax-full')`.

This lets you do

```
require('mathjax-full').init({
  ...configuration...
}).then((MathJax) => {
  ...your MathJax code...
}).catch((err) => console.error(err.message));
```

to load, configure, and run MathJax code.