### PR TITLE
Work around Safari bug with negative margins used in bussproofs.  (mathjax/MathJax#3547)

### DIFF
--- a/testsuite/tests/input/tex/__snapshots__/Bussproofs.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Bussproofs.test.ts.snap
@@ -616,8 +616,7 @@ exports[`BussproofsRegInf Unary Inference Abbr 1`] = `
 
 exports[`BussproofsRegProofs Extreme 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-    <mspace width="16.317em"></mspace>
+  <mrow style="margin-left: 16.317em" semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
     <mrow data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}">
       <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
         <mstyle displaystyle="false">
@@ -630,10 +629,8 @@ exports[`BussproofsRegProofs Extreme 1`] = `
             <mtable framespacing="0 0">
               <mtr>
                 <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
-                    <mspace width="-18.656em"></mspace>
-                    <mrow>
-                      <mspace width="3.94em"></mspace>
+                  <mrow style="margin-left: -18.656em" semantics="bspr_inference:2;bspr_labelledRule:both">
+                    <mrow style="margin-left: 3.94em">
                       <mrow data-latex="\\RightLabel{QERE}">
                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                           <mtext>WWW</mtext>
@@ -644,8 +641,7 @@ exports[`BussproofsRegProofs Extreme 1`] = `
                               <mtable framespacing="0 0">
                                 <mtr>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3;bspr_labelledRule:both">
-                                      <mspace width="-7.239em"></mspace>
+                                    <mrow style="margin-left: -7.239em" semantics="bspr_inference:3;bspr_labelledRule:both">
                                       <mrow data-latex="\\RightLabel{AAAA}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mtext>HHHHH</mtext>
@@ -700,7 +696,7 @@ exports[`BussproofsRegProofs Extreme 1`] = `
                                   </mtd>
                                   <mtd></mtd>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
+                                    <mrow style="margin-right: -7.925em" semantics="bspr_inference:2;bspr_labelledRule:both">
                                       <mrow data-latex="\\LL{WWW}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mtext>BBBB</mtext>
@@ -719,7 +715,7 @@ exports[`BussproofsRegProofs Extreme 1`] = `
                                                   </mtd>
                                                   <mtd></mtd>
                                                   <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
+                                                    <mrow style="margin-right: -3.216em" semantics="bspr_inference:2;bspr_labelledRule:both">
                                                       <mrow data-latex="\\RightLabel{MMM}">
                                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                                           <mtext>qqqq</mtext>
@@ -768,7 +764,6 @@ exports[`BussproofsRegProofs Extreme 1`] = `
                                                           <mtext>AAAA</mtext>
                                                         </mpadded>
                                                       </mrow>
-                                                      <mspace width="-3.216em"></mspace>
                                                     </mrow>
                                                   </mtd>
                                                 </mtr>
@@ -789,7 +784,6 @@ exports[`BussproofsRegProofs Extreme 1`] = `
                                           <mtext>MMM</mtext>
                                         </mpadded>
                                       </mrow>
-                                      <mspace width="-7.925em"></mspace>
                                     </mrow>
                                   </mtd>
                                 </mtr>
@@ -853,22 +847,18 @@ exports[`BussproofsRegProofs Extreme 1`] = `
 
 exports[`BussproofsRegProofs Proof Complex 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-    <mrow>
-      <mspace width="13.25em"></mspace>
-      <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}">
-        <mspace width="-1.155em"></mspace>
+  <mrow style="margin-right: 2.953em" semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+    <mrow style="margin-left: 13.25em">
+      <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" style="margin-left: -1.155em">
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
               <mtable framespacing="0 0">
                 <mtr>
                   <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                      <mrow>
-                        <mspace width="-13.25em"></mspace>
-                        <mrow>
-                          <mspace width="9.111em"></mspace>
+                    <mrow style="margin-right: -5.456em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                      <mrow style="margin-left: -13.25em">
+                        <mrow style="margin-left: 9.111em">
                           <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -876,10 +866,8 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
                                   <mtable framespacing="0 0">
                                     <mtr>
                                       <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.111em"></mspace>
-                                          <mrow>
-                                            <mspace width="3.592em"></mspace>
+                                        <mrow style="margin-left: -9.111em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                                          <mrow style="margin-left: 3.592em">
                                             <mrow data-latex="\\BIC{$R$}">
                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                 <mtr>
@@ -887,8 +875,7 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
                                                     <mtable framespacing="0 0">
                                                       <mtr>
                                                         <mtd rowalign="bottom">
-                                                          <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.592em"></mspace>
+                                                          <mrow style="margin-left: -3.592em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                                             <mrow data-latex="\\BIC{$Q^2$}">
                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                                 <mtr>
@@ -1019,7 +1006,7 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
                                       </mtd>
                                       <mtd></mtd>
                                       <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                        <mrow style="margin-right: -2.055em" semantics="bspr_inference:1;bspr_labelledRule:right">
                                           <mrow data-latex="\\RL{$\\wedge_I$}">
                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
@@ -1063,7 +1050,6 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
                                               </mstyle>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width="-2.055em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1095,7 +1081,6 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
                           </mrow>
                         </mrow>
                       </mrow>
-                      <mspace width="-5.456em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -1135,29 +1120,24 @@ exports[`BussproofsRegProofs Proof Complex 1`] = `
         </mpadded>
       </mrow>
     </mrow>
-    <mspace width="2.953em"></mspace>
   </mrow>
 </math>"
 `;
 
 exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-    <mrow>
-      <mspace width="13.25em"></mspace>
-      <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}">
-        <mspace width="-1.155em"></mspace>
+  <mrow style="margin-right: 2.953em" semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+    <mrow style="margin-left: 13.25em">
+      <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" style="margin-left: -1.155em">
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
               <mtable framespacing="0 0">
                 <mtr>
                   <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                      <mrow>
-                        <mspace width="-13.25em"></mspace>
-                        <mrow>
-                          <mspace width="9.111em"></mspace>
+                    <mrow style="margin-right: -5.456em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                      <mrow style="margin-left: -13.25em">
+                        <mrow style="margin-left: 9.111em">
                           <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -1165,10 +1145,8 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
                                   <mtable framespacing="0 0">
                                     <mtr>
                                       <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.111em"></mspace>
-                                          <mrow>
-                                            <mspace width="3.592em"></mspace>
+                                        <mrow style="margin-left: -9.111em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                                          <mrow style="margin-left: 3.592em">
                                             <mrow data-latex="\\BIC{$R$}">
                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                 <mtr>
@@ -1176,8 +1154,7 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
                                                     <mtable framespacing="0 0">
                                                       <mtr>
                                                         <mtd rowalign="bottom">
-                                                          <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.592em"></mspace>
+                                                          <mrow style="margin-left: -3.592em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                                             <mrow data-latex="\\alwaysRootAtBottom">
                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
                                                                 <mtr>
@@ -1308,7 +1285,7 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
                                       </mtd>
                                       <mtd></mtd>
                                       <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                        <mrow style="margin-right: -2.055em" semantics="bspr_inference:1;bspr_labelledRule:right">
                                           <mrow data-latex="\\RL{$\\wedge_I$}">
                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
@@ -1352,7 +1329,6 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
                                               </mstyle>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width="-2.055em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1384,7 +1360,6 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
                           </mrow>
                         </mrow>
                       </mrow>
-                      <mspace width="-5.456em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -1424,25 +1399,21 @@ exports[`BussproofsRegProofs Proof Mixing Order 1`] = `
         </mpadded>
       </mrow>
     </mrow>
-    <mspace width="2.953em"></mspace>
   </mrow>
 </math>"
 `;
 
 exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
-    <mspace width="9.835em"></mspace>
+  <mrow style="margin-left: 9.835em; margin-right: 3.091em" semantics="bspr_inference:2;bspr_proof:true">
     <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" semantics="bspr_inferenceRule:down">
       <mtr>
         <mtd>
           <mtable framespacing="0 0">
             <mtr>
               <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                  <mspace width="-9.835em"></mspace>
-                  <mrow>
-                    <mspace width="3.274em"></mspace>
+                <mrow style="margin-left: -9.835em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                  <mrow style="margin-left: 3.274em">
                     <mrow data-latex="\\RightLabel{QERE}">
                       <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                         <mtr>
@@ -1450,8 +1421,7 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                             <mtable framespacing="0 0">
                               <mtr>
                                 <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:3;bspr_labelledRule:right">
-                                    <mspace width="-3.274em"></mspace>
+                                  <mrow style="margin-left: -3.274em" semantics="bspr_inference:3;bspr_labelledRule:right">
                                     <mrow data-latex="\\RightLabel{Nowhere}">
                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                         <mtr>
@@ -1503,7 +1473,7 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                 </mtd>
                                 <mtd></mtd>
                                 <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                  <mrow style="margin-right: -6.135em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                     <mrow data-latex="\\RightLabel{CCCCC}">
                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                         <mtr>
@@ -1519,7 +1489,7 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                                 </mtd>
                                                 <mtd></mtd>
                                                 <mtd rowalign="bottom">
-                                                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                  <mrow style="margin-right: -4.023em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                                     <mrow data-latex="\\RightLabel{BBB}">
                                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                         <mtr>
@@ -1565,7 +1535,6 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                                         <mtext>Nowhere</mtext>
                                                       </mpadded>
                                                     </mrow>
-                                                    <mspace width="-4.023em"></mspace>
                                                   </mrow>
                                                 </mtd>
                                               </mtr>
@@ -1586,7 +1555,6 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                         <mtext>BBB</mtext>
                                       </mpadded>
                                     </mrow>
-                                    <mspace width="-6.135em"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
@@ -1626,7 +1594,7 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                   <mtable framespacing="0 0">
                                     <mtr>
                                       <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                        <mrow style="margin-right: -3.092em" semantics="bspr_inference:1;bspr_labelledRule:right">
                                           <mrow data-latex="\\UnaryInfC{More and more}">
                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
@@ -1658,7 +1626,6 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
                                               <mtext>QERE</mtext>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width="-3.092em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1709,14 +1676,13 @@ exports[`BussproofsRegProofs Proof Very Right Label 1`] = `
         </mtd>
       </mtr>
     </mtable>
-    <mspace width="3.091em"></mspace>
   </mrow>
 </math>"
 `;
 
 exports[`BussproofsRegProofs Simple Proof 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
+  <mrow style="margin-right: 3.795em" semantics="bspr_inference:2;bspr_proof:true">
     <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_inferenceRule:down">
       <mtr>
         <mtd>
@@ -1731,7 +1697,7 @@ exports[`BussproofsRegProofs Simple Proof 1`] = `
               </mtd>
               <mtd></mtd>
               <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
+                <mrow style="margin-right: -3.795em" semantics="bspr_inference:2">
                   <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                     <mtr>
                       <mtd>
@@ -1801,7 +1767,6 @@ exports[`BussproofsRegProofs Simple Proof 1`] = `
                       </mtd>
                     </mtr>
                   </mtable>
-                  <mspace width="-3.795em"></mspace>
                 </mrow>
               </mtd>
             </mtr>
@@ -1818,31 +1783,27 @@ exports[`BussproofsRegProofs Simple Proof 1`] = `
         </mtd>
       </mtr>
     </mtable>
-    <mspace width="3.795em"></mspace>
   </mrow>
 </math>"
 `;
 
 exports[`BussproofsRegProofs Simple Proof Large 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
-    <mspace width="8.227em"></mspace>
+  <mrow style="margin-left: 4.953em" semantics="bspr_inference:2;bspr_proof:true">
     <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" semantics="bspr_inferenceRule:down">
       <mtr>
         <mtd>
           <mtable framespacing="0 0">
             <mtr>
               <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
-                  <mspace width="-4.953em"></mspace>
+                <mrow style="margin-left: -1.679em" semantics="bspr_inference:2">
                   <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down">
                     <mtr>
                       <mtd>
                         <mtable framespacing="0 0">
                           <mtr>
                             <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:3">
-                                <mspace width="-3.274em"></mspace>
+                              <mrow style="margin-left: -3.274em" semantics="bspr_inference:3">
                                 <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\TrinaryInfC{Q}" semantics="bspr_inferenceRule:down">
                                   <mtr>
                                     <mtd>
@@ -1889,7 +1850,7 @@ exports[`BussproofsRegProofs Simple Proof Large 1`] = `
                             </mtd>
                             <mtd></mtd>
                             <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:2">
+                              <mrow style="margin-right: -3.795em" semantics="bspr_inference:2">
                                 <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                                   <mtr>
                                     <mtd>
@@ -1959,7 +1920,6 @@ exports[`BussproofsRegProofs Simple Proof Large 1`] = `
                                     </mtd>
                                   </mtr>
                                 </mtable>
-                                <mspace width="-3.795em"></mspace>
                               </mrow>
                             </mtd>
                           </mtr>
@@ -2012,7 +1972,7 @@ exports[`BussproofsRegProofs Simple Proof Large 1`] = `
 
 exports[`BussproofsRegProofs Simple Proof Noise 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_proof:true">
+  <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" style="margin-right: 3.795em" semantics="bspr_proof:true">
     <mo>$</mo>
     <mi>&#x3B1;</mi>
     <mo>$</mo>
@@ -2030,7 +1990,7 @@ exports[`BussproofsRegProofs Simple Proof Noise 1`] = `
               </mtd>
               <mtd></mtd>
               <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
+                <mrow style="margin-right: -3.795em" semantics="bspr_inference:2">
                   <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                     <mtr>
                       <mtd>
@@ -2100,7 +2060,6 @@ exports[`BussproofsRegProofs Simple Proof Noise 1`] = `
                       </mtd>
                     </mtr>
                   </mtable>
-                  <mspace width="-3.795em"></mspace>
                 </mrow>
               </mtd>
             </mtr>
@@ -2117,15 +2076,13 @@ exports[`BussproofsRegProofs Simple Proof Noise 1`] = `
         </mtd>
       </mtr>
     </mtable>
-    <mspace width="3.795em"></mspace>
   </mrow>
 </math>"
 `;
 
 exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
-    <mspace width="3.835em"></mspace>
+  <mrow style="margin-left: 7.109em" semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
     <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}">
       <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
         <mstyle displaystyle="false">
@@ -2138,12 +2095,9 @@ exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
             <mtable framespacing="0 0">
               <mtr>
                 <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                    <mspace width="-6.927em"></mspace>
-                    <mrow>
-                      <mspace width="-0.551em"></mspace>
-                      <mrow data-latex="\\LeftLabel{QERE}">
-                        <mspace width="0.551em"></mspace>
+                  <mrow style="margin-left: -10.201em" semantics="bspr_inference:2;bspr_labelledRule:left">
+                    <mrow style="margin-left: -0.551em">
+                      <mrow data-latex="\\LeftLabel{QERE}" style="margin-left: 0.551em">
                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                           <mtext>CCCCC</mtext>
                         </mpadded>
@@ -2153,8 +2107,7 @@ exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
                               <mtable framespacing="0 0">
                                 <mtr>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
+                                    <mrow style="margin-left: -3.274em" semantics="bspr_inference:3">
                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\LeftLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                         <mtr>
                                           <mtd>
@@ -2201,7 +2154,7 @@ exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
                                   </mtd>
                                   <mtd></mtd>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                    <mrow style="margin-right: -5.403em" semantics="bspr_inference:2;bspr_labelledRule:left">
                                       <mrow data-latex="\\LeftLabel{CCCCC}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mtext>BBB</mtext>
@@ -2281,7 +2234,6 @@ exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
                                           </mtr>
                                         </mtable>
                                       </mrow>
-                                      <mspace width="-5.403em"></mspace>
                                     </mrow>
                                   </mtd>
                                 </mtr>
@@ -2337,8 +2289,7 @@ exports[`BussproofsRegProofs Simple Proofs Left Labels 1`] = `
 
 exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-    <mspace width="4.379em"></mspace>
+  <mrow style="margin-left: 7.653em" semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
     <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}">
       <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
         <mstyle displaystyle="false">
@@ -2351,12 +2302,9 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
             <mtable framespacing="0 0">
               <mtr>
                 <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                    <mspace width="-6.123em"></mspace>
-                    <mrow>
-                      <mspace width="-0.551em"></mspace>
-                      <mrow data-latex="\\LeftLabel{DD}">
-                        <mspace width="0.551em"></mspace>
+                  <mrow style="margin-left: -9.397em" semantics="bspr_inference:2;bspr_labelledRule:left">
+                    <mrow style="margin-left: -0.551em">
+                      <mrow data-latex="\\LeftLabel{DD}" style="margin-left: 0.551em">
                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                           <mtext>CCCCC</mtext>
                         </mpadded>
@@ -2366,8 +2314,7 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
                               <mtable framespacing="0 0">
                                 <mtr>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
+                                    <mrow style="margin-left: -3.274em" semantics="bspr_inference:3">
                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                         <mtr>
                                           <mtd>
@@ -2414,7 +2361,7 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
                                   </mtd>
                                   <mtd></mtd>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                    <mrow style="margin-right: -3.795em" semantics="bspr_inference:2;bspr_labelledRule:left">
                                       <mrow data-latex="\\LeftLabel{CCCCC}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mtext>BBB</mtext>
@@ -2433,7 +2380,7 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
                                                   </mtd>
                                                   <mtd></mtd>
                                                   <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                    <mrow style="margin-right: -3.216em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                                       <mrow data-latex="\\LeftLabel{BBB}">
                                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                           <mtr>
@@ -2479,7 +2426,6 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
                                                           <mtext>AAAA</mtext>
                                                         </mpadded>
                                                       </mrow>
-                                                      <mspace width="-3.216em"></mspace>
                                                     </mrow>
                                                   </mtd>
                                                 </mtr>
@@ -2497,7 +2443,6 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
                                           </mtr>
                                         </mtable>
                                       </mrow>
-                                      <mspace width="-3.795em"></mspace>
                                     </mrow>
                                   </mtd>
                                 </mtr>
@@ -2558,8 +2503,7 @@ exports[`BussproofsRegProofs Simple Proofs Mixed Labels 1`] = `
 
 exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
-    <mspace width="8.227em"></mspace>
+  <mrow style="margin-left: 8.227em" semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
     <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}">
       <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
         <mtr>
@@ -2567,10 +2511,8 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
             <mtable framespacing="0 0">
               <mtr>
                 <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                    <mspace width="-8.227em"></mspace>
-                    <mrow>
-                      <mspace width="3.274em"></mspace>
+                  <mrow style="margin-left: -8.227em" semantics="bspr_inference:2;bspr_labelledRule:right">
+                    <mrow style="margin-left: 3.274em">
                       <mrow data-latex="\\RightLabel{QERE}">
                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                           <mtr>
@@ -2578,8 +2520,7 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
                               <mtable framespacing="0 0">
                                 <mtr>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
+                                    <mrow style="margin-left: -3.274em" semantics="bspr_inference:3">
                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                         <mtr>
                                           <mtd>
@@ -2626,7 +2567,7 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
                                   </mtd>
                                   <mtd></mtd>
                                   <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                    <mrow style="margin-right: -6.134em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                       <mrow data-latex="\\RightLabel{CCCCC}">
                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                           <mtr>
@@ -2642,7 +2583,7 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
                                                   </mtd>
                                                   <mtd></mtd>
                                                   <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                    <mrow style="margin-right: -3.216em" semantics="bspr_inference:2;bspr_labelledRule:right">
                                                       <mrow data-latex="\\RightLabel{BBB}">
                                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                           <mtr>
@@ -2688,7 +2629,6 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
                                                           <mtext>AAAA</mtext>
                                                         </mpadded>
                                                       </mrow>
-                                                      <mspace width="-3.216em"></mspace>
                                                     </mrow>
                                                   </mtd>
                                                 </mtr>
@@ -2709,7 +2649,6 @@ exports[`BussproofsRegProofs Simple Proofs Right Labels 1`] = `
                                           <mtext>BBB</mtext>
                                         </mpadded>
                                       </mrow>
-                                      <mspace width="-6.134em"></mspace>
                                     </mrow>
                                   </mtd>
                                 </mtr>

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -52,7 +52,7 @@ let item: MATHITEM = null;
  * @param {MmlNode} node The target node.
  * @returns {number} Width of the proof node.
  */
-const getBBox = function (node: MmlNode) {
+const getBBox = function (node: MmlNode): number {
   item.root = node;
   const { w: width } = (doc.outputJax as any).getBBox(item, doc);
   return width;
@@ -190,8 +190,8 @@ const getParentInf = function (inf: MmlNode): MmlNode {
   return inf;
 };
 
-// Computes bbox spaces
 //
+// Computes bbox spaces
 //
 
 /**
@@ -214,6 +214,8 @@ const getSpaces = function (
     return result;
   }
   if (inf !== rule.parent) {
+    result +=
+      (inf.getProperty(right ? 'proof-right' : 'proof-left') as number) || 0;
     const children = inf.childNodes;
     const index = right ? children.length - 1 : 0;
     if (NodeUtil.isType(children[index], 'mspace')) {
@@ -278,29 +280,16 @@ const addSpace = function (
     moveProperties(inf, mrow);
     inf = mrow;
   }
-  // TODO: Simplify below as we now have a definite mrow.
-  const index = right ? inf.childNodes.length - 1 : 0;
-  let mspace = inf.childNodes[index];
-  if (NodeUtil.isType(mspace, 'mspace')) {
-    NodeUtil.setAttribute(
-      mspace,
-      'width',
-      UnitUtil.em(
-        UnitUtil.dimen2em(NodeUtil.getAttribute(mspace, 'width') as string) +
-          space
-      )
-    );
-    return;
+  const prop = right ? 'proof-right' : 'proof-left';
+  inf.setProperty(prop, ((inf.getProperty(prop) as number) || 0) + space);
+  const styles = [];
+  for (const side of ['left', 'right']) {
+    const margin = inf.getProperty(`proof-${side}`) as number;
+    if (margin) {
+      styles.push(`margin-${side}: ${UnitUtil.em(margin)}`);
+    }
   }
-  mspace = config.nodeFactory.create('node', 'mspace', [], {
-    width: UnitUtil.em(space),
-  });
-  if (right) {
-    inf.appendChild(mspace);
-    return;
-  }
-  mspace.parent = inf;
-  inf.childNodes.unshift(mspace);
+  inf.attributes.set('style', styles.join('; '));
 };
 
 /**

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -216,11 +216,6 @@ const getSpaces = function (
   if (inf !== rule.parent) {
     result +=
       (inf.getProperty(right ? 'proof-right' : 'proof-left') as number) || 0;
-    const children = inf.childNodes;
-    const index = right ? children.length - 1 : 0;
-    if (NodeUtil.isType(children[index], 'mspace')) {
-      result += getBBox(children[index]);
-    }
     inf = rule.parent;
   }
   if (inf === rule) {


### PR DESCRIPTION
This PR works around a bug in Safari that causes the negative spacing at the right-hand side of bussproof layouts to be ignored when computing the widths of the parent element.  This does away with the `mspace` elements at the left and right of the layouts and uses `margin-left` and `margin-right` CSS attributes instead.  I have resisted using CSS in this way in the past, trying to keep everything in MathML directly, but could not find another solution that worked in all browsers.

Resolves issue mathjax/MathJax#3547.