### PR TITLE
Update tests to improve coverage of some modules

### DIFF
--- a/testsuite/tests/input/tex/Bbm.test.ts
+++ b/testsuite/tests/input/tex/Bbm.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, beforeEach, describe, test } from '@jest/globals';
-import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { afterAll, beforeEach, describe, test, expect } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, setupComponents, tex2mml } from '#helpers';
 import '#js/input/tex/bbm/BbmConfiguration';
 
 /**********************************************************************************/
@@ -148,6 +148,20 @@ describe('Bbm', () => {
 
   /********************************************************************************/
 
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+declare const MathJax: any;
+
+setupComponents({loader: {load: ['input/tex-base', 'output/chtml']}});
+
+describe('Bbm', () => {
+
+  test('bbm with no output', async() => {
+    await expect(MathJax.loader.load('[tex]/bbm').then(() => true)).resolves.toBe(true);
+  });
 });
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/TagFormat.test.ts
+++ b/testsuite/tests/input/tex/TagFormat.test.ts
@@ -172,6 +172,88 @@ describe('Tagformat', () => {
 
   /********************************************************************************/
 
+  test('Array tag', () => {
+    setupTex(['base', 'ams', 'tagformat'], {
+      tagformat: {
+        tag: (tag: string) => ['|', tag, '|'],
+      },
+      tags: 'ams'
+    });
+    toXmlMatch(
+      tex2mml('x \\tag{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x \\tag{1}" display="block">
+         <mtable displaystyle="true" data-latex="x \\tag{1}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{|}">|</mtext>
+               <mtext data-latex="\\text{1}">1</mtext>
+               <mtext data-latex="\\text{|}">|</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{1}">x</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Array tag with empty entry', () => {
+    setupTex(['base', 'ams', 'tagformat'], {
+      tagformat: {
+        tag: (tag: string) => ['', tag, '.'],
+      },
+      tags: 'ams'
+    });
+    toXmlMatch(
+      tex2mml('x \\tag{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x \\tag{1}" display="block">
+         <mtable displaystyle="true" data-latex="x \\tag{1}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{1}">1</mtext>
+               <mtext data-latex="\\text{.}">.</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{1}">x</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Array tag with null entry', () => {
+    setupTex(['base', 'ams', 'tagformat'], {
+      tagformat: {
+        tag: (tag: string) => [ , tag, '.'],
+      },
+      tags: 'ams'
+    });
+    toXmlMatch(
+      tex2mml('x \\tag{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x \\tag{1}" display="block">
+         <mtable displaystyle="true" data-latex="x \\tag{1}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{1}">1</mtext>
+               <mtext data-latex="\\text{.}">.</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{1}">x</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
 /**********************************************************************************/

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -790,7 +790,7 @@ export class FnItem extends BaseItem {
       // @test Mathop Apply, Mathop No Apply
       if (
         top.isKind('TeXAtom') &&
-        top.childNodes[0]?.childNodes?.length === 0
+        top.childNodes[0].childNodes.length === 0
       ) {
         return [[top, item], true];
       }


### PR DESCRIPTION
Thus PR adds some tests to get more coverage of some of the recent changes.

It also adjusts `BaseItems.ts` to remove some unneeded `?`, as the TeXAtom gets an inferred mrow child automatically when created, so (unless someone deletes them explicitly), they will always be available.