### PR TITLE
Update Locale to handle synchronous JSON file loading, when possible.

### DIFF
--- a/testsuite/tests/util/Locale.test.ts
+++ b/testsuite/tests/util/Locale.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
+import { mathjax } from '#js/mathjax.js';
 import { Locale } from '#js/util/Locale.js';
 import '#js/util/asyncLoad/esm.js';
 
@@ -117,6 +118,46 @@ describe('Locale', () => {
 
     expect(errors[0]).toContain("MathJax(fallback): Can't load 'xy.json'");
     expect(locale.data.fallback?.en).toEqual({ Id1: 'Test of %1 in %2' });
+  });
+
+  /********************************************************************************/
+
+  test('Locale sync', async () => {
+    const locale = Locale as any;
+    Locale.registerLocaleFiles('sync', '../testsuite/lib/component');
+
+    //
+    // Save environment
+    //
+    const [load, sync] = [mathjax.asyncLoad, mathjax.asyncIsSynchronous];
+    const error = console.error;
+
+    //
+    // Test synchronous loading failure
+    //
+    mathjax.asyncLoad = () => {throw Error('failed!')};
+    mathjax.asyncIsSynchronous = true;
+
+    const log: string[] = [];
+    console.error = (msg) => log.push(msg);
+
+    locale.getLocaleData('sync', 'en', 'en.json').catch(() => {});
+    expect(log).toEqual(["MathJax(sync): Can't load 'en.json': failed!"]);
+
+    //
+    // Test synchronous loading success
+    //
+    mathjax.asyncLoad = () => {return {'test': 'A test'}};
+
+    locale.getLocaleData('sync', 'en', 'en.json');
+    expect(Locale.message('sync', 'test')).toBe('A test');
+
+    //
+    // Restore environment
+    //
+    mathjax.asyncLoad = load;
+    mathjax.asyncIsSynchronous = sync;
+    console.error = error;
   });
 
   /********************************************************************************/

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -21,6 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import { mathjax } from '../mathjax.js';
 import { asyncLoad } from './AsyncLoad.js';
 
 /**
@@ -123,7 +124,7 @@ export class Locale {
    *
    * @param {string} component        The component whose message is requested
    * @param {string} id               The id of the message
-   * @param {string|namedData} data   The first argument or the object of names arguments
+   * @param {string|namedData} data   The first argument or the object of named arguments
    * @param {string[]} args           Any additional string arguments (if data is a string)
    * @returns {string}                The localized message with arguments substituted in
    */
@@ -147,11 +148,10 @@ export class Locale {
    * Process a message string by substituting the given arguments. The arguments
    * can be positional, or a data mapping of names to values.
    *
-   * @param {string} message The message string to process.
-   * @param {string| namedData} data The first argument or the object of
-   *     names arguments
-   * @param {string[]} args Additional arguments (if data is a string)
-   * @returns {string} The processed message string with arguments substituted
+   * @param {string} message          The message string to process.
+   * @param {string|namedData} data   The first argument or the object of named arguments
+   * @param {string[]} args           Additional arguments (if data is a string)
+   * @returns {string}                The processed message string with arguments substituted
    */
   public static processMessage(
     message: string,
@@ -262,6 +262,14 @@ export class Locale {
     locale: string,
     file: string
   ): Promise<void> {
+    if (mathjax.asyncIsSynchronous) {
+      try {
+        this.registerMessages(component, locale, mathjax.asyncLoad(file));
+      } catch (error) {
+        await this.localeError(component, locale, error);
+      }
+      return;
+    }
     return asyncLoad(file)
       .then((data: messageData) =>
         this.registerMessages(component, locale, data)


### PR DESCRIPTION
This PR allows the `Locale` object to load the localization files synchronously, when the `mathjax.asyncLoad` method is marked as synchronous.  It also fixes the JSDoc issue that I mentioned in the review of #1479.