### PR TITLE
Make sure tagName exists before using it. (mathjax/MathJax#3461)

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -1461,6 +1461,7 @@ export class SpeechExplorer
         if (
           child !== this.speech &&
           child !== this.img &&
+          child.tagName &&
           child.tagName.toLowerCase() !== 'rect'
         ) {
           const { left, right, top, bottom } = child.getBoundingClientRect();


### PR DESCRIPTION
This PR fixes an error where clicking on the `mjx-break` element used to allow in-line line breaks causes an error from MathJax.  It was due to treating the `#text` child of the `mjx-break` element as an `HTMLElement` by assuming that it has a `tagName`.  The fix is to check that `tagName` exists before using it.

Resolves issue mathjax/MathJax#3461.