### PR TITLE
Preload en locale in component definitions

### DIFF
--- a/components/bin/package.json
+++ b/components/bin/package.json
@@ -1,6 +1,7 @@
 {
   "type": "commonjs",
   "imports": {
+    "#ts/*": "@mathjax/src/ts/*",
     "#js/*": "@mathjax/src/cjs/*",
     "#source/*": "@mathjax/src/components/cjs/*",
     "#root/*": "@mathjax/src/cjs/components/cjs/*",

--- a/components/mjs/a11y/explorer/en.js
+++ b/components/mjs/a11y/explorer/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/a11y/explorer/__locales__/Component.js';
+import data from '#ts/a11y/explorer/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/a11y/explorer/explorer.js
+++ b/components/mjs/a11y/explorer/explorer.js
@@ -1,4 +1,5 @@
 import './lib/explorer.js';
+import './en.js';
 
 import {ExplorerHandler} from '#js/a11y/explorer.js';
 import {hasWindow} from '#js/util/context.js';

--- a/components/mjs/a11y/semantic-enrich/en.js
+++ b/components/mjs/a11y/semantic-enrich/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/a11y/semantic-enrich/__locales__/Component.js';
+import data from '#ts/a11y/semantic-enrich/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/mjs/a11y/semantic-enrich/semantic-enrich.js
@@ -1,4 +1,5 @@
 import './lib/semantic-enrich.js';
+import './en.js';
 
 import {combineDefaults} from '#js/components/global.js';
 import {EnrichHandler} from '#js/a11y/semantic-enrich.js';

--- a/components/mjs/a11y/speech/en.js
+++ b/components/mjs/a11y/speech/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/a11y/speech/__locales__/Component.js';
+import data from '#ts/a11y/speech/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/a11y/speech/speech.js
+++ b/components/mjs/a11y/speech/speech.js
@@ -1,4 +1,5 @@
 import './lib/speech.js';
+import './en.js';
 
 import {combineDefaults} from '#js/components/global.js';
 import {Package} from '#js/components/package.js';

--- a/components/mjs/adaptors/linkedom/en.js
+++ b/components/mjs/adaptors/linkedom/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/adaptors/linkedom/__locales__/Component.js';
+import data from '#ts/adaptors/linkedom/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/adaptors/linkedom/linkedom.js
+++ b/components/mjs/adaptors/linkedom/linkedom.js
@@ -1,4 +1,5 @@
 import './lib/linkedom.js';
+import './en.js';
 
 import {linkedomAdaptor} from '#js/adaptors/linkedomAdaptor.js';
 

--- a/components/mjs/core/core.js
+++ b/components/mjs/core/core.js
@@ -5,6 +5,8 @@ import {HTMLHandler} from '#js/handlers/html/HTMLHandler.js';
 import {browserAdaptor} from '#js/adaptors/browserAdaptor.js';
 import {Package} from '#js/components/package.js';
 
+import './en.js';
+
 if (MathJax.startup) {
   MathJax.startup.registerConstructor('HTMLHandler', HTMLHandler);
   MathJax.startup.registerConstructor('browserAdaptor', browserAdaptor);

--- a/components/mjs/core/en.js
+++ b/components/mjs/core/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/core/__locales__/Component.js';
+import data from '#ts/core/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/mml/en.js
+++ b/components/mjs/input/mml/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/mathml/__locales__/Component.js';
+import data from '#ts/input/mathml/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/mml/init.js
+++ b/components/mjs/input/mml/init.js
@@ -1,4 +1,5 @@
 import './lib/mml.js';
+import './en.js';
 
 import {MathML} from '#js/input/mathml.js';
 export {MathML};

--- a/components/mjs/input/tex/en.js
+++ b/components/mjs/input/tex/en.js
@@ -1,0 +1,8 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/__locales__/Component.js';
+import { COMPONENT as BASE } from '#js/input/tex/base/__locales__/Component.js';
+import data from '#ts/input/tex/__locales__/en.json' with {type: 'json'};
+import basedata from '#ts/input/tex/base/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);
+Locale.registerMessages(BASE, 'en', basedata);

--- a/components/mjs/input/tex/extensions/ams/ams.js
+++ b/components/mjs/input/tex/extensions/ams/ams.js
@@ -1,1 +1,2 @@
 import './lib/ams.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/ams/en.js
+++ b/components/mjs/input/tex/extensions/ams/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/ams/__locales__/Component.js';
+import data from '#ts/input/tex/ams/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/bbox/bbox.js
+++ b/components/mjs/input/tex/extensions/bbox/bbox.js
@@ -1,1 +1,2 @@
 import './lib/bbox.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/bbox/en.js
+++ b/components/mjs/input/tex/extensions/bbox/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/bbox/__locales__/Component.js';
+import data from '#ts/input/tex/bbox/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/begingroup/begingroup.js
+++ b/components/mjs/input/tex/extensions/begingroup/begingroup.js
@@ -1,1 +1,2 @@
 import './lib/begingroup.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/begingroup/en.js
+++ b/components/mjs/input/tex/extensions/begingroup/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/begingroup/__locales__/Component.js';
+import data from '#ts/input/tex/begingroup/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/bussproofs/bussproofs.js
+++ b/components/mjs/input/tex/extensions/bussproofs/bussproofs.js
@@ -1,1 +1,2 @@
 import './lib/bussproofs.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/bussproofs/en.js
+++ b/components/mjs/input/tex/extensions/bussproofs/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/bussproofs/__locales__/Component.js';
+import data from '#ts/input/tex/bussproofs/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/cases/cases.js
+++ b/components/mjs/input/tex/extensions/cases/cases.js
@@ -1,1 +1,2 @@
 import './lib/cases.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/cases/en.js
+++ b/components/mjs/input/tex/extensions/cases/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/cases/__locales__/Component.js';
+import data from '#ts/input/tex/cases/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/color/color.js
+++ b/components/mjs/input/tex/extensions/color/color.js
@@ -1,1 +1,2 @@
 import './lib/color.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/color/en.js
+++ b/components/mjs/input/tex/extensions/color/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/color/__locales__/Component.js';
+import data from '#ts/input/tex/color/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/colortbl/colortbl.js
+++ b/components/mjs/input/tex/extensions/colortbl/colortbl.js
@@ -1,1 +1,2 @@
 import './lib/colortbl.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/colortbl/en.js
+++ b/components/mjs/input/tex/extensions/colortbl/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/colortbl/__locales__/Component.js';
+import data from '#ts/input/tex/colortbl/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/empheq/empheq.js
+++ b/components/mjs/input/tex/extensions/empheq/empheq.js
@@ -1,1 +1,2 @@
 import './lib/empheq.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/empheq/en.js
+++ b/components/mjs/input/tex/extensions/empheq/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/empheq/__locales__/Component.js';
+import data from '#ts/input/tex/empheq/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/extpfeil/en.js
+++ b/components/mjs/input/tex/extensions/extpfeil/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/extpfeil/__locales__/Component.js';
+import data from '#ts/input/tex/extpfeil/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/extpfeil/extpfeil.js
+++ b/components/mjs/input/tex/extensions/extpfeil/extpfeil.js
@@ -1,1 +1,2 @@
 import './lib/extpfeil.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/html/en.js
+++ b/components/mjs/input/tex/extensions/html/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/html/__locales__/Component.js';
+import data from '#ts/input/tex/html/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/html/html.js
+++ b/components/mjs/input/tex/extensions/html/html.js
@@ -1,1 +1,2 @@
 import './lib/html.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/mathtools/en.js
+++ b/components/mjs/input/tex/extensions/mathtools/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/mathtools/__locales__/Component.js';
+import data from '#ts/input/tex/mathtools/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/mathtools/mathtools.js
+++ b/components/mjs/input/tex/extensions/mathtools/mathtools.js
@@ -1,1 +1,2 @@
 import './lib/mathtools.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/mhchem/en.js
+++ b/components/mjs/input/tex/extensions/mhchem/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/mhchem/__locales__/Component.js';
+import data from '#ts/input/tex/mhchem/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/mhchem/mhchem.js
+++ b/components/mjs/input/tex/extensions/mhchem/mhchem.js
@@ -1,4 +1,5 @@
 import './lib/mhchem.js';
+import './en.js';
 import {fontExtension} from '../../extension.js';
 
 fontExtension('[tex]/mhchem', 'mathjax-mhchem-font-extension');

--- a/components/mjs/input/tex/extensions/newcommand/en.js
+++ b/components/mjs/input/tex/extensions/newcommand/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/newcommand/__locales__/Component.js';
+import data from '#ts/input/tex/newcommand/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/newcommand/newcommand.js
+++ b/components/mjs/input/tex/extensions/newcommand/newcommand.js
@@ -1,1 +1,2 @@
 import './lib/newcommand.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/physics/en.js
+++ b/components/mjs/input/tex/extensions/physics/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/physics/__locales__/Component.js';
+import data from '#ts/input/tex/physics/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/physics/physics.js
+++ b/components/mjs/input/tex/extensions/physics/physics.js
@@ -1,1 +1,2 @@
 import './lib/physics.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/require/en.js
+++ b/components/mjs/input/tex/extensions/require/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/require/__locales__/Component.js';
+import data from '#ts/input/tex/require/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/require/require.js
+++ b/components/mjs/input/tex/extensions/require/require.js
@@ -1,1 +1,2 @@
 import './lib/require.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/setoptions/en.js
+++ b/components/mjs/input/tex/extensions/setoptions/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/setoptions/__locales__/Component.js';
+import data from '#ts/input/tex/setoptions/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/setoptions/setoptions.js
+++ b/components/mjs/input/tex/extensions/setoptions/setoptions.js
@@ -1,1 +1,2 @@
 import './lib/setoptions.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/textmacros/en.js
+++ b/components/mjs/input/tex/extensions/textmacros/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/textmacros/__locales__/Component.js';
+import data from '#ts/input/tex/textmacros/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/textmacros/textmacros.js
+++ b/components/mjs/input/tex/extensions/textmacros/textmacros.js
@@ -1,1 +1,2 @@
 import './lib/textmacros.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/unicode/en.js
+++ b/components/mjs/input/tex/extensions/unicode/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/unicode/__locales__/Component.js';
+import data from '#ts/input/tex/unicode/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/unicode/unicode.js
+++ b/components/mjs/input/tex/extensions/unicode/unicode.js
@@ -1,1 +1,2 @@
 import './lib/unicode.js';
+import './en.js';

--- a/components/mjs/input/tex/extensions/verb/en.js
+++ b/components/mjs/input/tex/extensions/verb/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/input/tex/verb/__locales__/Component.js';
+import data from '#ts/input/tex/verb/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/input/tex/extensions/verb/verb.js
+++ b/components/mjs/input/tex/extensions/verb/verb.js
@@ -1,1 +1,2 @@
 import './lib/verb.js';
+import './en.js';

--- a/components/mjs/input/tex/tex.js
+++ b/components/mjs/input/tex/tex.js
@@ -1,4 +1,5 @@
 import './lib/tex.js';
+import './en.js';
 
 import {registerTeX} from './register.js';
 import {Loader} from '#js/components/loader.js';

--- a/components/mjs/ui/menu/en.js
+++ b/components/mjs/ui/menu/en.js
@@ -1,0 +1,5 @@
+import { Locale } from '#js/util/Locale.js';
+import { COMPONENT } from '#js/ui/menu/__locales__/Component.js';
+import data from '#ts/ui/menu/__locales__/en.json' with {type: 'json'};
+
+Locale.registerMessages(COMPONENT, 'en', data);

--- a/components/mjs/ui/menu/menu.js
+++ b/components/mjs/ui/menu/menu.js
@@ -1,4 +1,5 @@
 import './lib/menu.js';
+import './en.js';
 
 import {combineDefaults} from '#js/components/global.js';
 import {MenuHandler} from '#js/ui/menu/MenuHandler.js';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "./*": "./*"
   },
   "imports": {
+    "#ts/*": "@mathjax/src/ts/*",
     "#js/*": "@mathjax/src/mjs/*",
     "#source/*": "@mathjax/src/components/mjs/*",
     "#root/*": "@mathjax/src/mjs/components/mjs/*",
@@ -140,7 +141,7 @@
     "build-mjs": "pnpm -s mjs:build",
     "make-cjs-components": "pnpm -s cjs:components:make && pnpm -s cjs:bundle:finalize",
     "make-mjs-components": "pnpm -s mjs:components:make",
-    "make-one": "make() { node components/bin/makeAll --no-subdirs $3 $4 --${2:-mjs} components/${2-:mjs}/$1; }; make",
+    "make-one": "make() { node components/bin/makeAll --no-subdirs $3 $4 --${2:-mjs} components/${2:-mjs}/$1; }; make",
     "make-components": "pnpm -s make-mjs-components",
     "compile": "pnpm -s compile-mjs",
     "build": "pnpm -s build-mjs",

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -117,6 +117,7 @@ export class Locale {
       cdata[locale] = Object.create(null);
     }
     Object.assign(cdata[locale], data);
+    this.locations[component][1].add(locale);
   }
 
   /**

--- a/tsconfig/cjs.json
+++ b/tsconfig/cjs.json
@@ -5,6 +5,7 @@
     "outDir": "../cjs",
     "module": "CommonJS",
     "paths": {
+      "#ts/*": ["./*"],
       "#js/*": ["../cjs/*"],
       "#source/*": ["../components/cjs/*"],
       "#root/*": ["../ts/components/cjs/*"],

--- a/tsconfig/mjs.json
+++ b/tsconfig/mjs.json
@@ -6,6 +6,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "paths": {
+      "#ts/*": ["./*"],
       "#js/*": ["../mjs/*"],
       "#source/*": ["../components/mjs/*"],
       "#root/*": ["../ts/components/mjs/*"],


### PR DESCRIPTION
This PR adds files to the `components/mjs` subdirectories in order to pre-load the `en` locale definitions when the components are webpacked (or loaded into a node application).  This required the addition of a `#ts` pseudo-path in order to be able to access the definitions from the `ts` directory (since they might not have been moved to the `mjs` or `bundle` directories yet).

This is done through the use of separate `en.js` files for each component so that it would be possible to use the webpack configuration to replace them easily with files for another locale, if a version with a different built-in default wanted to be created.

An alternative would be to move these to the `ts/**/__locales__` directories and have the `Component.ts` files load them directly.  Then even node applications with direct calls to the modules would have the default `en` localization automatically, and there would not be a need for the warning message if `Locale.setLocale()` wasn't called first.  But then node applications that change the default locale will end up loading both `en` and the new one, whereas with the files where they are now, that would not be the case for direct module loading.  I'm not sure which is the better approach.