### PR TITLE
Updates sre to latest beta.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,11 +139,10 @@
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.8.10",
-    "commander": "^12.0.0",
     "mathjax-modern-font": "^4.0.0-beta.5",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^4.1.0-beta.9",
+    "speech-rule-engine": "^4.1.0-beta.10",
     "wicked-good-xpath": "^1.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@xmldom/xmldom':
         specifier: ^0.8.10
         version: 0.8.10
-      commander:
-        specifier: ^12.0.0
-        version: 12.0.0
       mathjax-modern-font:
         specifier: ^4.0.0-beta.5
         version: 4.0.0-beta.5
@@ -24,8 +21,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: ^4.1.0-beta.9
-        version: 4.1.0-beta.9
+        specifier: ^4.1.0-beta.10
+        version: 4.1.0-beta.10
       wicked-good-xpath:
         specifier: ^1.3.0
         version: 1.3.0
@@ -44,7 +41,7 @@ importers:
         version: 5.7.5
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.3.10(webpack@5.91.0)
+        version: 5.3.10(webpack@5.91.0(webpack-cli@5.1.4))
       tslint:
         specifier: ^6.1.3
         version: 6.1.3(typescript@5.4.5)
@@ -360,10 +357,6 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
-
-  commander@12.0.0:
-    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
-    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1008,8 +1001,8 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  speech-rule-engine@4.1.0-beta.9:
-    resolution: {integrity: sha512-t/h1RIw5Xv+IbSn5E9dgjqOddo/VQBh2hdqJPERzvUDMm6HRutNmdoGTU/Mj8QEWwp7GbuwKkbRfaAcKYNINhg==}
+  speech-rule-engine@4.1.0-beta.10:
+    resolution: {integrity: sha512-SPqPF4YPdqvg0+VvQKpOi68SFFMCyvGI3zNfWPJx0faxh/eHjH3ATbRu4GjoWWnHGWKY8uSqXjz/1UnFVI6NmQ==}
     hasBin: true
 
   sprintf-js@1.0.3:
@@ -1414,17 +1407,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
@@ -1583,8 +1576,6 @@ snapshots:
   commander@10.0.1: {}
 
   commander@11.1.0: {}
-
-  commander@12.0.0: {}
 
   commander@2.20.3: {}
 
@@ -2282,7 +2273,7 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  speech-rule-engine@4.1.0-beta.9:
+  speech-rule-engine@4.1.0-beta.10:
     dependencies:
       '@xmldom/xmldom': 0.9.0-beta.8
       commander: 11.1.0
@@ -2375,7 +2366,7 @@ snapshots:
       resolve: 2.0.0-next.5
       string.prototype.trim: 1.2.8
 
-  terser-webpack-plugin@5.3.10(webpack@5.91.0):
+  terser-webpack-plugin@5.3.10(webpack@5.91.0(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -2509,9 +2500,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.91.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -2553,10 +2544,11 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.91.0(webpack-cli@5.1.4))
       watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.91.0)
       webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack@5.91.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
Updates to the latest version SRE 4.1 beta.10. This addresses the issues we had discussed Friday.
It works for me in both `commonjs` and ES `modules` (with `require.mjs` for the latter).
It also removes `commander` as dependency as this is no longer required for the `system_external` in SRE.