### PR TITLE
Allow cleanAttributes to work on nodes with no attributes (e.g., XML nodes)

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -187,6 +187,7 @@ const FilterUtil = {
     const node = arg.data.root;
     node.walkTree((mml: MmlNode, _d: any) => {
       const attribs = mml.attributes;
+      if (!attribs) return;
       const keep = new Set(
         ((attribs.get('mjx-keep-attrs') as string) || '').split(/ /)
       );


### PR DESCRIPTION
This PR allows the TeX input jax's `cleanAttributes()` filter to work with nodes that don't have attributes (like XML nodes).  Currently, it will crash with an error about not being able to call `get()` on an undefined value.