### PR TITLE
Fix backslash issues discovered during Linting 

### DIFF
--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -3448,7 +3448,7 @@ describe('Linebreaks', () => {
   });
 
   it('allowbreak cdot', () => {
-    expect(tex2mml('a\\allowbreak \cdot b')).toMatchSnapshot();
+    expect(tex2mml('a\\allowbreak \\cdot b')).toMatchSnapshot();
   });
 
   it('goodbreak', () => {

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -1542,7 +1542,7 @@ describe('Environment Errors', () => {
   });
 
   it('Template loop', () => {
-    expectTexError('\\begin{array}{r@{a\\\\b}l}a&b\\\end{array}').toBe(
+    expectTexError('\\begin{array}{r@{a\\\\b}l}a&b\\end{array}').toBe(
       'Maximum template substitutions exceeded; is there an invalid use of \\\\ in the template?'
     );
   });

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -197,7 +197,7 @@ describe('BussproofsRegProofs', () => {
   it('Proof Mixing Order', () => {
     expect(
       tex2mml(
-        '\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
+        '\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
       )
     ).toMatchSnapshot();
   });

--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -555,7 +555,7 @@ describe('Nested Environments', () => {
       tex2mml(
         [
           '\\newenvironment{boxed}{\\begin{array}{|c|c|}\\hline}{\\\\\\hline\\end{array}}',
-          '\\begin{boxed}\\begin{boxed}a&b\\\\c&d\\end{boxed} & X \\\end{boxed}',
+          '\\begin{boxed}\\begin{boxed}a&b\\\\c&d\\end{boxed} & X \\end{boxed}',
         ].join('')
       )
     ).toMatchSnapshot();

--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -4480,13 +4480,10 @@ exports[`Linebreaks allowbreak 1`] = `
 `;
 
 exports[`Linebreaks allowbreak cdot 1`] = `
-"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\allowbreak cdot b" display="block">
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\allowbreak \\cdot b" display="block">
   <mi data-latex="a">a</mi>
   <mspace data-latex="\\allowbreak"></mspace>
-  <mi data-latex="c">c</mi>
-  <mi data-latex="d">d</mi>
-  <mi data-latex="o">o</mi>
-  <mi data-latex="t">t</mi>
+  <mo data-latex="\\cdot">&#x22C5;</mo>
   <mi data-latex="b">b</mi>
 </math>"
 `;


### PR DESCRIPTION
* Removes three superfluous backslashes
* Adds one missing backslash, which alters the test output