### PR TITLE
Update assistive-mml to mark all child elements as aria-hidden.  (mathjax/MathJax#3555)

### DIFF
--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -136,11 +136,9 @@ export function AssistiveMmlMathItemMixin<
         // Hide the typeset math from assistive technology and append the MathML that is visually
         //   hidden from other users
         //
-        adaptor.setAttribute(
-          adaptor.firstChild(this.typesetRoot) as N,
-          'aria-hidden',
-          'true'
-        );
+        for (const child of adaptor.childNodes(this.typesetRoot) as N[]) {
+          adaptor.setAttribute(child, 'aria-hidden', 'true');
+        }
         adaptor.setStyle(this.typesetRoot, 'position', 'relative');
         adaptor.append(this.typesetRoot, node);
       }


### PR DESCRIPTION
This PR fixes a problem with the `assistive-mml` extension when in-line breaks occur in SVG output.  The extension was only marking the first child SVG as `aria-hidden`, but in-line breaks can cause multiple SVG and `mjx-break` elements, and the second an subsequent ones are not being hidden.

The fix is easy:  loop through all the children instead of just the first one.

Resolves issue mathjax/MathJax#3555.