### PR TITLE
Make sure the parsers array is cleared for tex and text parsers.  (#1474)

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -187,6 +187,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   public reset(tag: number = 0) {
+    this.parseOptions.clear();
     this.parseOptions.tags.reset(tag);
   }
 

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -159,7 +159,7 @@ export class Configuration {
   }
 
   /**
-   * Creates an unnamed, ephemeral package configuration. It will not added to
+   * Creates an unnamed, ephemeral package configuration. It is not added to
    * the configuration handler.
    *
    * @param {object} config See `create` method.

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -248,11 +248,11 @@ export default class TexParser {
    * @returns {MmlNode} The internal Mathml structure.
    */
   public mml(): MmlNode {
+    this.configuration.popParser();
     if (!this.stack.Top().isKind('mml')) {
       return null;
     }
     const node = this.stack.Top().First;
-    this.configuration.popParser();
     const latex = this.trimTex(this.string);
     if (latex) {
       node.attributes.set(TexConstant.Attr.LATEX, latex);

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -160,6 +160,7 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
       //
       const config = data.data.packageData.get('textmacros');
       config.parseOptions.nodeFactory.setMmlFactory(config.jax.mmlFactory);
+      config.parseOptions.clear();
     },
   ],
   [ConfigurationType.OPTIONS]: {


### PR DESCRIPTION
This PR moves the `popParser()` call in the `mml()` function of the `TeXParser` object so that it will be performed even when the function exits early.  It also adds `parseOptions.clear()` to the TeX input jax `reset()` function, as well as the TextMacros preprocessor, just like is done in the TeX input jax `compile()` function.

Resolves issue #1474.