### PR TITLE
Encode attribute names

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -184,7 +184,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
     for (const name of Object.keys(attributes)) {
       const value = String(attributes[name]);
       if (value === undefined) continue;
-      attr.push(name + '="' + this.quoteHTML(value) + '"');
+      attr.push(this.quoteHTML(name) + '="' + this.quoteHTML(value) + '"');
     }
     return attr.length ? ' ' + attr.join(' ') : '';
   }


### PR DESCRIPTION
Attribute names are not encoded. This can be an issue if user-controlled data flows into them. I have not find any of these cases, but I think its better to encode them as a security in-depth control.