### PR TITLE
Fix problem with `\limits` and `\nolimits` when used after a script. (mathjax/MathJax#3569)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -645,14 +645,14 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       // @test Limits UnderOver
       node = parser.create('node', 'msubsup');
       NodeUtil.copyChildren(op, node);
-      op = top.Last = node;
+      op = top.First = node;
     } else if (NodeUtil.isType(op, 'msubsup') && limits) {
       // @test Limits SubSup
       // node = parser.create('node', 'munderover', NodeUtil.getChildren(op), {});
       // Needs to be copied, otherwise we get an error in MmlNode.appendChild!
       node = parser.create('node', 'munderover');
       NodeUtil.copyChildren(op, node);
-      op = top.Last = node;
+      op = top.First = node;
     }
     NodeUtil.setProperty(op, 'movesupsub', limits ? true : false);
     NodeUtil.setProperties(NodeUtil.getCoreMO(op), { movablelimits: false });


### PR DESCRIPTION
This PR fixes a problem with `\limits` and `\nolimits` when they are used after a super- or subscript is already specified and the operator has a coefficient.  E.g. `1 \sum_n\nolimits`.  The problem is that the wrong stack item is being replaced.

Resolves issue mathjax/MathJax#3569.