### PR TITLE
Action to push to the `MathJax` repository

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,68 @@
+NAME    : Publish Release to MathJax
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout MathJax-src repository
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm -s i
+
+      - name: Build MathJax
+        run: |
+          ./components/bin/version
+          pnpm -s link:src
+          pnpm -s build
+        
+      # - name: Get files to push from package.json
+      #   id: get_files
+      #   run: |
+      #     # Extract the "files" list from package.json
+      #     FILES=$(jq -r '.files | join(" ")' package.json)
+      #     echo "FILES=$FILES" >> $GITHUB_ENV
+
+      - name: Create MathJax branch and push build
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          
+          # Get the release name from the context
+          # RELEASE_NAME="${{ github.event.release.name }}"
+          RELEASE_NAME="Testing"
+          
+          # Clone the MathJax repo
+          git clone https://github.com/MathJax/MathJax.git
+          cd MathJax
+          
+          # Create a new branch using the release name
+          git checkout -b "$RELEASE_NAME"
+          
+          # Copy the build output from MathJax-src repo to MathJax
+          cp -r ../bundle/* ./
+
+          # Add, commit, and push the changes
+          git add .
+          git commit -m "Add build artifacts for release $RELEASE_NAME"
+          git push origin "$RELEASE_NAME"
+
+      - name: Create a pull request in MathJax
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: MathJax/MathJax
+          head: "$RELEASE_NAME"
+          base: develop
+          title: "New build artifacts for release $RELEASE_NAME"
+          body: "This pull request contains the build artifacts from release $RELEASE_NAME."

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,8 +39,7 @@ jobs:
           git config --global user.email "actions@github.com"
           
           # Get the release name from the context
-          # RELEASE_NAME="${{ github.event.release.name }}"
-          RELEASE_NAME="Testing"
+          RELEASE_NAME="${{ github.event.release.name }}"
           
           # Clone the MathJax repo
           git clone https://github.com/MathJax/MathJax.git


### PR DESCRIPTION
PR adds an action that pushes the new release to the `MathJax` repository, creating a branch with the new release name and making pull request into develop.

* This action could be combined with the `publish` action. For ease of testing I kept it separately.
* I have tested with `act` up to the point of actually pushing the branch as this needs a token that is automatically created on Github but cannot be simulated in `act`. 