### PR TITLE
Fix spacing issues with \operatorname. (mathjax/MathJax#3448)

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -1182,6 +1182,8 @@ export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
       if (this.isEmbellished || base.isKind('mi')) {
         result = base.setTeXclass(prev);
         this.updateTeXclass(this.core());
+      } else if (base.isKind('TeXAtom')) {
+        this.texClass = base.texClass;
       } else {
         base.setTeXclass(null);
       }

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -359,13 +359,18 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         font: TexConstant.Variant.NORMAL,
         multiLetterIdentifiers: parser.options.ams.operatornamePattern,
         operatorLetters: true,
+        noAutoOP: true,
       },
       parser.configuration
     ).mml();
     //
-    //  If we get something other than a single mi, wrap in a TeXAtom.
+    //  If we get a single mi, remove the autoOp property
+    //  (it will get that automatically if more than one letter),
+    //  otherwise wrap the results in a TeXAtom.
     //
-    if (!mml.isKind('mi')) {
+    if (mml.isKind('mi')) {
+      mml.removeProperty('autoOP');
+    } else {
       mml = parser.create('node', 'TeXAtom', [mml]);
     }
     //


### PR DESCRIPTION
This PR fixes two problems with `\operatorname` involving spacing.  The first is that, when the operator name has more than one element (e.g., `\operatorname*{arg\,min}`), it doesn't get the `OP` TeX class, so the spacing around it isn't correct.  The other is that the pieces inside the operator name *do* get TeX class `OP` when they shouldn't.  The latter is due to the removal of `noAutoOP` in #989, which removed it.  That needs to be put back, and the problem handled in a different way.

The first issue above is handled in the `AbstractMmlBaseNode` class in `MmlNode.ts` below by transferring the base class to the `msubsup` element when the base is a TeXAtom (i.e., has a non-standard TeX class).

The second issue is resolved by replacing the `noAutpOP` flag, but removing the `autoOP` property from the result if it is a single `mi` (which will either get the `OP` class automatically if it is multi-letter, or will have the `data-mjx-texclass="OP"` attribute if it is a single letter).

Resolves issues mathjax/MathJax#3448, mathjax/MathJax#2991, and mathjax/MathJax#3369.