### PR TITLE
Fix problem with CD environment cell ending with a prime. (mathjax/MathJax#3373)

### DIFF
--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -778,6 +778,38 @@ describe('AmsCD', () => {
 
   /********************************************************************************/
 
+  it('Entry with prime (#3373)', () => {
+    toXmlMatch(
+      tex2mml(`\\begin{CD}A' @>>> B\\end{CD}`),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A' @&gt;&gt;&gt; B\\end{CD}" display="block">
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A' @&gt;&gt;&gt; B\\end{CD}">
+           <mtr>
+             <mtd>
+               <msup>
+                 <mi data-latex="A">A</mi>
+                 <mo data-mjx-alternate="1">&#x2032;</mo>
+               </msup>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
 /**********************************************************************************/

--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -197,7 +197,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
    */
   cell(parser: TexParser, name: string) {
     const top = parser.stack.Top() as ArrayItem;
-    if (top.table.length % 2 === 0 && top.row.length === 0) {
+    if ((top.table || []).length % 2 === 0 && (top.row || []).length === 0) {
       //
       // Add a strut to the first cell in even rows to get
       // better spacing of arrow rows.


### PR DESCRIPTION
This PR reverts a change from #1192 that turns out to have been needed.  One case is when the cell entry ends with a prime, so the top stack item is the prime item not the table item.  There are other cases where this can occur as well.  A test for this situation is included.

Resolves issue mathjax/MathJax#3373.