### PR TITLE
Add hidden option to retain regions and highlighting, as requested by Volker

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -459,8 +459,10 @@ export class SpeechExplorer
    */
   public FocusOut(_event: FocusEvent) {
     if (this.current && !this.focusSpeech) {
-      this.setCurrent(null);
-      this.Stop();
+      if (!this.document.options.keepRegions) {
+        this.setCurrent(null);
+        this.Stop();
+      }
       if (!document.hasFocus()) {
         this.focusTop();
       }


### PR DESCRIPTION
This adds an option that prevents the highlighting and speech/Braille regions from being removed when the expression loses focus, as requested by Volker.  You can use the developer's console to enter

``` js
MathJax.startup.document.options.keepRegions = true;
```

to set it.  I will see about adding a checkbox to the lab to make that easier.