### PR TITLE
Update www.mathjax.org link target to be a new tab.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -348,7 +348,7 @@ export class Menu {
       extraNodes: [
         this.document.adaptor.node(
           'a',
-          { href: 'https://www.mathjax.org', 'data-drag': 'false' },
+          { href: 'https://www.mathjax.org', 'data-drag': 'false', target: '_blank'},
           [this.document.adaptor.text('https://www.mathjax.org')]
         ),
       ],

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -348,7 +348,11 @@ export class Menu {
       extraNodes: [
         this.document.adaptor.node(
           'a',
-          { href: 'https://www.mathjax.org', 'data-drag': 'false', target: '_blank'},
+          {
+            href: 'https://www.mathjax.org',
+            'data-drag': 'false',
+            target: '_blank',
+          },
           [this.document.adaptor.text('https://www.mathjax.org')]
         ),
       ],


### PR DESCRIPTION
This PR makes the link to mathjax.org from the About MathJax dialog box open a new tab for the link, as requested by IEEE.