### PR TITLE
Localize a11y/speech

### DIFF
--- a/components/mjs/a11y/speech/config.json
+++ b/components/mjs/a11y/speech/config.json
@@ -4,6 +4,12 @@
     "targets": ["a11y/speech.ts", "a11y/speech"],
     "exclude": ["a11y/speech/SpeechMenu.ts"]
   },
+  "copy": {
+    "to": "[bundle]/a11y/speech",
+    "from": "[ts]/a11y/speech",
+    "copy": ["__locales__"],
+    "excludes": ["__locales__/Component.ts"]
+  },
   "webpack": {
     "name": "a11y/speech",
     "libs": [

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -34,6 +34,7 @@ import { OptionList, expandable } from '../util/Options.js';
 import { GeneratorPool } from './speech/GeneratorPool.js';
 import { WorkerHandler } from './speech/WebWorker.js';
 import { sreRoot } from '#root/sre-root.js';
+import { localize } from './speech/__locales__/Component.js';
 
 /*==========================================================================*/
 
@@ -317,7 +318,7 @@ export function SpeechMathDocumentMixin<
       _math: SpeechMathItem<N, T, D>,
       err: Error
     ) {
-      console.warn('Speech generation error:', err);
+      console.warn(localize('SpeechError'), err);
     }
 
     /**

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -22,6 +22,8 @@
  */
 
 import * as Sre from '../sre.js';
+import { Locale } from '../../util/Locale.js';
+import { COMPONENT } from './__locales__/Component.js';
 
 const ProsodyKeys = ['pitch', 'rate', 'volume'];
 
@@ -162,7 +164,7 @@ const prosodyRegexp = /([+-]?)([0-9]+)%/;
 function extractProsody(attr: string): [string, string] {
   const match = attr.match(prosodyRegexp);
   if (!match) {
-    console.warn('Something went wrong with the prosody matching.');
+    Locale.warn(COMPONENT, 'ProsodyError');
     return ['', '100'];
   }
   return [match[1], match[2]];

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -26,6 +26,8 @@ import { OptionList } from '../../util/Options.js';
 import { Message, ClientCommand, Structure } from './MessageTypes.js';
 import { SpeechMathItem } from '../speech.js';
 import { SemAttr } from './SpeechUtil.js';
+import { Locale } from '../../util/Locale.js';
+import { localize, COMPONENT } from './__locales__/Component.js';
 
 /**
  * Class for relevant task information.
@@ -77,7 +79,9 @@ export class WorkerHandler<N, T, D> {
    * This starts the worker.
    */
   public async Start() {
-    if (this.ready) throw Error('Worker already started');
+    if (this.ready) {
+      Locale.throw(COMPONENT, 'Worker/Started');
+    }
     this.worker = await this.adaptor.createWorker(
       this.Listener.bind(this),
       this.options
@@ -155,7 +159,7 @@ export class WorkerHandler<N, T, D> {
   public Cancel(item: SpeechMathItem<N, T, D>) {
     const i = this.tasks.findIndex((task) => task.item === item);
     if (i > 0) {
-      this.tasks[i].reject(`Task ${this.tasks[i].cmd.cmd} cancelled`);
+      this.tasks[i].reject(localize('Worker/Cancelled', this.tasks[i].cmd.cmd));
       this.tasks.splice(i, 1);
     }
   }
@@ -499,9 +503,7 @@ export class WorkerHandler<N, T, D> {
   public Terminate(): Promise<any> | void {
     this.debug('Terminating pending tasks');
     for (const task of this.tasks) {
-      task.reject(
-        `${task.cmd.data.cmd} cancelled by WorkerHandler termination`
-      );
+      task.reject(localize('Worker/Terminate', task.cmd.data.cmd));
     }
     this.tasks = [];
     this.debug('Terminating worker');
@@ -514,7 +516,7 @@ export class WorkerHandler<N, T, D> {
    */
   public async Stop() {
     if (!this.worker) {
-      throw Error('Worker has not been started');
+      Locale.throw(COMPONENT, 'Worker/NotStarted');
     }
     await this.Terminate();
     this.worker = null;

--- a/ts/a11y/speech/__locales__/Component.ts
+++ b/ts/a11y/speech/__locales__/Component.ts
@@ -1,0 +1,39 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2026 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @file  Locale component registration for a11y/speech
+ *
+ * @author dpvc@mathjax.org (Davide P. Cervone)
+ */
+
+import { Locale, namedData } from '../../../util/Locale.js';
+
+export const COMPONENT = 'a11y/speech';
+
+Locale.registerLocaleFiles(COMPONENT, '../ts/a11y/speech');
+
+/**
+ * Get a localized message for this component
+ *
+ * @param {string} id                   The id of the message
+ * @param {(string|namedData)[]} args   The replacement arguments for the message, if any
+ * @returns {string}                    The localized message
+ */
+export function localize(id: string, ...args: (string | namedData)[]): string {
+  return Locale.message(COMPONENT, id, ...args);
+}

--- a/ts/a11y/speech/__locales__/de.json
+++ b/ts/a11y/speech/__locales__/de.json
@@ -1,0 +1,8 @@
+{
+  "ProsodyError": "Beim Prosody-Abgleich ist ein Fehler aufgetreten",
+  "SpeechError": "Fehler bei der Sprachgenerierung:",
+  "Worker/Cancelled": "Aufgabe %1 abgebrochen",
+  "Worker/NotStarted": "Worker wurde nicht gestartet",
+  "Worker/Started": "Worker bereits gestartet",
+  "Worker/Terminate": "%1 durch Beendigung des WorkerHandlers abgebrochen"
+}

--- a/ts/a11y/speech/__locales__/en.json
+++ b/ts/a11y/speech/__locales__/en.json
@@ -1,0 +1,8 @@
+{
+  "ProsodyError": "Something went wrong with the prosody matching",
+  "SpeechError": "Speech generation error:",
+  "Worker/Cancelled": "Task %1 cancelled",
+  "Worker/NotStarted": "Worker has not been started",
+  "Worker/Started": "Worker already started",
+  "Worker/Terminate": "%1 cancelled by WorkerHandler termination"
+}


### PR DESCRIPTION
This PR localizes the `a11y/speech` component.  As discussed in the developers' meeting, we do not localize the messages from the web-worker itself.