### PR TITLE
Allow digits in \operatorname (mathjax/MathJax#2991)

### DIFF
--- a/ts/input/tex/ams/AmsConfiguration.ts
+++ b/ts/input/tex/ams/AmsConfiguration.ts
@@ -59,7 +59,7 @@ export const AmsConfiguration = Configuration.create('ams', {
   [ConfigurationType.OPTIONS]: {
     multlineWidth: '',
     ams: {
-      operatornamePattern: /^[-*a-zA-Z]+/, // multiLetterIdentifier for \operatorname
+      operatornamePattern: /^[-*a-zA-Z0-9]+/, // multiLetterIdentifier for \operatorname
       multlineWidth: '100%', // The width to use for multline environments.
       multlineIndent: '1em', // The margin to use on both sides of multline environments.
     },


### PR DESCRIPTION
Extend operatornamePattern to include `0-9`, so operators like `\operatorname{atan2}` are parsed as a single identifier.

Fixes mathjax/MathJax#2991

<br>

The bug first appeared in commit 2cd7f7cc, and was fixed in 7545df4c, which was later reverted in c8834c61.