### PR TITLE
Prevent a disappearing stretchy arrow in CHTML. (mathjax/MathJax#3457)

### DIFF
--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -359,53 +359,64 @@ export function CommonMoMixin<
      * @override
      */
     public getStretchedVariant(WH: number[], exact: boolean = false) {
-      if (this.stretch.dir !== DIRECTION.None) {
-        let D = this.getWH(WH);
-        const min = this.getSize('minsize', 0);
-        const max = this.getSize('maxsize', Infinity);
-        const mathaccent = this.node.getProperty('mathaccent');
-        //
-        //  Clamp the dimension to the max and min
-        //  then get the target size via TeX rules
-        //
-        D = Math.max(min, Math.min(max, D));
-        const df = this.font.params.delimiterfactor / 1000;
-        const ds = this.font.params.delimitershortfall;
-        const m =
-          min || exact
-            ? D
-            : mathaccent
-              ? Math.min(D / df, D + ds)
-              : Math.max(D * df, D - ds);
-        //
-        //  Look through the delimiter sizes for one that matches
-        //
-        const delim = this.stretch;
-        const c = delim.c || this.getText().codePointAt(0);
-        let i = 0;
-        if (delim.sizes) {
-          for (const d of delim.sizes) {
-            if (d >= m) {
-              if (mathaccent && i) {
-                i--;
-              }
-              this.setDelimSize(c, i);
-              return;
+      if (this.stretch.dir === DIRECTION.None) {
+        return;
+      }
+      let D = this.getWH(WH);
+      const min = this.getSize('minsize', 0);
+      const max = this.getSize('maxsize', Infinity);
+      const mathaccent = this.node.getProperty('mathaccent');
+      //
+      //  Clamp the dimension to the max and min
+      //  then get the target size via TeX rules
+      //
+      D = Math.max(min, Math.min(max, D));
+      const df = this.font.params.delimiterfactor / 1000;
+      const ds = this.font.params.delimitershortfall;
+      const m =
+        min || exact
+          ? D
+          : mathaccent
+            ? Math.min(D / df, D + ds)
+            : Math.max(D * df, D - ds);
+      //
+      //  Get the delimiter character, and look up the
+      //  delimiter data again if we have already stretched it
+      //  (in case a fixed size set the delim.c).  See #3457.
+      //
+      const C = this.getText().codePointAt(0);
+      let delim = this.stretch;
+      if (this.size) {
+        this.stretch = delim = this.font.getDelimiter(C) as DD;
+        this.size = null;
+      }
+      const c = delim.c || C;
+      //
+      //  Look through the delimiter sizes for one that matches
+      //
+      let i = 0;
+      if (delim.sizes) {
+        for (const d of delim.sizes) {
+          if (d >= m) {
+            if (mathaccent && i) {
+              i--;
             }
-            i++;
+            this.setDelimSize(c, i);
+            return;
           }
+          i++;
         }
-        //
-        //  No size matches, so if we can make multi-character delimiters,
-        //  record the data for that, otherwise, use the largest fixed size.
-        //
-        if (delim.stretch) {
-          this.size = -1;
-          this.invalidateBBox();
-          this.getStretchBBox(WH, this.checkExtendedHeight(D, delim), delim);
-        } else {
-          this.setDelimSize(c, i - 1);
-        }
+      }
+      //
+      //  No size matches, so if we can make multi-character delimiters,
+      //  record the data for that, otherwise, use the largest fixed size.
+      //
+      if (delim.stretch) {
+        this.size = -1;
+        this.invalidateBBox();
+        this.getStretchBBox(WH, this.checkExtendedHeight(D, delim), delim);
+      } else {
+        this.setDelimSize(c, i - 1);
       }
     }
 


### PR DESCRIPTION
This PR fixes a problem with stretchy characters in CHTML where, if they were stretched once and produce a fixed-size version that has a different Unicode position, then are stretched again and need to use a multi-character assembly, then the stretch character would be invisible.  This was due to the fact that the since-character version will have set the `stretch.c` value to the single-size character, and that will be requested in the `mjx-stretchy-h` (or `v`) DOM elements, but the CSS added to the page will be fore the original Unicode character, so don't apply to the `mjx-stretchy-h` element.  Since that CSS creates the height and depth of the characters used, it will end up being 0 height, and the clipping for the assembly will end up making it invisible because of that.

The solution used here is, when the symbols is stretched, which check if it was already stretched to a fixed size, and then get a new copy of the stretchy data (without the unwanted `c` that was added before) and start stretching again.

I also reduced the indentation by returning early for the initial check (since you like that), so it may be easier to view the diffs with spacing differences hidden.

Resolves part of mathjax/MathJax#3457.