### PR TITLE
Add missing preLoaded() call for input/mml when a11y is used.

### DIFF
--- a/components/mjs/a11y/util.js
+++ b/components/mjs/a11y/util.js
@@ -9,5 +9,6 @@ Loader.preLoaded(
   'a11y/sre',
   'a11y/semantic-enrich',
   'a11y/speech',
-  'a11y/explorer'
+  'a11y/explorer',
+  'input/mml',
 );


### PR DESCRIPTION
The `semantic-enrich` extension has `input/mml` as a dependency (so that it can re-parse the SRE output), but it wasn't being listed in the preloaded items when the A11y utilities were being included in a combined component.  That means that loading `tex-chtml.js`, for example, and adding `input/mml` to the loaded items could cause the extension to be loaded a second time without sharing the common code, leading to problems with objects and options not being properly shared.