### PR TITLE
Update node-main to initialize the locale, and properly find the locale json files

### DIFF
--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -33,7 +33,6 @@ import {Package} from '#js/components/package.js';
 
 const REQUIRE = eval('require');          // get require from node, not webpack
 const path = REQUIRE("path");
-const fs = REQUIRE("fs").promises;
 const dir = context.path(MathJax.config.__dirname);   // set up by node-main.mjs or node-main.cjs
 
 /*
@@ -67,10 +66,15 @@ if (path.basename(dir) === 'node-main') {
  * Set the asynchronous loader to handle json files
  */
 mathjax.asyncLoad = function (name) {
-  return name.match(/.json$/)
-    ? fs.readFile(Package.resolvePath(name)).then((json) => JSON.parse(json))
-    : REQUIRE(resolvePath(name, (name) => path.resolve(CONFIG.paths.mathjax, name)));
+  return REQUIRE(
+    resolvePath(
+      name,
+      (name) => path.resolve(CONFIG.paths.mathjax, name),
+      (name) => Package.resolvePath(name)
+    )
+  );
 };
+mathjax.asyncIsSynchronous = true;
 
 /*
  * The initialization function.  Use as:

--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -27,6 +27,9 @@ import {context} from '#js/util/context.js';
 import '../core/core.js';
 import '../adaptors/liteDOM/liteDOM.js';
 import {source} from '../source.js';
+import {mathjax} from '#js/mathjax.js';
+import {Locale} from '#js/util/Locale.js';
+import {Package} from '#js/components/package.js';
 
 const REQUIRE = eval('require');          // get require from node, not webpack
 const path = REQUIRE("path");
@@ -63,11 +66,10 @@ if (path.basename(dir) === 'node-main') {
 /*
  * Set the asynchronous loader to handle json files
  */
-MathJax._.mathjax.mathjax.asyncLoad = function (name) {
-  const file = resolvePath(name, (name) => path.resolve(CONFIG.paths.mathjax, name));
-  return file.match(/\.json$/)
-    ? fs.readFile(REQUIRE.resolve(file)).then((json) => JSON.parse(json))
-    : REQUIRE(file);
+mathjax.asyncLoad = function (name) {
+  return name.match(/.json$/)
+    ? fs.readFile(Package.resolvePath(name)).then((json) => JSON.parse(json))
+    : REQUIRE(resolvePath(name, (name) => path.resolve(CONFIG.paths.mathjax, name)));
 };
 
 /*
@@ -86,7 +88,8 @@ MathJax._.mathjax.mathjax.asyncLoad = function (name) {
  */
 const init = MathJax.init = (config = {}) => {
   combineConfig(MathJax.config, config);
-  return Loader.load(...CONFIG.load)
+  return Locale.setLocale(MathJax.config.locale ?? Locale.current)
+    .then(() => Loader.load(...CONFIG.load))
     .then(() => CONFIG.ready())
     .then(() => MathJax.startup.promise)    // Wait for MathJax to finish starting up
     .then(() => MathJax)                    // Pass MathJax global as argument to subsequent .then() calls


### PR DESCRIPTION
This PR fixes `node-main` to initialize the locale before it starts loading anything (like the changes in `feature/menu-locale`).  it also adjusts the `asyncLoad()` function to properly find the JSON files, even when the package name doesn't start with `[` (it currently fails to find the localization files for `input/tex` because of that).  Also, mark the `asyncLoad()` method as being synchronous.