### PR TITLE
Fix label ids for expressions with forward refs.  (mathjax/MathJax#3562)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -2177,13 +2177,13 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       // @test Label Empty
       return;
     }
+    // @test Label, Ref, Ref Unknown
+    if (parser.tags.label) {
+      // @test Double Label Error
+      throw new TexError('MultipleCommand', 'Multiple %1', parser.currentCS);
+    }
+    parser.tags.label = label;
     if (!parser.tags.refUpdate) {
-      // @test Label, Ref, Ref Unknown
-      if (parser.tags.label) {
-        // @test Double Label Error
-        throw new TexError('MultipleCommand', 'Multiple %1', parser.currentCS);
-      }
-      parser.tags.label = label;
       if (
         (parser.tags.allLabels[label] || parser.tags.labels[label]) &&
         !parser.options['ignoreDuplicateLabels']


### PR DESCRIPTION
This PR fixes a problem where the ID attribute used for a tagged equation is incorrect if the equation includes a forward reference.  This turns out to be due to the `HandleLabel()` base method skipping the setting of the tag's label during the `refUpdate` pass.  The check for `refUpdate` occurs too early, and the fix is to move that check until after the label is set.

This may cause a merge conflict when the locale branch is merged, since the altered code includes a tex error call.  We will have to deal with that at when it occurs.

Resolves issue mathjax/MathJax#3562.