### PR TITLE
Skip TeX comments correctly.  mathjax/MathJax#2271.

### DIFF
--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -154,7 +154,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
      * @return {RegExp}     The regular expression for the end delimiter
      */
     protected endPattern(end: string) {
-        return new RegExp(quotePattern(end) + '|\\\\(?:[a-zA-Z]|.)|[{}]', 'g');
+        return new RegExp(quotePattern(end) + '|\\\\(?:[a-zA-Z]|.)|[{}%]', 'g');
     }
 
     /**
@@ -180,9 +180,22 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
                 braces++;
             } else if (match[0] === '}' && braces) {
                 braces--;
+            } else if (match[0] === '%') {
+                pattern.lastIndex += this.skipComment(text.substr(pattern.lastIndex));
             }
         }
         return null;
+    }
+
+    /**
+     * Skip a comment (without matching braces or other special characters)
+     *
+     * @param {string} text   The string containing the comment to skip
+     * @return {number}       The position of the string after the comment
+     */
+    protected skipComment(text: string) {
+        const match = text.match(/.*?[\n\r]/);
+        return match ? match[0].length : text.length;
     }
 
     /**

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -154,7 +154,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
      * @return {RegExp}     The regular expression for the end delimiter
      */
     protected endPattern(end: string) {
-        return new RegExp(quotePattern(end) + '|\\\\(?:[a-zA-Z]|.)|[{}%]', 'g');
+        return new RegExp(quotePattern(end) + '|\\\\(?:[a-zA-Z]|.)|[{}]|%.*(?:[\n\r]|$)', 'g');
     }
 
     /**
@@ -180,22 +180,11 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
                 braces++;
             } else if (match[0] === '}' && braces) {
                 braces--;
-            } else if (match[0] === '%') {
-                pattern.lastIndex += this.skipComment(text.substr(pattern.lastIndex));
+            } else if (match[0].substr(0) === '%') {
+                pattern.lastIndex += match[0].length;
             }
         }
         return null;
-    }
-
-    /**
-     * Skip a comment (without matching braces or other special characters)
-     *
-     * @param {string} text   The string containing the comment to skip
-     * @return {number}       The position of the string after the comment
-     */
-    protected skipComment(text: string) {
-        const match = text.match(/.*?[\n\r]/);
-        return match ? match[0].length : text.length;
     }
 
     /**


### PR DESCRIPTION
Update `FindTeX` to properly skip comments, even if they include unbalanced braces.

Resolves issue mathjax/MathJax#2271