### PR TITLE
Fix problem with sre.style being ignored.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1015,10 +1015,11 @@ export class Menu {
    */
   protected mergeUserSettings() {
     try {
-      const settings = localStorage.getItem(Menu.MENU_STORAGE);
-      if (!settings) return;
-      Object.assign(this.settings, JSON.parse(settings));
-      this.setA11y(this.settings);
+      const json = localStorage.getItem(Menu.MENU_STORAGE);
+      if (!json) return;
+      const settings = JSON.parse(json);
+      Object.assign(this.settings, settings);
+      this.setA11y(settings);
     } catch (err) {
       console.log('MathJax localStorage error: ' + err.message);
     }


### PR DESCRIPTION
Setting `options.sre.style` in the MathJax configuration ends up being ignored.  This is due to the fact that `mergeUserSettings()` is merging in all the default settings as well as any saved user settings, so that later when `applySettings()` is performed, the `settings.speechRules` will always be non-empty, so the `sre.domain` and `sre.style` are never applied.

The solution here is to only merge the saved user settings, not all of the defaults.

This can be tested using a fie like:

``` html
<!DOCTYPE html>
<html>
<head>
<meta content="width=device-width, initial-scale=1" name="viewport"/>
<meta charset="utf-8"/>
<title>Clearspeak Preferences</title>
<script>
MathJax = {
  options: {
    sre: {
      style: "TriangleSymbol_Delta:ImpliedTimes_MoreImpliedTimes"
    }
  }
};
</script>
<script defer src="[path-to-mathjax-src]/bundle/tex-chtml.js"></script>
</head>
<body>

$$\Delta x$$

</body>
</html>
```

and check to see that the speech for the expression uses "Delta" and includes "times".