### PR TITLE
Produce message if locale isn't set when using direct access to MathJax modules.

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -774,7 +774,9 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   constructor(document: D, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
     if (!Locale.initialized) {
       // FIXME: add URL when we have one.
-      console.error('MathJax locales not loaded.  You may receive cryptic error messages.');
+      console.error(
+        'MathJax locales not loaded.  You may receive cryptic error messages.'
+      );
     }
     const CLASS = this.constructor as typeof AbstractMathDocument;
     this.document = document;

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -37,6 +37,7 @@ import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import { BitField, BitFieldClass } from '../util/BitField.js';
 import { PrioritizedList } from '../util/PrioritizedList.js';
 import { handleRetriesFor } from '../util/Retries.js';
+import { Locale } from '../util/Locale.js';
 
 /*****************************************************************/
 
@@ -771,6 +772,10 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @class
    */
   constructor(document: D, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
+    if (!Locale.initialized) {
+      // FIXME: add URL when we have one.
+      console.error('MathJax locales not loaded.  You may receive cryptic error messages.');
+    }
     const CLASS = this.constructor as typeof AbstractMathDocument;
     this.document = document;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -36,6 +36,10 @@ export type namedData = { [name: string | number]: string };
  */
 export class Locale {
   /**
+   * Whether setLocale() has been called or not.
+   */
+  public static initialized = false;
+  /**
    * The current locale
    */
   public static current: string = 'en';
@@ -251,6 +255,7 @@ export class Locale {
   public static async setLocale(
     locale: string = this.current
   ): Promise<void[]> {
+    this.initialized = true;
     this.current = locale;
     const promises = [];
     for (const [component, [directory, loaded]] of Object.entries(


### PR DESCRIPTION
This PR introduces an error message about not having set up localization, if that is the case.  This applies only to node applications that use direct access to the MathJax modules (since the component-based apps in node or the browser will have `Locale.setLocale()` performed automatically).  In this PR, when a MathDocument is created, the Locale is checked and it `setLocale()` has never been called, the message is generated.   When we have a URL to point to, it should be added to the message.