### PR TITLE
moves thests in ConfigMacros to use snapshots

### DIFF
--- a/testsuite/src/xmlMatch.ts
+++ b/testsuite/src/xmlMatch.ts
@@ -24,7 +24,7 @@ expect.extend({
  * @param {string} received  The string received from the tests
  * @param {string} expected  The string expected to be produced by the tests
  */
-export function toXmlMatch(received: string, expected: string) {
+function toXmlMatch(received: string, expected: string) {
   // This is slightly awkward way of getting around ts-jest problems with custom
   // matcher extensions.
   (expect(received) as any).toBeXmlMatch(expected);

--- a/testsuite/tests/input/tex/ConfigMacros.test.ts
+++ b/testsuite/tests/input/tex/ConfigMacros.test.ts
@@ -1,17 +1,16 @@
-import { beforeEach, describe, it } from '@jest/globals';
-import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { setupTex, tex2mml } from '#helpers';
 import '#js/input/tex/configmacros/ConfigMacrosConfiguration';
 
 beforeEach(() => {});
 
 function runMacroTests(
   macros: {[key: string]: any},
-  expected: string,
   control: string,
   macro: string) {
   setupTex(['base', 'configmacros'], macros);
-  toXmlMatch(tex2mml(control), expected.replace('PH', control));
-  toXmlMatch(tex2mml(macro), expected.replace('PH', macro));
+  expect(tex2mml(control)).toMatchSnapshot();
+  expect(tex2mml(macro)).toMatchSnapshot();
 }
 
 /**********************************************************************************/
@@ -22,16 +21,7 @@ describe('Config Macros Active', () => {
   /********************************************************************************/
 
   it('Macros Simple', () => {
-    runMacroTests(
-      {active: {"@": "~"}},
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-         <mi data-latex="A">A</mi>
-         <mtext data-latex="~">&#xA0;</mtext>
-         <mi data-latex="a">a</mi>
-       </math>`,
-      'A~a',
-      'A@a'
-    );
+    runMacroTests({active: {"@": "~"}}, 'A~a', 'A@a');
   });
 
   /********************************************************************************/
@@ -46,16 +36,7 @@ describe('Config Macros Commands', () => {
   /********************************************************************************/
 
   it('Commands Simple', () => {
-    runMacroTests(
-      {macros: {"RR": "{\\bf R}"}},
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-         <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
-           <mi mathvariant="bold" data-latex="R">R</mi>
-         </mrow>
-      </math>`,
-      '{\\bf R}',
-      '\\RR'
-    );
+    runMacroTests({macros: {"RR": "{\\bf R}"}}, '{\\bf R}', '\\RR');
   });
 
   /********************************************************************************/
@@ -63,14 +44,6 @@ describe('Config Macros Commands', () => {
   it('Commands Argument', () => {
     runMacroTests(
       {macros: {"bold": ["{\\bf #1}", 1]}},
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-         <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
-           <mi mathvariant="bold" data-latex="b">b</mi>
-           <mi mathvariant="bold" data-latex="o">o</mi>
-           <mi mathvariant="bold" data-latex="l">l</mi>
-           <mi mathvariant="bold" data-latex="d">d</mi>
-         </mrow>
-       </math>`,
       '{\\bf bold}',
       '\\bold{bold}'
     );
@@ -81,21 +54,6 @@ describe('Config Macros Commands', () => {
   it('Commands Aux Argument', () => {
     runMacroTests(
       {macros: {"foo": ["\\mbox{first } #1 \\mbox{ second } #2", 2, ["[", "]"]]}},
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-         <mstyle displaystyle="false" data-latex="\\mbox{first }">
-           <mtext>first&#xA0;</mtext>
-         </mstyle>
-         <mi data-latex="h">h</mi>
-         <mi data-latex="i">i</mi>
-         <mstyle displaystyle="false" data-latex="\\mbox{ second }">
-           <mtext>&#xA0;second&#xA0;</mtext>
-         </mstyle>
-         <mi data-latex="t">t</mi>
-         <mi data-latex="h">h</mi>
-         <mi data-latex="e">e</mi>
-         <mi data-latex="r">r</mi>
-         <mi data-latex="e">e</mi>
-       </math>`,
       '\\mbox{first } hi \\mbox{ second } there',
       '\\foo[hi]{there}'
     );
@@ -115,11 +73,6 @@ describe('Config Macros Environment', () => {
   it('Environment Simple', () => {
     runMacroTests(
       {environments: {"myHeartEnv": ["\\heartsuit", "\\spadesuit"]}},
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{myHeartEnv}a\\end{myHeartEnv}" display="block">
-         <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
-         <mi data-latex="a">a</mi>
-         <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
-       </math>`,
       '\\begin{myHeartEnv}a\\end{myHeartEnv}',
       '\\begin{myHeartEnv}a\\end{myHeartEnv}'
     );

--- a/testsuite/tests/input/tex/__snapshots__/ConfigMacros.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/ConfigMacros.test.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Config Macros Active Macros Simple 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A~a" display="block">
+  <mi data-latex="A">A</mi>
+  <mtext data-latex="~">&#xA0;</mtext>
+  <mi data-latex="a">a</mi>
+</math>"
+`;
+
+exports[`Config Macros Active Macros Simple 2`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A@a" display="block">
+  <mi data-latex="A">A</mi>
+  <mtext data-latex="~">&#xA0;</mtext>
+  <mi data-latex="a">a</mi>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Argument 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\bf bold}" display="block">
+  <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
+    <mi mathvariant="bold" data-latex="b">b</mi>
+    <mi mathvariant="bold" data-latex="o">o</mi>
+    <mi mathvariant="bold" data-latex="l">l</mi>
+    <mi mathvariant="bold" data-latex="d">d</mi>
+  </mrow>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Argument 2`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bold{bold}" display="block">
+  <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
+    <mi mathvariant="bold" data-latex="b">b</mi>
+    <mi mathvariant="bold" data-latex="o">o</mi>
+    <mi mathvariant="bold" data-latex="l">l</mi>
+    <mi mathvariant="bold" data-latex="d">d</mi>
+  </mrow>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Aux Argument 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mbox{first } hi \\mbox{ second } there" display="block">
+  <mstyle displaystyle="false" data-latex="\\mbox{first }">
+    <mtext>first&#xA0;</mtext>
+  </mstyle>
+  <mi data-latex="h">h</mi>
+  <mi data-latex="i">i</mi>
+  <mstyle displaystyle="false" data-latex="\\mbox{ second }">
+    <mtext>&#xA0;second&#xA0;</mtext>
+  </mstyle>
+  <mi data-latex="t">t</mi>
+  <mi data-latex="h">h</mi>
+  <mi data-latex="e">e</mi>
+  <mi data-latex="r">r</mi>
+  <mi data-latex="e">e</mi>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Aux Argument 2`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\foo[hi]{there}" display="block">
+  <mstyle displaystyle="false" data-latex="\\mbox{first }">
+    <mtext>first&#xA0;</mtext>
+  </mstyle>
+  <mi data-latex="h">h</mi>
+  <mi data-latex="i">i</mi>
+  <mstyle displaystyle="false" data-latex="\\mbox{ second }">
+    <mtext>&#xA0;second&#xA0;</mtext>
+  </mstyle>
+  <mi data-latex="t">t</mi>
+  <mi data-latex="h">h</mi>
+  <mi data-latex="e">e</mi>
+  <mi data-latex="r">r</mi>
+  <mi data-latex="e">e</mi>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Simple 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\bf R}" display="block">
+  <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
+    <mi mathvariant="bold" data-latex="R">R</mi>
+  </mrow>
+</math>"
+`;
+
+exports[`Config Macros Commands Commands Simple 2`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\RR" display="block">
+  <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
+    <mi mathvariant="bold" data-latex="R">R</mi>
+  </mrow>
+</math>"
+`;
+
+exports[`Config Macros Environment Environment Simple 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{myHeartEnv}a\\end{myHeartEnv}" display="block">
+  <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
+  <mi data-latex="a">a</mi>
+  <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
+</math>"
+`;
+
+exports[`Config Macros Environment Environment Simple 2`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{myHeartEnv}a\\end{myHeartEnv}" display="block">
+  <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
+  <mi data-latex="a">a</mi>
+  <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
+</math>"
+`;


### PR DESCRIPTION
This PR removes the remaining occurrences of `toXmlMatches` from the `ConfigMacros.test.ts` file and handles those using snapshots.