### PR TITLE
Make the keep-attrs attribute into a property, since it is removed after use

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -179,13 +179,11 @@ const FilterUtil = {
    */
   cleanAttributes(arg: { data: ParseOptions }) {
     const node = arg.data.root;
-    node.walkTree((mml: MmlNode, _d: any) => {
-      const attribs = mml.attributes;
-      if (!attribs) return;
+    node.walkTree((mml: MmlNode) => {
       const keep = new Set(
-        ((attribs.get('mjx-keep-attrs') as string) || '').split(/ /)
+        ((mml.getProperty('keep-attrs') as string) || '').split(/ /)
       );
-      attribs.unset('mjx-keep-attrs');
+      const attribs = mml.attributes;
       for (const key of attribs.getExplicitNames()) {
         if (
           !keep.has(key) &&
@@ -194,7 +192,7 @@ const FilterUtil = {
           attribs.unset(key);
         }
       }
-    }, {});
+    });
   },
 
   /**

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1125,7 +1125,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       attr = attr.substring(match[0].length);
     }
     if (keep.length) {
-      def['mjx-keep-attrs'] = keep.join(' ');
+      node.setProperty('keep-attrs', keep.join(' '));
     }
     const textNode = parser.create('text', replaceUnicode(text));
     node.appendChild(textNode);


### PR DESCRIPTION
This PR changes the `mjx-keep-attrs` attribute into a property, since it is only used in the tex input phase, and doesn't need to be exposed as an explicit attribute.  It also removes the unused `_d` argument from the `walkTree()` call.