### PR TITLE
Set box-sizing in dialogs to avoid CSS bleed through that affects close and help buttons.

### DIFF
--- a/ts/ui/dialog/DraggableDialog.ts
+++ b/ts/ui/dialog/DraggableDialog.ts
@@ -210,6 +210,9 @@ export class DraggableDialog {
       position: 'fixed',
       top: '-4%',
     },
+    '.mjx-dialog *': {
+      'box-sizing': 'content-box',
+    },
     '.mjx-dialog.mjx-moving': {
       cursor: 'grabbing',
     },


### PR DESCRIPTION
I've seen several sites that use CSS like

``` css
* {
  box-sizing: border-box;
}
```

and this CSS affects the layout of MathJax's dialog boxes (it distorts the close and help buttons in the top corners).

This PR adds CSS to reset the `box-sizing` to `content-box` so that those button will not be distorted.