### PR TITLE
Fix typo in menu.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -714,7 +714,7 @@ export class Menu {
               hidden: !MenuUtil.isMac,
             }),
             this.checkbox('Control', 'Control', 'ctrl', {
-              hiddne: MenuUtil.isMac,
+              hidden: MenuUtil.isMac,
             }),
             this.checkbox('Shift', 'Shift', 'shift'),
           ]),


### PR DESCRIPTION
This PR fixes a typo in the menu creation that failed to properly remove the CTRL option from the zoom settings.  (CTRL-clicking on a mac generates the contextual menu event, so shouldn't be overridden for zooming.)
