### PR TITLE
Use a default font size when it can't be computed directly. (mathjax/MathJax#3458)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -199,7 +199,6 @@ export class HTMLAdaptor<
   extends AbstractDOMAdaptor<N, T, D>
   implements MinHTMLAdaptor<N, T, D>
 {
-
   /**
    * The font size to use when it can't be measured (e.g., the element
    * isn't in the DOM).
@@ -597,7 +596,7 @@ export class HTMLAdaptor<
     const style = this.window.getComputedStyle(node);
     return parseFloat(
       style.fontSize ||
-      String((this.constructor as typeof HTMLAdaptor).DEFAULT_FONT_SIZE)
+        String((this.constructor as typeof HTMLAdaptor).DEFAULT_FONT_SIZE)
     );
   }
 


### PR DESCRIPTION
This PR adds a default font size for the situation where the font size can't be computed, e.g, when the DOM element is not in an active DOM, or when it has `display: none`, rather than returning `NaN`.

Resolves issue mathjax/MathJax#3458.