### PR TITLE
Make sure multi-byte UTF8 characters are handled properly in data-latex attributes.  (mathjax/MathJax#3575)

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -151,7 +151,7 @@ export default class TexParser {
     //
     // Back up one to pick up the parsed character (this.i is past it at this point).
     //
-    this.saveI = this.i - (kind === 'character' && input[1] !== '&' ? 1 : 0);
+    this.saveI = this.i - (kind === 'character' && input[1] !== '&' ? input[1].length : 0);
     const result = this.configuration.handlers.get(kind).parse(input);
     //
     // The macro gets processed by the \\ character later


### PR DESCRIPTION
This PR fixes a problem where unicode characters from planes other than Plane0 are not properly entered in some `data-latex` attributes.  The problem is that for a character that requires multiple string character at the beginning of the attribute, we need to back up the correct number of characters (not just 1).  The fix uses the string length of the unicode character passed to it.

Resolves issue mathjax/MathJax#3575.