### PR TITLE
Add missing 'help' menu option

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -158,6 +158,7 @@ export class Menu {
       speechRules: 'clearspeak-default',
       roleDescription: 'math',
       tabSelects: 'all',
+      help: true,
     },
     jax: {
       CHTML: null,


### PR DESCRIPTION
This PR adds a missing `help` option to the menu settings.  Its variable was set up, but not the option, so it could not be configured.