### PR TITLE
Prevent circular dependency for tex extensions that load font extensions.

### DIFF
--- a/components/mjs/input/tex/extension.js
+++ b/components/mjs/input/tex/extension.js
@@ -7,7 +7,9 @@ export function fontExtension(id, name, pkg = `@mathjax/${name}`) {
     const path = name.replace(/-font-extension$/, '-extension');
     const jax = (MathJax.config?.startup?.output || 'chtml');
     combineDefaults(MathJax.config.loader, 'paths', {[path]: FONTPATH});
-    combineDefaults(MathJax.config.loader, 'dependencies', {[`[${path}]/${jax}`]: [`output/${jax}`]});
+    if (!MathJax._.output?.[jax]) {
+      combineDefaults(MathJax.config.loader, 'dependencies', {[`[${path}]/${jax}`]: [`output/${jax}`]});
+    }
     MathJax.loader.addPackageData(id, {
       extraLoads: [`[${path}]/${jax}`],
       rendererExtensions: [path]


### PR DESCRIPTION
This PR prevents a potential circular dependency when a tex extension that loads a font extension is loaded while the output jax is being loaded.  If the output jax is not yet loaded but requests the extension and the font-extension lists the output jax as a dependency, then both are waiting for the other to finish before they finish, and that means neither load will be marked as complete, and MathJax will wait forever.

The issue arose in [this post](https://groups.google.com/g/mathjax-dev/c/RhFkRkrOQ0Q) on the developer's list, and the first message gives an example of when that occurs.

The dependency is needed in other cases (like in the lab) when the extension may be loaded before the output jax has been loaded, so that it will wait until the output jax is loaded.