### PR TITLE
Allow stretched character to increase column size (e.g., if it has minsize).  (mathjax/MathJax#3423)

### DIFF
--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -728,12 +728,10 @@ export function CommonMtableMixin<
         //
         const TW = this.getTableData().W;
         for (const child of stretchy) {
+          const w = child.getBBox().w;
           child
             .coreMO()
-            .getStretchedVariant([
-              Math.max(W, child.getBBox().w) / child.coreRScale(),
-            ]);
-          const w = child.getBBox().w;
+            .getStretchedVariant([Math.max(W, w) / child.coreRScale()]);
           if (w > TW[i]) {
             TW[i] = w;
           }


### PR DESCRIPTION
This PR fixes a problem where the column width for a column with stretchy characters isn't adjusted if the stretched version of the character is wider than the expected stretch width.  This can happen if a fixed-size character is used that is slightly larger than needed (which is allowed), or if the stretchy has a `minsize` attribute that makes it larger than expected.  The latter is true in the case cited in mathjax/MathJax#3423.

We fix the problem by making sure we always stretch characters, even if there is only one stretchy (so as to handle `minsize` even on a single row), and testing if the new width is wider than the column width, and adjusting that width if so.  We also remove a variable that is no longer needed.

A test case is

``` latex
\begin{CD}
A @= B
\end{CD}
```

Without this patch the equal sign overlaps the A and B.

Resolves issue mathjax/MathJax#3423.