### PR TITLE
Load font files synchronously, when possible.  (#1458)

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -1333,10 +1333,9 @@ export class FontData<
       if (mathjax.asyncIsSynchronous) {
         this.loadDynamicFileSync(delim);
         return this.getDelimiter(n);
-      } else {
-        retryAfter(this.loadDynamicFile(delim));
-        return null;
       }
+      retryAfter(this.loadDynamicFile(delim));
+      return null;
     }
     return delim as DelimiterData;
   }
@@ -1386,10 +1385,9 @@ export class FontData<
       if (mathjax.asyncIsSynchronous) {
         this.loadDynamicFileSync(char);
         return this.getChar(name, n);
-      } else {
-        retryAfter(this.loadDynamicFile(char));
-        return null;
       }
+      retryAfter(this.loadDynamicFile(char));
+      return null;
     }
     return char as CharDataArray<C>;
   }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -1330,8 +1330,13 @@ export class FontData<
     const delim = this.delimiters[n];
     if (delim && !('dir' in delim)) {
       this.delimiters[n] = null;
-      retryAfter(this.loadDynamicFile(delim));
-      return null;
+      if (mathjax.asyncIsSynchronous) {
+        this.loadDynamicFileSync(delim);
+        return this.getDelimiter(n);
+      } else {
+        retryAfter(this.loadDynamicFile(delim));
+        return null;
+      }
     }
     return delim as DelimiterData;
   }
@@ -1378,8 +1383,13 @@ export class FontData<
       const variant = this.variant[name];
       delete variant.chars[n];
       variant.linked.forEach((link) => delete link[n]);
-      retryAfter(this.loadDynamicFile(char));
-      return null;
+      if (mathjax.asyncIsSynchronous) {
+        this.loadDynamicFileSync(char);
+        return this.getChar(name, n);
+      } else {
+        retryAfter(this.loadDynamicFile(char));
+        return null;
+      }
     }
     return char as CharDataArray<C>;
   }


### PR DESCRIPTION
This PR allows font ranges to be loaded synchronously if the `mathjax.asyncLoad()` method is marked as synchronous.  That makes it possible to use the synchronous typesetting and conversion calls in more situations.

Resolves issue #1458.