### PR TITLE
Include the menu loading promises in the default startup page ready promise chain. (mathjax/MathJax#3401)

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -71,7 +71,9 @@ export interface MathJaxConfig extends MJConfig {
 /**
  * Generic types for the standard MathJax objects
  */
-export type MATHDOCUMENT = MathDocument<any, any, any> & {menu?: {loadingPromise: Promise<void>}};
+export type MATHDOCUMENT = MathDocument<any, any, any> & {
+  menu?: { loadingPromise: Promise<void> };
+};
 export type HANDLER = Handler<any, any, any>;
 export type DOMADAPTOR = DOMAdaptor<any, any, any>;
 export type INPUTJAX = InputJax<any, any, any>;


### PR DESCRIPTION
This PR adds the menu's `loadingPromise` into the promise chain for the initial typeset (and therefore the `MathJax.startup.promise`).  This makes sure that everything is loaded before MathJax's initial typesetting occurs.  This should only affect those loading components by hand rather than through a combined component.

Resolves issue mathjax/MathJax#3401.