### PR TITLE
Allow better configuration for patterns for numbers and identifiers

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -68,8 +68,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     ...AbstractInputJax.OPTIONS,
     FindTeX: null,
     packages: ['base'],
-    // Digit pattern to match numbers.
-    digits: /^(?:[0-9]+(?:\{,\}[0-9]{3})*(?:\.[0-9]*)?|\.[0-9]+)/,
     // Maximum size of TeX string to process.
     maxBuffer: 5 * 1024,
     // Maximum number of array template substitutions (avoids infinite loop from @{\\} for example)


### PR DESCRIPTION
This PR makes it possible to more fully configure the patterns used for number recognition and multi-letter identifiers.  In the past, you could set the pattern used for a number, but not the characters that initiate the check for one, and you could specify the pattern to use for multi-letter itednifiers in `\mathrm{}` and the other similar macros, but could not set the letter pattern that initiated the check.  That makes it harder to configure MathJax for use in other languages, that have different number characters, such as Persian and Arabic, or if you wanted to use accented letters directly in identifiers.

Here, we move the `digits` pattern to `numberPattern` in the `base` configuration and add an `initialDigit` pattern.  Similarly, we add an `initialLetter` pattern for identifiers.  Then we create the `RegExpMap`s for `digit` and `letter` in the base `config()` method (where the options have been initialized) and add these to the handler list at this point, so these are removed from the original handler lists because we don't have the options available then to set up the regular expressions.  (I also added a backward-compatibility `digits` that maps onto `numberPattern` if specified, so that old configurations can still work.  But I could be persuaded to remove that, since v4 is breaking anyway.)

The `ParseMethods.digit()` method is modified to drop out without doing anything if the number pattern doesn't match (e.g., if it is just a decimal point not followed by a digit), so that in case there is another handler that can process it, that will be used instead of just putting it in an `mo`.  (I considered doing something similar for `ParseMethods.varaiable()`, but don't think it is necessary.)

One question is whether we should include more letters in the letter patterns, like should they include the Latin accented character by default?