### PR TITLE
Add a 'nonce' attribute to inline stylesheets

### DIFF
--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -98,7 +98,8 @@ export abstract class CommonOutputJax<
     displayIndent: '0',            // default for indentshift when set to 'auto'
     wrapperFactory: null,          // The wrapper factory to use
     font: null,                    // The FontData object to use
-    cssStyles: null                // The CssStyles object to use
+    cssStyles: null,               // The CssStyles object to use
+    nonce: null                    // The nonce value to apply to style tags created by MathJax
   };
 
   /**
@@ -464,11 +465,26 @@ export abstract class CommonOutputJax<
     // Get the font styles
     //
     this.cssStyles.addStyles(this.font.styles);
+    // 
+    // Set up the properties for the stylesheet
+    //
+    const def : {id: string, nonce?: string} = {id: 'MJX-styles'};
+    const nonce = this.getNonce();
+    if (nonce) {
+        def['nonce'] = nonce;
+    }
     //
     // Create the stylesheet for the CSS
     //
-    const sheet = this.html('style', {id: 'MJX-styles'}, [this.text('\n' + this.cssStyles.cssText + '\n')]);
+    const sheet = this.html('style', def, [this.text('\n' + this.cssStyles.cssText + '\n')]);
     return sheet as N;
+  }
+
+  /**
+   * @return {string}   The nonce value to apply to stylesheets created by MathJax
+   */
+  protected getNonce(): string|null {
+      return this.options.nonce;
   }
 
   /**


### PR DESCRIPTION
The output options now has a property 'nonce', which is a string to use as the value for a 'nonce' attribute on <style> tags created by the output jax. If it's not given, no 'nonce' attribute is added.

This fixes mathjax/MathJax#2665

Here's a tiny page to test:

```html
<!doctype html>
<html>
    <head>
        <script>
            window.MathJax = {
                chtml: {
                    nonce: 'hello'
                },
            };
        </script>
        <script src="es5/tex-chtml.js"></script>
    </head>
    <body>
        <p>This is \(x^2 + \int y\)</p>
    </body>
</html>
```

The `style.MJX-CHTML-styles` tag has an attribute `nonce="hello"`. 