### PR TITLE
Add symmetric="true" to \middle results.  (mathjax/MathJax#3560)

### DIFF
--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -3552,7 +3552,7 @@ exports[`Fenced Fenced Arrows 3 1`] = `
       <mi data-latex="b">b</mi>
     </mfrac>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-latex="\\middle\\downarrow ">&#x2193;</mo>
+    <mo symmetric="true" data-latex="\\middle\\downarrow ">&#x2193;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\downarrow"></mrow>
     <mi data-latex="c">c</mi>
     <mo data-mjx-texclass="CLOSE" fence="true" symmetric="true" data-latex="\\right\\uparrow">&#x2191;</mo>
@@ -3660,7 +3660,7 @@ exports[`Fenced Middle 1`] = `
     <mo data-mjx-texclass="OPEN" data-latex="\\left(">(</mo>
     <mi data-latex="a">a</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle|">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle|">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
     <mi data-latex="b">b</mi>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right)">)</mo>
@@ -7931,7 +7931,7 @@ exports[`Spacing Nonscript scriptlevel 1`] = `
         <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex="\\left."></mo>
         <mi data-latex="a">a</mi>
         <mrow data-mjx-texclass="CLOSE"></mrow>
-        <mo stretchy="true" data-latex="\\middle|">|</mo>
+        <mo stretchy="true" symmetric="true" data-latex="\\middle|">|</mo>
         <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
         <mi data-latex="b">b</mi>
         <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex="\\right."></mo>
@@ -7948,7 +7948,7 @@ exports[`Spacing Nonscript toplevel 1`] = `
     <mi data-latex="a">a</mi>
     <mspace width="0.278em"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle|">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle|">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
     <mspace width="0.278em"></mspace>
     <mi data-latex="b">b</mi>
@@ -9156,7 +9156,7 @@ exports[`User Defined Macros Middle Color 1`] = `
     <mi data-latex="A">A</mi>
     <mstyle mathcolor="red"></mstyle>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" mathcolor="red" data-latex="\\middle|">|</mo>
+    <mo stretchy="true" symmetric="true" mathcolor="red" data-latex="\\middle|">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
     <mi data-latex="B">B</mi>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right)">)</mo>
@@ -9170,7 +9170,7 @@ exports[`User Defined Macros Right Color 1`] = `
     <mo data-mjx-texclass="OPEN" data-latex="\\left(">(</mo>
     <mi data-latex="A">A</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle|">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle|">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
     <mi data-latex="B">B</mi>
     <mstyle mathcolor="red"></mstyle>

--- a/testsuite/tests/input/tex/__snapshots__/Physics.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Physics.test.ts.snap
@@ -150,7 +150,7 @@ exports[`Bra-Ket Macros Rest innerproduct arg one 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
@@ -168,7 +168,7 @@ exports[`Bra-Ket Macros Rest innerproduct arg three 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -189,7 +189,7 @@ exports[`Bra-Ket Macros Rest innerproduct arg two 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -207,7 +207,7 @@ exports[`Bra-Ket Macros Rest ip arg one 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
@@ -225,7 +225,7 @@ exports[`Bra-Ket Macros Rest ip arg three 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -246,7 +246,7 @@ exports[`Bra-Ket Macros Rest ip arg two 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -4956,7 +4956,7 @@ exports[`Physics5_0 Derivatives_Deriv_9 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\rm d}">
       <mi mathvariant="normal" data-latex="d">d</mi>
@@ -4993,7 +4993,7 @@ exports[`Physics5_0 Derivatives_Deriv_10 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\rm d}">
       <mi mathvariant="normal" data-latex="d">d</mi>
@@ -5129,7 +5129,7 @@ exports[`Physics5_1 Derivatives_Partial_0 1`] = `
     <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex="\\left."></mo>
     <mi data-latex="x">x</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="y">y</mi>
     <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex="\\right."></mo>
@@ -5146,7 +5146,7 @@ exports[`Physics5_1 Derivatives_Partial_1 1`] = `
       <mn data-latex="2">2</mn>
     </msup>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="y">y</mi>
     <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex="\\right."></mo>
@@ -5294,7 +5294,7 @@ exports[`Physics5_1 Derivatives_Partial_10 1`] = `
     <mi data-latex="\\partial">&#x2202;</mi>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\partial">&#x2202;</mi>
     <mi data-latex="x">x</mi>
@@ -5315,7 +5315,7 @@ exports[`Physics5_1 Derivatives_Partial_11 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\partial">&#x2202;</mi>
     <msup data-latex="x^{3}">
@@ -5393,7 +5393,7 @@ exports[`Physics5_1 Derivatives_Partial_14 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\partial">&#x2202;</mi>
     <mi data-latex="x">x</mi>
@@ -5416,7 +5416,7 @@ exports[`Physics5_1 Derivatives_Partial_15 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\partial">&#x2202;</mi>
     <mi data-latex="x">x</mi>
@@ -5634,7 +5634,7 @@ exports[`Physics5_2 Derivatives_Functional_8 1`] = `
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="F">F</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="x">x</mi>
@@ -5650,7 +5650,7 @@ exports[`Physics5_2 Derivatives_Functional_9 1`] = `
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="F">F</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="x">x</mi>
@@ -5666,7 +5666,7 @@ exports[`Physics5_2 Derivatives_Functional_10 1`] = `
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="F">F</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\delta">&#x3B4;</mi>
     <mi data-latex="x">x</mi>
@@ -5791,7 +5791,7 @@ exports[`Physics5_2 Derivatives_Functional_15 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\delta">&#x3B4;</mi>
     <msup data-latex="x^{n}">
@@ -5824,7 +5824,7 @@ exports[`Physics5_2 Derivatives_Functional_16 1`] = `
     </msup>
     <mi data-latex="f">f</mi>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle/">/</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle/">/</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle/"></mrow>
     <mi data-latex="\\delta">&#x3B4;</mi>
     <msup data-latex="x^{}">
@@ -6482,7 +6482,7 @@ exports[`Physics6_0 BraKet_Bra_0 1`] = `
       <mi data-latex="\\phi">&#x3D5;</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\psi}">
       <mi data-latex="\\psi">&#x3C8;</mi>
@@ -6500,7 +6500,7 @@ exports[`Physics6_0 BraKet_Bra_1 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -6548,7 +6548,7 @@ exports[`Physics6_0 BraKet_Bra_3 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -6605,7 +6605,7 @@ exports[`Physics6_0 BraKet_Bra_6 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{B}">
       <mi data-latex="B">B</mi>
@@ -6623,7 +6623,7 @@ exports[`Physics6_0 BraKet_Bra_7 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -6639,7 +6639,7 @@ exports[`Physics6_0 BraKet_Bra_8 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -6655,7 +6655,7 @@ exports[`Physics6_0 BraKet_Bra_9 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -6675,7 +6675,7 @@ exports[`Physics6_0 BraKet_Bra_10 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -6777,7 +6777,7 @@ exports[`Physics6_1 BraKet_Braket_0 1`] = `
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
@@ -6798,7 +6798,7 @@ exports[`Physics6_1 BraKet_Braket_1 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
       <mfrac data-latex="\\frac{a}{b}">
@@ -6853,7 +6853,7 @@ exports[`Physics6_1 BraKet_Braket_4 1`] = `
       <mi data-latex="a">a</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{a}">
       <mi data-latex="a">a</mi>
@@ -6885,7 +6885,7 @@ exports[`Physics6_1 BraKet_Braket_6 1`] = `
       <mi data-latex="\\alpha">&#x3B1;</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\alpha}">
       <mi data-latex="\\alpha">&#x3B1;</mi>
@@ -6906,7 +6906,7 @@ exports[`Physics6_1 BraKet_Braket_7 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
@@ -6944,7 +6944,7 @@ exports[`Physics6_1 BraKet_Braket_9 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
       <mfrac data-latex="\\frac{a}{b}">
@@ -6990,7 +6990,7 @@ exports[`Physics6_1 BraKet_Braket_11 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mo data-mjx-texclass="CLOSE" data-latex="\\right\\rangle">&#x27E9;</mo>
@@ -7521,13 +7521,13 @@ exports[`Physics6_3 BraKet_Expect_7 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{A}{B}}">
       <mfrac data-latex="\\frac{A}{B}">
@@ -7632,13 +7632,13 @@ exports[`Physics6_3 BraKet_Expect_12 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{A}">
       <mi data-latex="A">A</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{A}{B}}">
       <mfrac data-latex="\\frac{A}{B}">
@@ -7749,7 +7749,7 @@ exports[`Physics6_3 BraKet_Expect_16 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{A}{B}}">
       <mfrac data-latex="\\frac{A}{B}">
@@ -7758,7 +7758,7 @@ exports[`Physics6_3 BraKet_Expect_16 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{\\Psi}{\\Phi}}">
       <mfrac data-latex="\\frac{\\Psi}{\\Phi}">
@@ -7924,7 +7924,7 @@ exports[`Physics6_4 BraKet_MatrixEl_6 1`] = `
       <mi data-latex="n">n</mi>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
       <mfrac data-latex="\\frac{a}{b}">
@@ -7933,7 +7933,7 @@ exports[`Physics6_4 BraKet_MatrixEl_6 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{m}">
       <mi data-latex="m">m</mi>
@@ -7954,7 +7954,7 @@ exports[`Physics6_4 BraKet_MatrixEl_7 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
       <mfrac data-latex="\\frac{a}{b}">
@@ -7963,7 +7963,7 @@ exports[`Physics6_4 BraKet_MatrixEl_7 1`] = `
       </mfrac>
     </mrow>
     <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo stretchy="true" data-latex="\\middle\\vert">|</mo>
+    <mo stretchy="true" symmetric="true" data-latex="\\middle\\vert">|</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
       <mfrac data-latex="\\frac{a}{b}">

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -432,7 +432,7 @@ export class LeftItem extends BaseItem {
       //
       //  Add the middle delimiter, with empty open and close elements around it for spacing
       //
-      const def = { stretchy: true } as any;
+      const def = { stretchy: true, symmetric: true } as any;
       if (item.getProperty('color')) {
         def.mathcolor = item.getProperty('color');
       }


### PR DESCRIPTION
This PR makes sure that the character used for `\middle` is placed symmetrically (to match the open abdominal close delimiters).

This resolves issue mathjax/MathJax#3560