### PR TITLE
Fix erroneous definition for --mjx-bg1-color.

### DIFF
--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -364,7 +364,7 @@ export class LiveRegion extends StringRegion {
       '--mjx-live-bg-color': 'white',
       '--mjx-live-shadow-color': '#888',
       '--mjx-live-border-color': '#CCCCCC',
-      '--mjx-bg1-color': 'rgba(var(--mjx-bg-blue), var(--mjx-bg-alpha))',
+      '--mjx-bg1-color': 'rgba(var(--mjx-bg-blue), var(--mjx-bg1-alpha))',
       '--mjx-fg1-color': 'rgba(var(--mjx-fg-black), 1)',
       '--mjx-bg2-color': 'rgba(var(--mjx-bg-red), 1)',
       '--mjx-fg2-color': 'rgba(var(--mjx-fg-black), 1)',


### PR DESCRIPTION
This PR fixes an incorrect CSS setting for the `--mjx-bg1-color`.  It is usually replaced when MathJax initializes itself, but the initial value should really be made correct anyway.