### PR TITLE
Fix `\bbox` problem with padding values that are decimals.  (mathjax/MathJax#3568)

### DIFF
--- a/ts/input/tex/bbox/BboxConfiguration.ts
+++ b/ts/input/tex/bbox/BboxConfiguration.ts
@@ -64,7 +64,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
             height: '+' + pad,
             depth: '+' + pad,
             lspace: pad,
-            width: '+' + 2 * parseInt(match[1], 10) + match[3],
+            width: '+' + 2 * parseFloat(match[1]) + match[3],
           };
         }
       } else if (part.match(/^([a-z0-9]+|#[0-9a-f]{6}|#[0-9a-f]{3})$/i)) {


### PR DESCRIPTION
This PR fixes a problem with `\bbox` where padding values that are decimals can lead to `NaN` values.  This was caused by using `parseInt()` instead of `parseFloat()`, so the fix is easy.

Resolves issue mathjax/MathJax#3568.