### PR TITLE
Fix isEmpty to work with partially complete `msubsup` elements with empty bases. (mathjax/MathJax#3532)

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -546,7 +546,7 @@ export abstract class AbstractMmlNode
    */
   public get isEmpty(): boolean {
     for (const child of this.childNodes) {
-      if (!child.isEmpty) return false;
+      if (child && !child.isEmpty) return false;
     }
     return true;
   }


### PR DESCRIPTION
This PR fixes an error with the `isEmpty` method introduced in v4.1.1.  Because superscript and subscripts are handled using an `msubsup` node with `null` entries until we know whether it will have both scripts, in the case where the base is empty, `isEmpty` would fail when trying to test these `null` children.  For, example `{}^2` will generate an error.  This PR fixes it by checking that the child is non-null before testing it.

It may be that this wants to be a 4.1.2 release, as this is not that unusual a construction, and it causes MathJax to crash.

Resolves issue mathjax/MathJax#3532.