### PR TITLE
Don't use padding for horizontal stretchy extenders.  (mathjax/MathJax#3429)

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -583,7 +583,9 @@ export class ChtmlFontData extends FontData<
       padding: this.padding(HDW as ChtmlCharData, w - HDW[2]),
     };
     if (part === 'ext') {
-      delete css.padding;
+      const padding = (css.padding as string).split(/ /);
+      padding[1] = padding[3] = '0';
+      css.padding = padding.join(' ');
       if (!w && options.dx) {
         w = 2 * options.dx - 0.06;
       }


### PR DESCRIPTION
This PR fixes a problem with horizontal stretchy character assemblies with middle pieces (like over- and under-braces) where the width is relatively small.  The unneeded padding was causing the size to be incorrect when the total padding was larger than the width of the needed extender.

Resolves issue mathjax/MathJax#3429.