### PR TITLE
Fix vector arrow positioning for Safari

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -552,8 +552,9 @@ export class MmlMo extends AbstractMmlTokenNode {
       this.getProperty('mathaccent') !== undefined ||
       !parent ||
       !parent.isKind('munderover')
-    )
+    ) {
       return;
+    }
     const [base, under, over] = parent.childNodes;
     if (base.isEmbellished && base.coreMO() === this) return;
     const isUnder = !!(under && under.isEmbellished && under.coreMO() === this);

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -636,7 +636,7 @@ export class ChtmlFontData extends FontData<
     if (options.oc) {
       styles[selector + '[noic]'] = { 'padding-right': this.em(data[2]) };
     }
-    this.checkCombiningChar(options, styles[selector]);
+    this.checkCombiningChar(options, styles[selector] as StyleJsonData);
   }
 
   /**
@@ -656,6 +656,10 @@ export class ChtmlFontData extends FontData<
       pad.pop();
     }
     css.padding = pad.join(' ');
+    if (css.width === '0' && options.dx) {
+      css.width = this.em(2 * options.dx);
+      css['margin-left'] = '-' + css.width;
+    }
   }
 
   /***********************************************************************/


### PR DESCRIPTION
This PR fixes a problem with zero-width accents in Safari output in CHTML.  In the past, fonts made combining accents using 0-width characters that overlapped to the left, but modern browsers now handle combining characters themselves regardless of whether they are 0-width or not.  So browsers differ on how they handle combining characters, and in particular on how the zero-width characters are displayed.

For this reason, MathJax uses the spacing-modifier Unicode block rather than the Combining Diacritical Marks block whenever possible.  This works well for most cases, except there is no Spacing Modifier version of the vector arrow, U+20D7, so that has been a perennial problem for MathJax.  I thought I had taken care of this in v3, but either that was lost in changes for v4, or it was font-specific (I think it was the latter, where I made a full width vector arrow rather than a zero one in order to work around this problem).  With the new fonts, the vector arrow is no longer properly placed when viewed from Safari (but is for other browsers).  This is fixed in this PR by additional CSS that resolves the problem in Safari without damaging the position in other browsers (at least in the ones I've tested).

This fixes more than just the U+20D7, but also other combining diacriticals, like U+0303 and the other ones in the 0300 block, e.g.

``` html
<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
  <mover>
    <mi>x</mi>
    <mo stretchy="false" accent="true">&#x303;</mo>
  </mover>
</math>
```