### PR TITLE
Don't try to create the clearspeak menu if enrichment is disabled

### DIFF
--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -243,7 +243,7 @@ export async function clearspeakMenu(
       )
     );
   };
-  if (!menu.settings.speech) {
+  if (!menu.settings.speech || !menu.settings.enrich) {
     exit([]);
     return;
   }


### PR DESCRIPTION
This PR prevents the menu code from trying to create the clearspeak setting menu when enrichment is off (and so the webworker may not even be created yet).  When enrichment is off, the speech menu is disabled, so the clearspeak menu will not be available in that case, so it is OK to not generate it.