### PR TITLE
Fix CSS for zero-width combining characters so it doesn't impact other variants.

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -630,13 +630,19 @@ export class ChtmlFontData extends FontData<
       options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
     const padding = options.oc || options.ic || 0;
-    styles[selector] = {
+    const css = {
       padding: this.padding(data, padding),
     } as StyleJsonData;
     if (options.oc) {
       styles[selector + '[noic]'] = { 'padding-right': this.em(data[2]) };
     }
-    this.checkCombiningChar(options, styles[selector] as StyleJsonData);
+    this.checkCombiningChar(options, css);
+    styles[
+      selector +
+        (css['margin-left'] && !font
+          ? `:not([class*="${this.cssFontPrefix}-"])`
+          : '')
+    ] = css;
   }
 
   /**


### PR DESCRIPTION
In some fonts, the combining characters are zero-width (so that they overlap the character on the left).  Others are normal width, and the browser positions the character automatically, at least win some browsers (not Safari).  MathJax has to accommodate both types of characters, and browsers that do and do not handle the normal width characters themselves.  It does this by setting `width` CSS for the zero-width characters so that they have the actual width of the ink of the character and `margin-left` to position it so it extends to the left.  This gives the character an actual width, but still places it as usual when not used as an accent.  But if there are other sizes of the character that are *not* zero-width, they will inherit the `margin-left` from the normal size, and so get placed incorrectly.

This happens with U+0332 (combining underline) in the `mathjax-newcm` font.  For example, the expression

``` html
<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
  <munder>
    <mi>&#x2202;</mi>
    <mo>&#x332;</mo>
  </munder>
  <munder>
    <mi>t</mi>
    <mo>&#x332;</mo>
  </munder>
</math>
```

currently produces output where the first underline is shifted to the left:

<img width="118" height="84" alt="underline misplaced" src="https://github.com/user-attachments/assets/6bcffde5-698c-48ce-9a9b-30aa7962f763" />

This is because the CSS for the normal size (used under the "t") has `margin-left`, while the first one (in a larger size) does not, but inherits the margin-left from the normal size when it shouldn't.

The solution used here is to isolate the normal size's CSS to not apply to other variants when it has `margin-left` set.  That is done by adding a `:not()` portion to the selector that rules out versions taken from other variants.