### PR TITLE
Don't rerender the output during menu initialization.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -250,6 +250,8 @@ export class Menu {
    */
   protected document: MenuMathDocument;
 
+  protected initialized: boolean = false;
+
   /**
    * Instances of the various output jax that we can switch to
    */
@@ -566,6 +568,7 @@ export class Menu {
     this.mergeUserSettings();
     this.initMenu();
     this.applySettings();
+    this.initialized = true;
   }
 
   /**
@@ -1108,7 +1111,7 @@ export class Menu {
    */
   protected setOverflow(overflow: string) {
     this.document.outputJax.options.displayOverflow = overflow.toLowerCase();
-    if (!Menu.loading) {
+    if (!Menu.loading && this.initialized) {
       this.document.rerenderPromise();
     }
   }
@@ -1118,7 +1121,7 @@ export class Menu {
    */
   protected setInlineBreaks(breaks: boolean) {
     this.document.outputJax.options.linebreaks.inline = breaks;
-    if (!Menu.loading) {
+    if (!Menu.loading && this.initialized) {
       this.document.rerenderPromise();
     }
   }
@@ -1128,7 +1131,7 @@ export class Menu {
    */
   protected setScale(scale: string) {
     this.document.outputJax.options.scale = parseFloat(scale);
-    if (!Menu.loading) {
+    if (!Menu.loading && this.initialized) {
       this.document.rerenderPromise();
     }
   }


### PR DESCRIPTION
This PR adjusts the menu code to **not** re-render while the menu is being initialized and user preferences are being set (the actions attached to the menu variables could cause re-rendering).