### PR TITLE
Fix Bussproofs handing of document and output jax

### DIFF
--- a/components/src/output/svg/svg.js
+++ b/components/src/output/svg/svg.js
@@ -4,7 +4,7 @@ import {combineDefaults} from '../../../../js/components/global.js';
 import {SVG} from '../../../../js/output/svg.js';
 
 if (MathJax.loader) {
-    combineDefaults(MathJax.config.loader, 'svg', {
+    combineDefaults(MathJax.config.loader, 'output/svg', {
         checkReady() {
             return MathJax.loader.load("output/svg/fonts/tex");
         }

--- a/ts/core/InputJax.ts
+++ b/ts/core/InputJax.ts
@@ -21,6 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {MathDocument} from './MathDocument.js';
 import {MathItem, ProtoItem} from './MathItem.js';
 import {MmlNode} from './MmlTree/MmlNode.js';
 import {MmlFactory} from './MmlTree/MmlFactory.js';
@@ -100,7 +101,7 @@ export interface InputJax<N, T, D> {
      * @param {MathItem} math  The MathItem whose math content is to processed
      * @return {MmlNode}       The resulting internal node tree for the math
      */
-    compile(math: MathItem<N, T, D>): MmlNode;
+    compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode;
 }
 
 /*****************************************************************/
@@ -178,19 +179,21 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     /**
      * @override
      */
-    public abstract compile(math: MathItem<N, T, D>): MmlNode;
+    public abstract compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode;
 
     /**
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *
-     * @param {FunctionList} filters  The list of functions to be performed
-     * @param {MathItem} math         The math item that is being processed
-     * @param {any} data              Whatever other data is needed
-     * @return {any}                  The (possibly modified) data
+     * @param {FunctionList} filters   The list of functions to be performed
+     * @param {MathItem} math          The math item that is being processed
+     * @param {MathDocument} document  The math document contaiing the math item
+     * @param {any} data               Whatever other data is needed
+     * @return {any}                   The (possibly modified) data
      */
-    protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>, data: any) {
-        let args = {math: math, data: data};
+    protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>,
+                             document: MathDocument<N, T, D>, data: any) {
+        let args = {math: math, document: document, data: data};
         filters.execute(args);
         return args.data;
     }

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -324,7 +324,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
      */
     public compile(document: MathDocument<N, T, D>) {
         if (this.state() < STATE.COMPILED) {
-            this.root = this.inputJax.compile(this);
+            this.root = this.inputJax.compile(this, document);
             this.state(STATE.COMPILED);
         }
     }

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -187,13 +187,15 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
      * Execute a set of filters, passing them the MathItem and any needed data,
      *  and return the (possibly modified) data
      *
-     * @param {FunctionList} filters  The list of functions to be performed
-     * @param {MathItem} math         The math item that is being processed
-     * @param {any} data              Whatever other data is needed
-     * @return {any}                  The (possibly modified) data
+     * @param {FunctionList} filters   The list of functions to be performed
+     * @param {MathItem} math          The math item that is being processed
+     * @param {MathDocument} document  The math document contaiing the math item
+     * @param {any} data               Whatever other data is needed
+     * @return {any}                   The (possibly modified) data
      */
-    protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>, data: any) {
-        let args = {math: math, data: data};
+    protected executeFilters(filters: FunctionList, math: MathItem<N, T, D>,
+                             document: MathDocument<N, T, D>, data: any) {
+        let args = {math, document, data};
         filters.execute(args);
         return args.data;
     }

--- a/ts/input/asciimath.ts
+++ b/ts/input/asciimath.ts
@@ -24,6 +24,7 @@
 import {AbstractInputJax} from '../core/InputJax.js';
 import {LegacyAsciiMath} from './asciimath/mathjax2/input/AsciiMath.js';
 import {separateOptions, OptionList} from '../util/Options.js';
+import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
 
 import {FindAsciiMath} from './asciimath/FindAsciiMath.js';
@@ -63,7 +64,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
      *
      * @override
      */
-    public compile(math: MathItem<N, T, D>) {
+    public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
         return LegacyAsciiMath.Compile(math.math, math.display);
     }
 

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -24,6 +24,7 @@
 import {AbstractInputJax} from '../core/InputJax.js';
 import {defaultOptions, separateOptions, OptionList} from '../util/Options.js';
 import {FunctionList} from '../util/FunctionList.js';
+import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
@@ -125,10 +126,10 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
      *
      * @override
      */
-    public compile(math: MathItem<N, T, D>) {
+    public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
         let mml = math.start.node;
         if (!mml || this.options['forceReparse']) {
-            let mathml = this.executeFilters(this.preFilters, math, math.math || '<math></math>');
+            let mathml = this.executeFilters(this.preFilters, math, document, math.math || '<math></math>');
             let doc = this.checkForErrors(this.adaptor.parse(mathml, 'text/' + this.options['parseAs']));
             let body = this.adaptor.body(doc);
             if (this.adaptor.childNodes(body).length !== 1) {
@@ -140,8 +141,8 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
                            this.adaptor.kind(mml) + '>');
             }
         }
-        mml = this.executeFilters(this.mmlFilters, math, mml);
-        return this.executeFilters(this.postFilters, math, this.mathml.compile(mml as N));
+        mml = this.executeFilters(this.mmlFilters, math, document, mml);
+        return this.executeFilters(this.postFilters, math, document, this.mathml.compile(mml as N));
     }
 
     /**

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -23,6 +23,7 @@
 
 import {AbstractInputJax} from '../core/InputJax.js';
 import {defaultOptions, userOptions, separateOptions, selectOptions, OptionList} from '../util/Options.js';
+import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
@@ -71,6 +72,11 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     // Maximum size of TeX string to process.
     maxBuffer: 5 * 1024
   };
+
+  /**
+   * The MathDocument for which this is the InputJax
+   */
+  public document: MathDocument<N, T, D>;
 
   /**
    * The FindTeX instance used for locating TeX in strings
@@ -136,6 +142,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
   constructor(options: OptionList = {}) {
     const [rest, tex, find] = separateOptions(options, TeX.OPTIONS, FindTeX.OPTIONS);
     super(tex);
+    this.document = null;
     this.findTeX = this.options['FindTeX'] || new FindTeX(find);
     const packages = this.options.packages;
     const configuration = this.configuration = TeX.configure(packages);
@@ -170,9 +177,9 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
   /**
    * @override
    */
-  public compile(math: MathItem<N, T, D>): MmlNode {
+  public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode {
     this.parseOptions.clear();
-    this.executeFilters(this.preFilters, math, this.parseOptions);
+    this.executeFilters(this.preFilters, math, document, this.parseOptions);
     let display = math.display;
     this.latex = math.math;
     let node: MmlNode;
@@ -195,7 +202,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     }
     this.parseOptions.tags.finishEquation(math);
     this.parseOptions.root = node;
-    this.executeFilters(this.postFilters, math, this.parseOptions);
+    this.executeFilters(this.postFilters, math, document, this.parseOptions);
     this.mathNode = this.parseOptions.root;
     return this.mathNode;
   };

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -137,7 +137,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
   constructor(options: OptionList = {}) {
     const [rest, tex, find] = separateOptions(options, TeX.OPTIONS, FindTeX.OPTIONS);
     super(tex);
-    this.document = null;
     this.findTeX = this.options['FindTeX'] || new FindTeX(find);
     const packages = this.options.packages;
     const configuration = this.configuration = TeX.configure(packages);

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -74,11 +74,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
   };
 
   /**
-   * The MathDocument for which this is the InputJax
-   */
-  public document: MathDocument<N, T, D>;
-
-  /**
    * The FindTeX instance used for locating TeX in strings
    */
   protected findTeX: FindTeX<N, T, D>;

--- a/ts/input/tex/bussproofs/BussproofsConfiguration.ts
+++ b/ts/input/tex/bussproofs/BussproofsConfiguration.ts
@@ -24,7 +24,7 @@
 
 import {Configuration} from '../Configuration.js';
 import {ProofTreeItem} from './BussproofsItems.js';
-import {balanceRules, makeBsprAttributes, initUtil} from './BussproofsUtil.js';
+import {saveDocument, clearDocument, balanceRules, makeBsprAttributes} from './BussproofsUtil.js';
 import './BussproofsMappings.js';
 
 
@@ -37,10 +37,13 @@ export const BussproofsConfiguration = Configuration.create(
    items: {
      [ProofTreeItem.prototype.kind]: ProofTreeItem,
    },
+   preprocessors: [
+     [saveDocument, 1]
+   ],
    postprocessors: [
+     [clearDocument, 3],
      [makeBsprAttributes, 2],
      [balanceRules, 1]
-   ],
-  init: initUtil
+   ]
   }
 );

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -27,7 +27,6 @@ import ParseOptions from '../ParseOptions.js';
 import NodeUtil from '../NodeUtil.js';
 import ParseUtil from '../ParseUtil.js';
 
-import {CHTML} from '../../../output/chtml.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {mathjax} from '../../../mathjax.js';
 import {Property, PropertyList} from '../../../core/Tree/Node.js';

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -223,7 +223,7 @@ export abstract class CommonOutputJax<
         this.container = node;
         this.processMath(math.root, node);
         this.nodeMap = null;
-        this.executeFilters(this.postFilters, math, node);
+        this.executeFilters(this.postFilters, math, html, node);
     }
 
     /**


### PR DESCRIPTION
This PR changes how `bussproofs` obtains a MathDocument and OutputJax.  It should use the actual MathDocument and OutputJax in use, since (in the future) these will be able to specify the font in use, and that will affect the spacing.  So we don't want to use a generic math document and output jax, but the specific one in use for the document.

Unfortunately, the InputJax doesn't have access to the MathDocument when it is created (since the InputJax is instantiated before the MathDocument), so the TeX extensions don't have access to it while they are initialized.

In order to overcome this, I've added the MathDocument to the arguments to `InputJax.compile()` function (it probably should have had that to begin with), and pass it along to the pre- and post-filters via `InputJax.executeFilters()` (and `OutputJax.executeFilter()` for consistency).  Because the TeX extensions can supply pre-and post-filters, this gives them access to the document.

So the bussproofs extension grabs the document using a pre-filter and sets the `doc` variable using that, rather than creating a new document.  It gets the output jax from the MathDocument rather than creating a new instance of one.

Because of the addition of the document to the `compile()` and `executeFilters()` functions, there are a bunch of non-bussproof files that are being adjusted, here.

Also, there was a typo in the component file for the SVG output that prevented it from loading a font file when the compressed component file was used.  Glad I caught that one!