### PR TITLE
Properly handle trailing spaces in \def. (mathjax/MathJax#3550)

### DIFF
--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -222,6 +222,21 @@ describe('Newcommand', () => {
       tex2mml('\\def\\x#1{\\def\\y##1#1{[##1]}\\y} \\x\\X abc \\X')
     ).toMatchSnapshot();
   });
+
+  it('Def insignificant spaces', () => {
+    expect(tex2mml('\\def\\x  #1  {[#1]} \\x{x}')).toMatchSnapshot();
+  });
+
+  it('Def significant spaces 1', () => {
+    expectTexError('\\def\\x#1 #2{[#1,#2]} \\x{a}{b}').toBe('Runaway argument for \\x?');
+    expect(tex2mml('\\def\\x#1 #2{[#1,#2]} \\x{a} {b}')).toMatchSnapshot();
+  });
+
+  it('Def significant spaces 2', () => {
+    expectTexError('\\def\\x#1 #2 {[#1,#2]} \\x{a}{b}').toBe('Runaway argument for \\x?');
+    expectTexError('\\def\\x#1 #2 {[#1,#2]} \\x{a} {b}').toBe('Runaway argument for \\x?');
+    expect(tex2mml('\\def\\x#1 #2{[#1,#2]} \\x{a} {b} ')).toMatchSnapshot();
+  });
 });
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/__snapshots__/Newcommand.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Newcommand.test.ts.snap
@@ -327,6 +327,34 @@ exports[`Newcommand Def Template Matching 1`] = `
 </math>"
 `;
 
+exports[`Newcommand Def insignificant spaces 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\x  #1  {[#1]} \\x{x}" display="block">
+  <mo data-latex="[" stretchy="false">[</mo>
+  <mi data-latex="x">x</mi>
+  <mo data-latex="]" stretchy="false">]</mo>
+</math>"
+`;
+
+exports[`Newcommand Def significant spaces 1 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\x#1 #2{[#1,#2]} \\x{a} {b}" display="block">
+  <mo data-latex="[" stretchy="false">[</mo>
+  <mi data-latex="a">a</mi>
+  <mo data-latex=",">,</mo>
+  <mi data-latex="b">b</mi>
+  <mo data-latex="]" stretchy="false">]</mo>
+</math>"
+`;
+
+exports[`Newcommand Def significant spaces 2 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\x#1 #2{[#1,#2]} \\x{a} {b} " display="block">
+  <mo data-latex="[" stretchy="false">[</mo>
+  <mi data-latex="a">a</mi>
+  <mo data-latex=",">,</mo>
+  <mi data-latex="b">b</mi>
+  <mo data-latex="]" stretchy="false">]</mo>
+</math>"
+`;
+
 exports[`Newcommand Let Angle Circular 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\lp\\langle\\let\\rp\\rangle\\let\\mp\\rp\\left\\lp \\frac{a}{b}\\middle\\mp c \\right\\rp" display="block">
   <mrow data-mjx-texclass="INNER" data-latex="\\let\\lp\\langle\\let\\rp\\rangle\\let\\mp\\rp\\left\\lp \\frac{a}{b}\\middle\\mp c \\right\\rp">

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -166,6 +166,9 @@ export const NewcommandUtil = {
           // @test Optional Brace Error
           // parser.i >= i!
           params[n] = parser.string.substring(i, parser.i);
+          if (params[n].replace(/^ +/, '') === '' && params.slice(0, n).join('') === '') {
+            return n;
+          }
         }
         if (params.length > 0) {
           // @test Def Let, Def Optional Brace


### PR DESCRIPTION
This PR fixes a problem with the `\def` command where trailing spaces are treated incorrectly as part of a template macro definition.  E.g.

``` latex
\def\x#1  {[#1]}
```

would include the space as part of a template, so `$$\x{y}$$` would fail (it would have to be `$$\x{y} $$`.  The trailing spaces should only be included in a template if there are other template entries like

``` latex
\def\x#1,#2 {[#1,#2]}
```

or 

``` latex
\def\x#1 #2 {[#1,#2]}
```

Resolves issue mathjax/MathJax#3550.
