### PR TITLE
Add localization for mhchem error messages.

### DIFF
--- a/components/mjs/input/tex/extensions/mhchem/config.json
+++ b/components/mjs/input/tex/extensions/mhchem/config.json
@@ -5,6 +5,12 @@
     "targets": ["input/tex/mhchem"],
     "excludeSubdirs": true
   },
+  "copy": {
+    "to": "[bundle]/input/tex/extensions/mhchem",
+    "from": "[ts]/input/tex/mhchem",
+    "copy": ["__locales__"],
+    "excludes": ["__locales__/Component.ts"]
+  },
   "webpack": {
     "name": "input/tex/extensions/mhchem",
     "libs": [

--- a/testsuite/tests/input/tex/Mhchem.test.ts
+++ b/testsuite/tests/input/tex/Mhchem.test.ts
@@ -486,8 +486,12 @@ describe('Mhchem-Ams', () => {
     ).toMatchSnapshot();
   });
 
-  it('Mhchem Error', () => {
+  it('Mhchem Bond Error', () => {
     expectTexError('\\ce{A\\bond{x}B}').toBe('mhchem bug T. Please report.');
+  });
+
+  it('Mhchem Brace Error', () => {
+    expectTexError('\\ce{{x^${x}}}').toBe('Extra close brace or missing open brace');
   });
 
   it('Mhchem stretchy <-', () => {

--- a/ts/input/tex/mhchem/MhchemConfiguration.ts
+++ b/ts/input/tex/mhchem/MhchemConfiguration.ts
@@ -32,6 +32,8 @@ import BaseMethods from '../base/BaseMethods.js';
 import { AmsMethods } from '../ams/AmsMethods.js';
 import { mhchemParser } from '#mhchem/mhchemParser.js';
 import { TEXCLASS } from '../../../core/MmlTree/MmlNode.js';
+import { COMPONENT } from './__locales__/Component.js';
+export { COMPONENT };
 
 /**
  * Creates mo token elements with the proper attributes
@@ -104,8 +106,20 @@ export const MhchemMethods: { [key: string]: ParseMethod } = {
       for (const [name, pattern] of MhchemReplacements.entries()) {
         tex = tex.replace(pattern, name as string);
       }
-    } catch (err) {
-      throw new TexError(null, err[0], err[1]);
+    } catch ([id, msg]) {
+      if (id === 'MhchemErrorBond') {
+        const match = msg.match(/\((.*)\)/);
+        throw new TexError(COMPONENT, id, match[1]);
+      }
+      if (id.startsWith('MhchemBug')) {
+        const match = msg.match(/mhchem bug (.).*\((.*)\)/);
+        if (match) {
+          throw new TexError(COMPONENT, 'MhchemBug2', match[1], match[2]);
+        } else {
+          throw new TexError(COMPONENT, 'MhchemBug', id.charAt(9));
+        }
+      }
+      throw new TexError('[tex]/base', id);
     }
     parser.string = tex + parser.string.substring(parser.i);
     parser.i = 0;

--- a/ts/input/tex/mhchem/MhchemConfiguration.ts
+++ b/ts/input/tex/mhchem/MhchemConfiguration.ts
@@ -119,7 +119,7 @@ export const MhchemMethods: { [key: string]: ParseMethod } = {
           throw new TexError(COMPONENT, 'MhchemBug', id.charAt(9));
         }
       }
-      throw new TexError('[tex]/base', id);
+      throw new TexError('input/tex', id);
     }
     parser.string = tex + parser.string.substring(parser.i);
     parser.i = 0;

--- a/ts/input/tex/mhchem/__locales__/Component.ts
+++ b/ts/input/tex/mhchem/__locales__/Component.ts
@@ -1,0 +1,28 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2026 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @file  Locale component registration for [tex]/mhchem
+ *
+ * @author dpvc@mathjax.org (Davide P. Cervone)
+ */
+
+import { Locale } from '../../../../util/Locale.js';
+
+export const COMPONENT = '[tex]/mhchem';
+
+Locale.registerLocaleFiles(COMPONENT, '../ts/input/tex/bbox');

--- a/ts/input/tex/mhchem/__locales__/Component.ts
+++ b/ts/input/tex/mhchem/__locales__/Component.ts
@@ -25,4 +25,4 @@ import { Locale } from '../../../../util/Locale.js';
 
 export const COMPONENT = '[tex]/mhchem';
 
-Locale.registerLocaleFiles(COMPONENT, '../ts/input/tex/mhchem);
+Locale.registerLocaleFiles(COMPONENT, '../ts/input/tex/mhchem');

--- a/ts/input/tex/mhchem/__locales__/Component.ts
+++ b/ts/input/tex/mhchem/__locales__/Component.ts
@@ -25,4 +25,4 @@ import { Locale } from '../../../../util/Locale.js';
 
 export const COMPONENT = '[tex]/mhchem';
 
-Locale.registerLocaleFiles(COMPONENT, '../ts/input/tex/bbox');
+Locale.registerLocaleFiles(COMPONENT, '../ts/input/tex/mhchem);

--- a/ts/input/tex/mhchem/__locales__/de.json
+++ b/ts/input/tex/mhchem/__locales__/de.json
@@ -1,0 +1,5 @@
+{
+  "MhchemBug": "mhchem-Fehler %1. Bitte melden.",
+  "MhchemBug2": "mhchem-Fehler %1. Bitte melden. (%2)",
+  "MhchemErrorBond": "mhchem-Fehler. Unbekannter Bindungstyp (%1)"
+}

--- a/ts/input/tex/mhchem/__locales__/en.json
+++ b/ts/input/tex/mhchem/__locales__/en.json
@@ -1,0 +1,5 @@
+{
+  "MhchemBug": "mhchem bug %1. Please report.",
+  "MhchemBug2": "mhchem bug %1. Please report. (%2)",
+  "MhchemErrorBond": "mhchem Error. Unknown bond type (%1)"
+}


### PR DESCRIPTION
This PR adds localization for the `mhchem` package, for both English and German.  It uses the error id and message thrown by the mhchem parser and translates them into the format needed for the new localized `TeXError` object.  Some of the messages have data inserted into the message strings that has to be extracted to be used as a parameter to `TexError`, and one of the messages is re-using the `[tex]/base` message `Extra close brace or missing open brace`.

I've updated the test file for mhchem, but have not been able to get full coverage.  The bond error message actually can never be produced, but I've included it in case the mhchem parser ever changes to permit it.  I wasn't able to generate one of the two-parameter bug messages (they seem to be for actual bug conditions, so may not be producible).  So the coverage for mhchem is not as complete as it was.

Note that if you add

``` js
    json: (file) => import(
      file.replace('/bundle/input/tex/extensions/', '/ts/input/tex/'),
      {with: {type: 'json'}}
    ),
```

to the `lib/v4-lab.js` file in the MathJax configuration's `loader` block (just after `require: ...` for example), then this will cause the json files to be loaded directly from the `ts/input/tex/<package>/__locales__` directory, so you won't have to keep doing the copy script.  Also note that

``` shell
./components/bin/makeAll --copy --terse components/mjs/input/tex/extensions/<package>
```

will perform the copying to `bundle` for a given component, while

``` shell
./components/bin/makeAll --copy --terse components/mjs/input/tex/extensions
```

would copy all of them.