### PR TITLE
Move the node createWorker() method to the NodeMixin.

### DIFF
--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -23,8 +23,18 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { DOMAdaptor } from '../core/DOMAdaptor.js';
+import { DOMAdaptor, minWorker } from '../core/DOMAdaptor.js';
 import { userOptions, defaultOptions, OptionList } from '../util/Options.js';
+import { asyncLoad } from '../util/AsyncLoad.js';
+
+/**
+ * A minimal worker thread interface
+ */
+export interface WebWorker {
+  on(kind: string, listener: (event: Event) => void): void;
+  postMessage(msg: any): void;
+  terminate(): void;
+}
 
 /**
  * A constructor for a given class
@@ -168,6 +178,39 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
       return options.badSizes
         ? { left: 0, right: 0, top: 0, bottom: 0 }
         : super.nodeBBox(node);
+    }
+
+    /**
+     * @override
+     */
+    public async createWorker(
+      listener: (event: any) => void,
+      options: OptionList
+    ): Promise<minWorker> {
+      const { Worker } = await asyncLoad('node:worker_threads');
+      class LiteWorker {
+        protected worker: WebWorker;
+        constructor(url: string, options: OptionList = {}) {
+          this.worker = new Worker(url, options);
+        }
+        addEventListener(kind: string, listener: (event: any) => void) {
+          this.worker.on(kind, listener);
+        }
+        postMessage(msg: any) {
+          this.worker.postMessage({ data: msg });
+        }
+        terminate() {
+          this.worker.terminate();
+        }
+      }
+      const { path, maps } = options;
+      const url = `${path}/${options.worker}`;
+      const worker = new LiteWorker(url, {
+        type: 'module',
+        workerData: { maps },
+      });
+      worker.addEventListener('message', listener);
+      return worker;
     }
   };
 }

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { AbstractDOMAdaptor, minWorker } from '../core/DOMAdaptor.js';
+import { AbstractDOMAdaptor } from '../core/DOMAdaptor.js';
 import { NodeMixin, Constructor } from './NodeMixin.js';
 import { LiteDocument } from './lite/Document.js';
 import { LiteElement, LiteNode } from './lite/Element.js';
@@ -31,17 +31,6 @@ import { LiteWindow } from './lite/Window.js';
 import { LiteParser } from './lite/Parser.js';
 import { Styles } from '../util/Styles.js';
 import { OptionList } from '../util/Options.js';
-
-import { asyncLoad } from '../util/AsyncLoad.js';
-
-/**
- * A minimal worker thread interface
- */
-export interface WebWorker {
-  on(kind: string, listener: (event: Event) => void): void;
-  postMessage(msg: any): void;
-  terminate(): void;
-}
 
 /************************************************************/
 
@@ -710,36 +699,12 @@ export class LiteBase extends AbstractDOMAdaptor<
   }
 
   /**
+   * This will be overridden by the NodeMixin below.
+   *
    * @override
    */
-  public async createWorker(
-    listener: (event: any) => void,
-    options: OptionList
-  ): Promise<minWorker> {
-    const { Worker } = await asyncLoad('node:worker_threads');
-    class LiteWorker {
-      protected worker: WebWorker;
-      constructor(url: string, options: OptionList = {}) {
-        this.worker = new Worker(url, options);
-      }
-      addEventListener(kind: string, listener: (event: any) => void) {
-        this.worker.on(kind, listener);
-      }
-      postMessage(msg: any) {
-        this.worker.postMessage({ data: msg });
-      }
-      terminate() {
-        this.worker.terminate();
-      }
-    }
-    const { path, maps } = options;
-    const url = `${path}/${options.worker}`;
-    const worker = new LiteWorker(url, {
-      type: 'module',
-      workerData: { maps },
-    });
-    worker.addEventListener('message', listener);
-    return worker;
+  public async createWorker(): Promise<any> {
+    return null;
   }
 }
 


### PR DESCRIPTION
This PR moves the node-based `createWorker()` function from the `liteAdaptor` into the generic `NodeMixin` that is used by the `liteAdaptor` as well as the `jsdomAdaptor` and the `linkedomAdaptor`, so that they can support speech generation in node as well.

The code is moved unchanged, but the `liteBase` class gets a stub for `createWorker()` that is overridden in the mix-in since one is required for the `AbstractDOMAdaptor` class that `liteBase` creates before using the mixin.