### PR TITLE
Add Locale.warn() and Locale.throw(), add tests for them, and use them in several TeX packages.

### DIFF
--- a/testsuite/package.json
+++ b/testsuite/package.json
@@ -14,6 +14,7 @@
     "#js/*": "../mjs/*",
     "#source/*": "../components/mjs/*",
     "#src/*": "./src/*",
+    "#helpers/*": "./js/src/*",
     "#helpers": "./js/src/index.js"
   },
   "dependencies": {

--- a/testsuite/src/index.ts
+++ b/testsuite/src/index.ts
@@ -1,1 +1,2 @@
 export * from './setupTex.js';
+export * from './traps.js';

--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -17,14 +17,16 @@ import { mathjax } from '#js/mathjax.js';
 import { OptionList } from '#js/util/Options.js';
 import { tmpJsonFile } from '#src/constants.js';
 import * as fs from 'fs';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { init } from '#source/node-main/node-main.mjs';
 import { expect } from '@jest/globals';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { source } from '#source/source.js';
 import { Locale } from '#js/util/Locale.js';
+import {
+  trapErrors,
+  trapAsyncErrors,
+  throwTexErrors,
+  throwCompileErrors,
+} from './traps.js';
 
 declare const MathJax: any;
 type MATHITEM = MathItem<any, any, any>;
@@ -56,87 +58,6 @@ const visitor = new SerializedMmlVisitor();
 export const toMathML = (node: MmlNode) => visitor.visitTree(node);
 
 /*********************************************************************/
-
-/**
- * Trap output produced while running code.
- *
- * @param {string} method The console method to trap.
- * @param {Function} code The code to run.
- * @returns {string} The output sent to the given method.
- */
-export function trapOutput(method: string, code: () => void): string {
-  const saved = (console as any)[method];
-  let message = '';
-  (console as any)[method] = (...msg: any[]) => {
-    message += (message ? '\n' : '') + msg.join(' ');
-  };
-  code();
-  (console as any)[method] = saved;
-  return message;
-}
-
-/**
- * Trap errors produced while running code.
- *
- * @param {Function} code The code to run.
- * @returns {string} The error message produced.
- */
-export function trapErrors(code: () => void): string {
-  let message = '(no error)';
-  reportErrors = true;
-  try {
-    code();
-  } catch (e) {
-    message = e.message;
-  }
-  reportErrors = false;
-  return message;
-}
-
-/**
- * Trap errors produced while running code.
- *
- * @param {Function} code The code to run.
- * @returns {string} The error message produced.
- */
-export async function trapAsyncErrors(code: () => Promise<void>) {
-  let message = '(no error)';
-  reportErrors = true;
-  await code().catch((e) => {
-    message = e.message;
-  });
-  reportErrors = false;
-  return message;
-}
-
-/**
- * When true, errors will throw rather than produce merror elements.
- */
-let reportErrors = false;
-
-/**
- * Configuration that causes TeX errors to throw rather than
- * generate merror elements, so we can trap them with trapErrors().
- */
-export const throwTexErrors = {
-  formatError(jax: any, err: Error) {
-    if (reportErrors) throw err;
-    return jax.formatError(err);
-  },
-};
-
-/**
- * Configuration that causes compile errors to throw rather than
- * generate merror elements, so we can trap them with trapErrors().
- */
-export const throwCompileErrors = {
-  options: {
-    compileError(jax: any, math: any, err: Error) {
-      if (reportErrors) throw err;
-      return jax.compileError(math, err);
-    },
-  },
-};
 
 /**
  * Trap TeX processing errors and return an expect() result
@@ -182,11 +103,12 @@ export function expectTypesetError(
  *
  * @param {string[]} packages    The TeX packages to configure
  * @param {OptionList} options   The TeX options to include
+ * @returns {Promise<void[]>}    The promise for when the locale is set up
  */
 export function setupTex(
   packages: PackageList = ['base'],
   options: OptionList = {}
-) {
+): Promise<void[]> {
   const parserOptions = Object.assign(
     {},
     { packages },
@@ -206,11 +128,12 @@ export function setupTex(
  *
  * @param {string[]} packages    The TeX packages to configure
  * @param {OptionList} options   The TeX options to include
+ * @returns {Promise<void[]>}    The promise for when the locale is set up
  */
 export function setupTexRender(
   packages: PackageList = ['base'],
   options: OptionList = {}
-) {
+): Promise<void[]> {
   const parserOptions = Object.assign(
     {},
     { packages: packages, inlineMath: { '[+]': [['$', '$']] } },
@@ -295,11 +218,12 @@ import { SVG } from '#js/output/svg.js';
  *
  * @param {string[]} packages    The TeX packages to configure
  * @param {OptionList} options   The TeX options to include
+ * @returns {Promise<void[]>}    The promise for when the locale is set up
  */
 export function setupTexWithOutput(
   packages: string[] = ['base'],
   options: OptionList = {}
-) {
+): Promise<void[]> {
   const parserOptions = Object.assign({}, { packages: packages }, options);
   const tex = new TeX(parserOptions);
   const html = new HTMLDocument('', adaptor, {

--- a/testsuite/src/traps.ts
+++ b/testsuite/src/traps.ts
@@ -1,4 +1,4 @@
-import {jest} from '@jest/globals';
+import { jest } from '@jest/globals';
 
 type consoleMethod = 'log' | 'warn' | 'error';
 
@@ -10,15 +10,17 @@ type consoleMethod = 'log' | 'warn' | 'error';
  * @returns {string} The output sent to the given method.
  */
 export function trapOutput(method: string, code: () => void): string {
-  const messages: string[] = [];
-  const spy = jest.spyOn(console, method as consoleMethod)
-    .mockImplementation((...msg) => messages.push(msg.join(' ')));
+  const spy = jest
+    .spyOn(console, method as consoleMethod)
+    .mockImplementation(() => {});
+  let message = '(no message)';
   try {
     code();
+    message = spy.mock.calls.map((msg: string[]) => msg.join(' ')).join('\n');
   } finally {
     spy.mockRestore();
   }
-  return messages.join('\n');
+  return message;
 }
 
 /**
@@ -50,15 +52,17 @@ export async function trapAsyncOutput(
   method: string,
   code: () => Promise<void>
 ): Promise<string> {
-  const messages: string[] = [];
-  const spy = jest.spyOn(console, method as consoleMethod)
-    .mockImplementation((...msg) => messages.push(msg.join(' ')));
+  const spy = jest
+    .spyOn(console, method as consoleMethod)
+    .mockImplementation(() => {});
+  let message = '(no message)';
   try {
     await code();
+    message = spy.mock.calls.map((msg: string[]) => msg.join(' ')).join('\n');
   } finally {
     spy.mockRestore();
   }
-  return messages.join('\n');
+  return message;
 }
 
 /**

--- a/testsuite/src/traps.ts
+++ b/testsuite/src/traps.ts
@@ -1,3 +1,7 @@
+import {jest} from '@jest/globals';
+
+type consoleMethod = 'log' | 'warn' | 'error';
+
 /**
  * Trap output produced while running code.
  *
@@ -6,14 +10,15 @@
  * @returns {string} The output sent to the given method.
  */
 export function trapOutput(method: string, code: () => void): string {
-  const saved = (console as any)[method];
-  let message = '';
-  (console as any)[method] = (...msg: any[]) => {
-    message += (message ? '\n' : '') + msg.join(' ');
-  };
-  code();
-  (console as any)[method] = saved;
-  return message;
+  const messages: string[] = [];
+  const spy = jest.spyOn(console, method as consoleMethod)
+    .mockImplementation((...msg) => messages.push(msg.join(' ')));
+  try {
+    code();
+  } finally {
+    spy.mockRestore();
+  }
+  return messages.join('\n');
 }
 
 /**
@@ -45,14 +50,15 @@ export async function trapAsyncOutput(
   method: string,
   code: () => Promise<void>
 ): Promise<string> {
-  const saved = (console as any)[method];
-  let message = '';
-  (console as any)[method] = (...msg: any[]) => {
-    message += (message ? '\n' : '') + msg.join(' ');
-  };
-  await code();
-  (console as any)[method] = saved;
-  return message;
+  const messages: string[] = [];
+  const spy = jest.spyOn(console, method as consoleMethod)
+    .mockImplementation((...msg) => messages.push(msg.join(' ')));
+  try {
+    await code();
+  } finally {
+    spy.mockRestore();
+  }
+  return messages.join('\n');
 }
 
 /**

--- a/testsuite/src/traps.ts
+++ b/testsuite/src/traps.ts
@@ -1,0 +1,103 @@
+/**
+ * Trap output produced while running code.
+ *
+ * @param {string} method The console method to trap.
+ * @param {Function} code The code to run.
+ * @returns {string} The output sent to the given method.
+ */
+export function trapOutput(method: string, code: () => void): string {
+  const saved = (console as any)[method];
+  let message = '';
+  (console as any)[method] = (...msg: any[]) => {
+    message += (message ? '\n' : '') + msg.join(' ');
+  };
+  code();
+  (console as any)[method] = saved;
+  return message;
+}
+
+/**
+ * Trap errors produced while running code.
+ *
+ * @param {Function} code The code to run.
+ * @returns {string} The error message produced.
+ */
+export function trapErrors(code: () => void): string {
+  let message = '(no error)';
+  reportErrors = true;
+  try {
+    code();
+  } catch (e) {
+    message = e.message;
+  }
+  reportErrors = false;
+  return message;
+}
+
+/**
+ * Trap output produced while running async code.
+ *
+ * @param {string} method The console method to trap.
+ * @param {Function} code The code to run.
+ * @returns {string} The output sent to the given method.
+ */
+export async function trapAsyncOutput(
+  method: string,
+  code: () => Promise<void>
+): Promise<string> {
+  const saved = (console as any)[method];
+  let message = '';
+  (console as any)[method] = (...msg: any[]) => {
+    message += (message ? '\n' : '') + msg.join(' ');
+  };
+  await code();
+  (console as any)[method] = saved;
+  return message;
+}
+
+/**
+ * Trap errors produced while running async code.
+ *
+ * @param {Function} code The code to run.
+ * @returns {string} The error message produced.
+ */
+export async function trapAsyncErrors(
+  code: () => Promise<void>
+): Promise<string> {
+  let message = '(no error)';
+  reportErrors = true;
+  await code().catch((e) => {
+    message = e.message;
+  });
+  reportErrors = false;
+  return message;
+}
+
+/**
+ * When true, errors will throw rather than produce merror elements.
+ */
+let reportErrors = false;
+
+/**
+ * Configuration that causes TeX errors to throw rather than
+ * generate merror elements, so we can trap them with trapErrors().
+ */
+export const throwTexErrors = {
+  formatError(jax: any, err: Error) {
+    if (reportErrors) throw err;
+    return jax.formatError(err);
+  },
+};
+
+/**
+ * Configuration that causes compile errors to throw rather than
+ * generate merror elements, so we can trap them with trapErrors().
+ */
+export const throwCompileErrors = {
+  options: {
+    compileError(jax: any, math: any, err: Error) {
+      if (reportErrors) throw err;
+      return jax.compileError(math, err);
+    },
+  },
+};

--- a/testsuite/tests/input/tex/Tex.test.ts
+++ b/testsuite/tests/input/tex/Tex.test.ts
@@ -275,7 +275,7 @@ describe('Configuration', () => {
       () => new TeX({ packages: ['base', 'undefined'] })
     );
     expect(message).toBe(
-      "MathJax Warning: Package 'undefined' not found.  Omitted."
+      "Package 'undefined' not found.  Omitted."
     );
   });
 });
@@ -290,11 +290,11 @@ describe('MapHandler', () => {
       },
     });
     const message = trapOutput(
-      'log',
+      'warn',
       () => new TeX({ packages: ['base', 'BadHandler'] })
     );
     expect(message).toBe(
-      "TexParser Warning: Configuration 'undefindHandler' not found! Omitted."
+      "Configuration 'undefindHandler' not found.  Omitted."
     );
   });
 

--- a/testsuite/tests/util/Locale.test.ts
+++ b/testsuite/tests/util/Locale.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
+import { trapOutput, trapAsyncOutput } from '#helpers/traps.js';
 import { Locale } from '#js/util/Locale.js';
 import '#js/util/asyncLoad/esm.js';
 
@@ -70,7 +71,7 @@ describe('Locale', () => {
     expect(Locale.message('undefined', 'Id1')).toBe(
       "MathJax(Locale): No localized or default version for message with id 'Id1' from 'undefined'"
     );
-    expect(() => Locale.error('component', 'error', 'x')).toThrow('Error in x');
+    expect(() => Locale.throw('component', 'error', 'x')).toThrow('Error in x');
     Locale.current = 'de';
     expect(Locale.message('undefined', 'Id1')).toBe(
       "MathJax(Locale): Keine lokalisierte oder Standardversion für die Meldung mit der ID 'Id1' aus 'undefined'"
@@ -106,17 +107,25 @@ describe('Locale', () => {
   test('Locale error falls back to default locale', async () => {
     const locale = Locale as any;
     Locale.registerLocaleFiles('fallback', '../testsuite/lib/component');
-
-    const errors: string[] = [];
-    const origError = console.error;
-    console.error = (msg: string) => errors.push(msg);
-
-    await locale.localeError('fallback', 'xy', new Error('xy.json not found'));
-
-    console.error = origError;
-
-    expect(errors[0]).toContain("MathJax(fallback): Can't load 'xy.json'");
+    const message = await trapAsyncOutput('error', async () => {
+      await locale.localeError(
+        'fallback',
+        'xy',
+        new Error('xy.json not found')
+      );
+    });
+    expect(message).toContain("MathJax(fallback): Can't load 'xy.json'");
     expect(locale.data.fallback?.en).toEqual({ Id1: 'Test of %1 in %2' });
+  });
+
+  /********************************************************************************/
+
+  test('Locale warn', async () => {
+    Locale.registerLocaleFiles('component', '../testsuite/lib/component');
+    const message = trapOutput('warn', () =>
+      Locale.warn('component', 'test2', 'warn')
+    );
+    expect(message).toEqual('Has warn one');
   });
 
   /********************************************************************************/

--- a/testsuite/tests/util/Locale.test.ts
+++ b/testsuite/tests/util/Locale.test.ts
@@ -28,7 +28,9 @@ describe('Locale', () => {
       '../testsuite/lib/component/__locales__',
       new Set(),
     ]);
-    const spy = jest.spyOn(console, 'error').mockImplementation((msg) => {throw msg});
+    const spy = jest.spyOn(console, 'error').mockImplementation((msg) => {
+      throw msg;
+    });
     await expect(Locale.setLocale('xy')).rejects.toContain(
       "MathJax(component): Can't load 'xy.json': ENOENT: no such file or directory"
     );

--- a/testsuite/tests/util/Locale.test.ts
+++ b/testsuite/tests/util/Locale.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import { trapOutput, trapAsyncOutput } from '#helpers/traps.js';
 import { Locale } from '#js/util/Locale.js';
 import '#js/util/asyncLoad/esm.js';
@@ -28,17 +28,14 @@ describe('Locale', () => {
       '../testsuite/lib/component/__locales__',
       new Set(),
     ]);
-    const error = console.error;
-    console.error = (message) => {
-      throw message;
-    };
+    const spy = jest.spyOn(console, 'error').mockImplementation((msg) => {throw msg});
     await expect(Locale.setLocale('xy')).rejects.toContain(
       "MathJax(component): Can't load 'xy.json': ENOENT: no such file or directory"
     );
     await expect(Locale.setLocale('de')).rejects.toContain(
       "MathJax(component): 'de.json' kann nicht geladen werden: ENOENT: no such file or directory"
     );
-    console.error = error;
+    spy.mockRestore();
     await Locale.setLocale('en');
     expect(locale.data.component).toEqual({ en: { Id1: 'Test of %1 in %2' } });
     expect(Locale.message('component', 'Id1', 'message', 'Locale')).toBe(

--- a/testsuite/tests/util/Options.test.ts
+++ b/testsuite/tests/util/Options.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import * as Options from '#js/util/Options.js';
 
 const SYMB = Symbol('symbol');
@@ -355,8 +355,7 @@ describe('Options utility', () => {
     //
     //  Warn does not throw an error
     //
-    const warn = console.warn;
-    console.warn = () => {};
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     OPTIONS.invalidOption = 'warn';
     try {
       copy = Options.userOptions({}, { a: 1 });
@@ -364,7 +363,7 @@ describe('Options utility', () => {
       // Should not throw an error
     }
     expect(copy).toEqual({});
-    console.warn = warn;
+    spy.mockRestore();
   });
 
   test('makeArray()', () => {

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -31,7 +31,9 @@ import { FunctionList } from '../../util/FunctionList.js';
 import { TeX } from '../tex.js';
 import { PrioritizedList } from '../../util/PrioritizedList.js';
 import { TagsFactory } from './Tags.js';
-export { COMPONENT } from './__locales__/Component.js';
+import { Locale} from '../../util/Locale.js';
+import { COMPONENT } from './__locales__/Component.js';
+export { COMPONENT };
 
 export type StackItemConfig = { [kind: string]: StackItemClass };
 export type TagsConfig = { [kind: string]: TagsClass };
@@ -433,15 +435,15 @@ export class ParserConfiguration {
    * Find a package and check that it is for the targeted parser
    *
    * @param {string} name       The name of the package to check
-   * @returns {Configuration}    The configuration for the package
+   * @returns {Configuration}   The configuration for the package
    */
   protected getPackage(name: string): Configuration {
     const config = ConfigurationHandler.get(name);
     if (config && !this.parsers.includes(config.parser)) {
-      throw Error(`Package '${name}' doesn't target the proper parser`);
+      Locale.throw(COMPONENT, 'WrongParser', name);
     }
     if (!config) {
-      this.warn(`Package '${name}' not found.  Omitted.`);
+      Locale.warn(COMPONENT, 'PackageNotFound', name);
     }
     return config;
   }
@@ -480,14 +482,5 @@ export class ParserConfiguration {
     for (const [post, priority] of config.postprocessors) {
       jax.postFilters.add(post, priority);
     }
-  }
-
-  /**
-   * Prints a warning message.
-   *
-   * @param {string} message The warning.
-   */
-  private warn(message: string) {
-    console.warn('MathJax Warning: ' + message);
   }
 }

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -31,7 +31,7 @@ import { FunctionList } from '../../util/FunctionList.js';
 import { TeX } from '../tex.js';
 import { PrioritizedList } from '../../util/PrioritizedList.js';
 import { TagsFactory } from './Tags.js';
-import { Locale} from '../../util/Locale.js';
+import { Locale } from '../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
 export { COMPONENT };
 

--- a/ts/input/tex/MapHandler.ts
+++ b/ts/input/tex/MapHandler.ts
@@ -26,6 +26,8 @@ import { AbstractTokenMap, TokenMap, CharacterMap } from './TokenMap.js';
 import { ParseInput, ParseResult, ParseMethod } from './Types.js';
 import { PrioritizedList } from '../../util/PrioritizedList.js';
 import { FunctionList } from '../../util/FunctionList.js';
+import { Locale } from '../../util/Locale.js';
+import { COMPONENT } from './__locales__/Component.js';
 
 export type HandlerConfig = { [P in HandlerType]?: string[] };
 export type FallbackConfig = { [P in HandlerType]?: ParseMethod };
@@ -79,7 +81,7 @@ export class SubHandler {
     for (const name of maps.slice().reverse()) {
       const map = MapHandler.getMap(name);
       if (!map) {
-        this.warn(`Configuration '${name}' not found! Omitted.`);
+        Locale.warn(COMPONENT, 'ConfigNotFound', name);
         return;
       }
       this._configuration.add(map, priority);
@@ -194,15 +196,6 @@ export class SubHandler {
       }
     }
     return null;
-  }
-
-  /**
-   * Prints a warning message.
-   *
-   * @param {string} message The warning.
-   */
-  private warn(message: string) {
-    console.log('TexParser Warning: ' + message);
   }
 }
 

--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -26,6 +26,8 @@ import { MmlNode } from '../../core/MmlTree/MmlNode.js';
 import { MathItem } from '../../core/MathItem.js';
 import { EnvList } from './StackItem.js';
 import ParseOptions from './ParseOptions.js';
+import { Locale } from '../../util/Locale.js';
+import { COMPONENT } from './__locales__/Component.js';
 
 /**
  *  Simple class for label objects.
@@ -696,7 +698,7 @@ export const TagsFactory = {
   create(name: string): Tags {
     const constr = tagsMapping.get(name) || tagsMapping.get(defaultTags);
     if (!constr) {
-      throw Error('Unknown tags class');
+      Locale.throw(COMPONENT, 'UnknownTag');
     }
     return new constr();
   },

--- a/ts/input/tex/__locales__/de.json
+++ b/ts/input/tex/__locales__/de.json
@@ -2,6 +2,7 @@
   "BadPreamToken": "Ungültiges Pream-Token (%1)",
   "BadRawUnicode": "Das Argument für %1 muss eine hexadezimale Zahl mit 1 bis 6 Ziffern sein",
   "ColArgNotNum": "Das erste Argument für den Spaltenbezeichner %1 muss eine Zahl sein",
+  "ConfigNotFound": "Konfiguration '%1' nicht gefunden.  Wird übersprungen.",
   "ErroneousNestingEq": "Fehlerhafte Verschachtelung von Gleichungsstrukturen",
   "ExtraCloseLooking": "Überflüssige schließende Klammer bei der Suche nach %1",
   "ExtraCloseMissingOpen": "Überflüssige schließende Klammer oder fehlende öffnende Klammer",
@@ -21,11 +22,13 @@
   "MissingBeginExtraEnd": "Fehlendes \\begin{%1} oder zusätzliches \\end{%1}",
   "MissingCloseBrace": "Fehlende schließende Klammer",
   "MissingCloseBracket": "Schließendes ']' für Argument zu %1 nicht gefunden",
-  "MissingColumnDimOrUnits": "Missing dimension or its units for %1 column declaration",
-  "MissingDimOrUnits": "Missing dimension or its units for %1",
-  "MissingLeftExtraRight": "Missing \\left or extra \\right",
-  "MissingOrUnrecognizedDelim": "Missing or unrecognized delimiter for %1",
+  "MissingColumnDimOrUnits": "Bei der Spaltendeklaration von %1 fehlt die Dimension oder deren Einheiten",
+  "MissingDimOrUnits": "Für %1 fehlt die Dimension oder deren Einheiten",
+  "MissingLeftExtraRight": "Fehlendes \\left oder überflüssiges \\right",
+  "MissingOrUnrecognizedDelim": "Fehlendes oder nicht erkanntes Trennzeichen für %1",
   "MissingScript": "Fehlendes Argument für Hoch- oder Tiefstellung",
-  "TokenNotFoundForCommand": "Could not find %1 for %2",
-  "UnknownTag": "Unbekannte Bezeichner Klasse"
+  "PackageNotFound": "Paket '%1' nicht gefunden.  Wird übersprungen.",
+  "TokenNotFoundForCommand": "%1 für %2 konnte nicht gefunden werden",
+  "UnknownTag": "Unbekannte Bezeichner Klasse",
+  "WrongParser": "Das Paket '%1' ist nicht auf den richtigen Parser ausgerichtet"
 }

--- a/ts/input/tex/__locales__/en.json
+++ b/ts/input/tex/__locales__/en.json
@@ -2,6 +2,7 @@
   "BadPreamToken": "Illegal pream-token (%1)",
   "BadRawUnicode": "Argument to %1 must a hexadecimal number with 1 to 6 digits",
   "ColArgNotNum": "First argument to %1 column specifier must be a number",
+  "ConfigNotFound": "Configuration '%1' not found.  Omitted.",
   "ErroneousNestingEq": "Erroneous nesting of equation structures",
   "ExtraCloseLooking": "Extra close brace while looking for %1",
   "ExtraCloseMissingOpen": "Extra close brace or missing open brace",
@@ -26,6 +27,8 @@
   "MissingLeftExtraRight": "Missing \\left or extra \\right",
   "MissingOrUnrecognizedDelim": "Missing or unrecognized delimiter for %1",
   "MissingScript": "Missing superscript or subscript argument",
+  "PackageNotFound": "Package '%1' not found.  Omitted.",
   "TokenNotFoundForCommand": "Could not find %1 for %2",
-  "UnknownTag": "Unknown tags class"
+  "UnknownTag": "Unknown tags class",
+  "WrongParser": "Package '%1' doesn't target the proper parser"
 }

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -30,6 +30,9 @@ import { Property } from '../../../core/Tree/Node.js';
 import { MathItem } from '../../../core/MathItem.js';
 import { MathDocument } from '../../../core/MathDocument.js';
 
+import { Locale } from '../../../util/Locale.js';
+import { COMPONENT } from './__locales__/Component.js';
+
 type MATHITEM = MathItem<any, any, any>;
 type MATHDOCUMENT = MathDocument<any, any, any>;
 
@@ -651,9 +654,7 @@ export const makeBsprAttributes = function (arg: FilterData) {
 export const saveDocument = function (arg: FilterData) {
   doc = arg.document;
   if (!('getBBox' in doc.outputJax)) {
-    throw Error(
-      'The bussproofs extension requires an output jax with a getBBox() method'
-    );
+    Locale.throw(COMPONENT, 'RequiresOutputJax');
   }
 };
 

--- a/ts/input/tex/bussproofs/__locales__/de.json
+++ b/ts/input/tex/bussproofs/__locales__/de.json
@@ -3,5 +3,6 @@
   "EnvMissingEnd": "\\end{%1} fehlt",
   "IllegalProofCommand": "Beweisbefehle sind nur in der prooftree-Umgebung zulässig.",
   "IllegalUseOfCommand": "Die Verwendung von %1 entspricht nicht seiner Definition.",
-  "MissingProofCommand": "%1 fehlt in %2."
+  "MissingProofCommand": "%1 fehlt in %2.",
+  "RequiresOutputJax": "Die Erweiterung bussproofs benötigt eine OutputJax mit einer getBBox() Methode"
 }

--- a/ts/input/tex/bussproofs/__locales__/en.json
+++ b/ts/input/tex/bussproofs/__locales__/en.json
@@ -3,5 +3,6 @@
   "EnvMissingEnd": "Missing \\end{%1}",
   "IllegalProofCommand": "Proof commands only allowed in prooftree environment.",
   "IllegalUseOfCommand": "Use of %1 does not match its definition.",
-  "MissingProofCommand": "Missing %1 in %2."
+  "MissingProofCommand": "Missing %1 in %2.",
+  "RequiresOutputJax": "The bussproofs extension requires an output jax with a getBBox() method";
 }

--- a/ts/input/tex/bussproofs/__locales__/en.json
+++ b/ts/input/tex/bussproofs/__locales__/en.json
@@ -4,5 +4,5 @@
   "IllegalProofCommand": "Proof commands only allowed in prooftree environment.",
   "IllegalUseOfCommand": "Use of %1 does not match its definition.",
   "MissingProofCommand": "Missing %1 in %2.",
-  "RequiresOutputJax": "The bussproofs extension requires an output jax with a getBBox() method";
+  "RequiresOutputJax": "The bussproofs extension requires an output jax with a getBBox() method"
 }

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -40,6 +40,7 @@ import { mathjax } from '../../../mathjax.js';
 import { expandable } from '../../../util/Options.js';
 import { MenuMathDocument } from '../../../ui/menu/MenuHandler.js';
 
+import { Locale } from '../../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
 export { COMPONENT };
 
@@ -207,7 +208,7 @@ function config(_config: ParserConfiguration, jax: TeX<any, any, any>) {
   const options = jax.parseOptions.options.require;
   const prefix = options.prefix;
   if (prefix.match(/[^_a-zA-Z0-9]/)) {
-    throw Error('Illegal characters used in \\require prefix');
+    Locale.throw(COMPONENT, 'IllegalChar');
   }
   if (!LOADERCONFIG.paths[prefix]) {
     LOADERCONFIG.paths[prefix] = '[mathjax]/input/tex/extensions';

--- a/ts/input/tex/require/__locales__/de.json
+++ b/ts/input/tex/require/__locales__/de.json
@@ -1,5 +1,6 @@
 {
   "BadPackageName": "Das Argument für %1 ist kein gültiger Paketname",
   "BadRequire": "Die Erweiterung \"%1\" darf nicht geladen werden",
+  "IllegalChar": "Im Präfix für \\require wurden ungültige Zeichen verwendet",
   "RequireFail": "Die Erweiterung \"%1\" konnte nicht geladen werden"
 }

--- a/ts/input/tex/require/__locales__/en.json
+++ b/ts/input/tex/require/__locales__/en.json
@@ -1,5 +1,6 @@
 {
   "BadPackageName": "Argument for %1 is not a valid package name",
   "BadRequire": "Extension \"%1\" is not allowed to be loaded",
+  "IllegalChar": "Illegal characters used in \\require prefix",
   "RequireFail": "Extension \"%1\" failed to load"
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -963,7 +963,7 @@ export class Menu {
       Object.assign(this.settings, settings);
       this.setA11y(settings);
     } catch (err) {
-      console.log(localize('StorageError', err.message));
+      Locale.warn(COMPONENT, 'StorageError', err.message);
     }
   }
 
@@ -985,7 +985,7 @@ export class Menu {
       }
       localStorage.setItem(Menu.LOCALE_STORAGE, this.settings.language);
     } catch (err) {
-      console.log(localize('StorageError', err.message));
+      Locale.warn(COMPONENT, 'StorageError', err.message);
     }
   }
 
@@ -1483,7 +1483,7 @@ export class Menu {
           Menu._loadingPromise = null;
           Menu._loadingFailed(err);
         } else {
-          console.log(err);
+          console.warn(err);
         }
       });
     Menu.loadingPromises.set(name, promise);

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -207,8 +207,8 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       enableExplorer: true,
       enableExplorerHelp: true,
       enrichSpeech: 'none',
-      enrichError: (_doc: MenuMathDocument, _math: MenuMathItem, err: Error) =>
-        console.warn('Enrichment Error:', err),
+      enrichError: (doc: MenuMathDocument, math: MenuMathItem, err: Error) =>
+        doc.enrichError(doc, math, err),
       ...BaseDocument.OPTIONS,
       MenuClass: Menu,
       menuOptions: Menu.OPTIONS,
@@ -306,7 +306,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
     public _checkLoading(): MenuMathDocument {
       if (this.menu.isLoading) {
         mathjax.retryAfter(
-          this.menu.loadingPromise.catch((err) => console.log(err))
+          this.menu.loadingPromise.catch((err) => console.warn(err))
         );
       }
       if (this.options.enableComplexity) {

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -215,13 +215,30 @@ export class Locale {
    * @param {string|namedData} data   The first argument or the object of names arguments
    * @param {string[]} args           Any additional string arguments (if data is a string)
    */
-  public static error(
+  public static throw(
     component: string,
     id: string,
-    data: string | namedData,
+    data: string | namedData = {},
     ...args: string[]
   ) {
     throw Error(this.message(component, id, data, ...args));
+  }
+
+  /**
+   * Report a warning with a given string substituting the given parameters
+   *
+   * @param {string} component        The component whose message is requested
+   * @param {string} id               The id of the message
+   * @param {string|namedData} data   The first argument or the object of names arguments
+   * @param {string[]} args           Any additional string arguments (if data is a string)
+   */
+  public static warn(
+    component: string,
+    id: string,
+    data: string | namedData = {},
+    ...args: string[]
+  ) {
+    console.warn(this.message(component, id, data, ...args));
   }
 
   /**

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -229,7 +229,7 @@ export class Locale {
    *
    * @param {string} component        The component whose message is requested
    * @param {string} id               The id of the message
-   * @param {string|namedData} data   The first argument or the object of names arguments
+   * @param {string|namedData} data   The first argument or the object of named arguments
    * @param {string[]} args           Any additional string arguments (if data is a string)
    */
   public static warn(


### PR DESCRIPTION
This PR adds the `Locale.warn()` function and renames `Locale.error()` as `Locale.throw()`, and uses these in the TeX packages that I mentioned in the finalize-tex branch.  It updates the tests to cover these, and moves some output-trapping functions from the `testsuite/src/setupTex.ts` file to a new `traps.ts` file.  The reason for this is that `setupTeX.ts` loads `node-main`, which does two two things that affect the `Locale` package:  because it is component-based, it means `Locale.isComponent` gets set, which we don't want (that changes the location where `Locale` looks for the localization files), second, it alters the `mathjax.asyncLoad` which ends up causing different error messages.  I could have gotten around these issues, but it seemed reasonable to separate out the non-tex-based output trapping functions from `setupTex.ts` in any case, and that avoids the problem.

The change to `package.js` is to allow access to the new `trap.ts` file via `#helpers/trap.js`.  The `index.js` file is modified to export the traps from the new file rather than `setupTex.js`.  The needed traps are loaded into `setupTex.ts` rather than being defined there.  I also fixed some JSDoc `@returns` that changed after adding the `Locale.setLocale()` calls (in an earlier PR).  

Some tests in `Tex.test.ts` are adjusted to accommodate the use of `Locale.warn()` and the removal of the `warn()` methods that we discussed in our meeting.  The `Locale.test.ts` file is implified to use the `trapOutput` and `trapAsyncOutput()` functions from the new `traps.ts` file, rather that chaining the `console.error` and `console.warn` functions by hand, and a new section to test `Locale.warn()` is added.

The usage of `console` and `throw new Error` in several TeX packages are changes to `Locale.warn()` and `Locale.throw()` and their `warn()` methods removed, and the needed messages are added to the localization files.