### PR TITLE
Build fix

### DIFF
--- a/components/src/a11y/explorer/webpack.config.js
+++ b/components/src/a11y/explorer/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = PACKAGE(
     'a11y/explorer',                    // the package to build
     '../../../../js',                   // location of the MathJax js library
     [                                   // packages to link to
+        'components/src/ui/menu/lib',
         'components/src/a11y/semantic-enrich/lib',
         'components/src/mml-input/lib',
         'components/src/core/lib'

--- a/components/src/input/tex/extensions/ams_cd/amscd.js
+++ b/components/src/input/tex/extensions/ams_cd/amscd.js
@@ -1,1 +1,1 @@
-import './lib/amsCd.js';
+import './lib/amscd.js';


### PR DESCRIPTION
Fixes two things in the build:
1) The missing dependency of the a11y component on the menu module. This is necessary for a11y to register the dynamic clearspeak preference menu. This problem does not show up in the lab, but for the webpacked components, only.

2) Spelling discrepancy of `amscd` vs `amsCd` which leads to an error in the build of the `amd_cd` extension. This probably works fine on a Mac, but Linux is case sensitive. 