### PR TITLE
Ignore braces in array preamble.  (mathjax/MathJax#3565)

### DIFF
--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4014,6 +4014,14 @@ describe('Complete Array', () => {
     expect(tex2mml('\\begin{array}{{{c}}} X \\end{array}')).toMatchSnapshot();
   });
 
+  it('column newline', () => {
+    expect(tex2mml('\\begin{array}{c\nc} X & Y\\end{array}')).toMatchSnapshot();
+  });
+
+  it('column > > c < <', () => {
+    expect(tex2mml('\\begin{array}{>{a}>{b}c<{x}<{y}} X \\end{array}')).toMatchSnapshot();
+  });
+
   it('column brace errors', () => {
     expectTexError(tex2mml('\\begin{array}{c{xx}} X Y \\end{array}')).toBe('Illegal pream-token (xx)');
     expectTexError(tex2mml('\\begin{array}{c{{c}}} X Y \\end{array}')).toBe('Illegal pream-token ({c})');

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4002,6 +4002,10 @@ describe('Complete Array', () => {
     expect(tex2mml('\\begin{array}{> {x} c} X \\end{array}')).toMatchSnapshot();
   });
 
+  it('column { }', () => {
+    expect(tex2mml('\\begin{array}{{c}} X \\end{array}')).toMatchSnapshot();
+  });
+
   it('BadPreamToken', () => {
     expectTexError('\\begin{array}a').toBe('Illegal pream-token (a)');
   });

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4014,6 +4014,10 @@ describe('Complete Array', () => {
     expect(tex2mml('\\begin{array}{{{c}}} X \\end{array}')).toMatchSnapshot();
   });
 
+  it('column {r}c{l}', () => {
+    expect(tex2mml('\\begin{array}{{r}c{l}} X & Y & Z \\end{array}')).toMatchSnapshot();
+  });
+
   it('column newline', () => {
     expect(tex2mml('\\begin{array}{c\nc} X & Y\\end{array}')).toMatchSnapshot();
   });

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4002,8 +4002,22 @@ describe('Complete Array', () => {
     expect(tex2mml('\\begin{array}{> {x} c} X \\end{array}')).toMatchSnapshot();
   });
 
-  it('column { }', () => {
-    expect(tex2mml('\\begin{array}{{c}} X \\end{array}')).toMatchSnapshot();
+  it('column {cc}', () => {
+    expect(tex2mml('\\begin{array}{{cc}} X Y \\end{array}')).toMatchSnapshot();
+  });
+
+  it('column {c}', () => {
+    expect(tex2mml('\\begin{array}{c{c}} X Y \\end{array}')).toMatchSnapshot();
+  });
+
+  it('column {{c}}', () => {
+    expect(tex2mml('\\begin{array}{{{c}}} X \\end{array}')).toMatchSnapshot();
+  });
+
+  it('column brace errors', () => {
+    expectTexError(tex2mml('\\begin{array}{c{xx}} X Y \\end{array}')).toBe('Illegal pream-token (xx)');
+    expectTexError(tex2mml('\\begin{array}{c{{c}}} X Y \\end{array}')).toBe('Illegal pream-token ({c})');
+    expectTexError(tex2mml('\\begin{array}{c{c{c}}} X Y \\end{array}')).toBe('Illegal pream-token (c{c})');
   });
 
   it('BadPreamToken', () => {

--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -1926,6 +1926,24 @@ exports[`Complete Array column {cc} 1`] = `
 </math>"
 `;
 
+exports[`Complete Array column {r}c{l} 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{{r}c{l}} X &amp; Y &amp; Z \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{{r}c{l}} X &amp; Y &amp; Z \\end{array}">
+    <mtr data-latex="{{r}c{l}}">
+      <mtd>
+        <mi data-latex="X">X</mi>
+      </mtd>
+      <mtd>
+        <mi data-latex="Y">Y</mi>
+      </mtd>
+      <mtd>
+        <mi data-latex="Z">Z</mi>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
 exports[`Complete Array column b  1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{b{1cm}b{1cm}b{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
   <mtable columnspacing="1em" rowspacing="4pt" columnalign="left left left" columnwidth="1cm 1cm 1cm" data-frame-styles="" framespacing=".5em .125em" data-latex="\\text{f}\\end{array}">

--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -1872,6 +1872,18 @@ exports[`Complete Array column @ p m 1`] = `
 </math>"
 `;
 
+exports[`Complete Array column { } 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{{c}} X \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{{c}} X \\end{array}">
+    <mtr data-latex="{{c}}">
+      <mtd>
+        <mi data-latex="X">X</mi>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
 exports[`Complete Array column b  1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{b{1cm}b{1cm}b{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
   <mtable columnspacing="1em" rowspacing="4pt" columnalign="left left left" columnwidth="1cm 1cm 1cm" data-frame-styles="" framespacing=".5em .125em" data-latex="\\text{f}\\end{array}">

--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -1820,6 +1820,22 @@ exports[`Complete Array column ! | @ 1`] = `
 </math>"
 `;
 
+exports[`Complete Array column > > c < < 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{&gt;{a}&gt;{b}c&lt;{x}&lt;{y}} X \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex="baXyx\\end{array}">
+    <mtr>
+      <mtd>
+        <mi data-latex="b">b</mi>
+        <mi data-latex="a">a</mi>
+        <mi data-latex="X">X</mi>
+        <mi data-latex="y">y</mi>
+        <mi data-latex="x">x</mi>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
 exports[`Complete Array column > space 1`] = `
 "<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{&gt; {x} c} X \\end{array}" display="block">
   <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex="xX\\end{array}">
@@ -2211,6 +2227,24 @@ exports[`Complete Array column m  1`] = `
         <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
           <mtext data-latex="\\text{f}">f</mtext>
         </mpadded>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
+exports[`Complete Array column newline 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c
+c} X &amp; Y\\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{c
+c} X &amp; Y\\end{array}">
+    <mtr data-latex="{c
+c}">
+      <mtd>
+        <mi data-latex="X">X</mi>
+      </mtd>
+      <mtd>
+        <mi data-latex="Y">Y</mi>
       </mtd>
     </mtr>
   </mtable>

--- a/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Base.test.ts.snap
@@ -1872,12 +1872,38 @@ exports[`Complete Array column @ p m 1`] = `
 </math>"
 `;
 
-exports[`Complete Array column { } 1`] = `
-"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{{c}} X \\end{array}" display="block">
-  <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{{c}} X \\end{array}">
-    <mtr data-latex="{{c}}">
+exports[`Complete Array column {{c}} 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{{{c}}} X \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{{{c}}} X \\end{array}">
+    <mtr data-latex="{{{c}}}">
       <mtd>
         <mi data-latex="X">X</mi>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
+exports[`Complete Array column {c} 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c{c}} X Y \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{c{c}} X Y \\end{array}">
+    <mtr data-latex="{c{c}}">
+      <mtd>
+        <mi data-latex="X">X</mi>
+        <mi data-latex="Y">Y</mi>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>"
+`;
+
+exports[`Complete Array column {cc} 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{{cc}} X Y \\end{array}" display="block">
+  <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex="\\begin{array}{{cc}} X Y \\end{array}">
+    <mtr data-latex="{{cc}}">
+      <mtd>
+        <mi data-latex="X">X</mi>
+        <mi data-latex="Y">Y</mi>
       </mtd>
     </mtr>
   </mtable>

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -94,6 +94,8 @@ export class ColumnParser {
     // Ignored
     //
     ' ': (_state) => {},
+    '{': (_state) => {},
+    '}': (_state) => {},
   };
 
   /**

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -112,12 +112,6 @@ export class ColumnParser {
    */
   public process(parser: TexParser, template: string, array: ArrayItem) {
     //
-    // Remove one pair of braces, if there are any
-    //
-    if (template.charAt(0) === '{' && template.slice(-1) === '}') {
-      template = template.slice(1, -1);
-    }
-    //
     // Initialize the state
     //
     const state: ColumnState = {
@@ -135,6 +129,16 @@ export class ColumnParser {
       ralign: array.ralign,
       cextra: array.cextra,
     };
+    //
+    // Remove one pair of braces, if there are any
+    //
+    if (template.charAt(0) === '{' && template.slice(-1) === '}') {
+      const braced = this.getBraces(state);
+      if (braced.length === template.length - 2) {
+        state.template = braced;
+      }
+      state.i = 0;
+    }
     //
     // Loop through the template to process the column specifiers
     //

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -77,10 +77,10 @@ export class ColumnParser {
     ':': (state) => this.addRule(state, 'dashed'),
     '>': (state) =>
       (state.cstart[state.j] =
-        (state.cstart[state.j] || '') + this.getBraces(state)),
+        this.getBraces(state) + (state.cstart[state.j] || '')),
     '<': (state) =>
       (state.cend[state.j - 1] =
-        (state.cend[state.j - 1] || '') + this.getBraces(state)),
+        this.getBraces(state) + (state.cend[state.j - 1] || '')),
     '@': (state) => this.addAt(state, this.getBraces(state)),
     '!': (state) => this.addBang(state, this.getBraces(state)),
     '*': (state) => this.repeat(state),

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -84,6 +84,7 @@ export class ColumnParser {
     '@': (state) => this.addAt(state, this.getBraces(state)),
     '!': (state) => this.addBang(state, this.getBraces(state)),
     '*': (state) => this.repeat(state),
+    '{': (state) => this.brace(state),
     //
     // Non-standard for math-mode versions
     //
@@ -94,8 +95,7 @@ export class ColumnParser {
     // Ignored
     //
     ' ': (_state) => {},
-    '{': (_state) => {},
-    '}': (_state) => {},
+    '\n': (_state_) => {},
   };
 
   /**
@@ -111,6 +111,12 @@ export class ColumnParser {
    * @param {ArrayItem} array    The ArrayItem for the template
    */
   public process(parser: TexParser, template: string, array: ArrayItem) {
+    //
+    // Remove one pair of braces, if there are any
+    //
+    if (template.charAt(0) === '{' && template.slice(-1) === '}') {
+      template = template.slice(1, -1);
+    }
     //
     // Initialize the state
     //
@@ -143,10 +149,7 @@ export class ColumnParser {
       const code = state.template.codePointAt(state.i);
       const c = (state.c = String.fromCodePoint(code));
       state.i += c.length;
-      if (!Object.hasOwn(this.columnHandler, c)) {
-        throw new TexError('BadPreamToken', 'Illegal pream-token (%1)', c);
-      }
-      this.columnHandler[c](state);
+      this.processColumn(state, c);
     }
     //
     // Set array definition values
@@ -156,6 +159,19 @@ export class ColumnParser {
     this.setColumnSpacing(state, array);
     this.setColumnLines(state, array);
     this.setPadding(state, array);
+  }
+
+  /**
+   * Process a column specifier, or throw an error if not defined.
+   *
+   * @param {ColumnState} state   The current state of the parser
+   * @param {string} c            The column type to process
+   */
+  protected processColumn(state: ColumnState, c: string) {
+    if (!Object.hasOwn(this.columnHandler, c)) {
+      throw new TexError('BadPreamToken', 'Illegal pream-token (%1)', c);
+    }
+    this.columnHandler[c](state);
   }
 
   /**
@@ -421,5 +437,15 @@ export class ColumnParser {
     state.template =
       new Array(n).fill(cols).join('') + state.template.substring(state.i);
     state.i = 0;
+  }
+
+  /**
+   * Process a braced column type
+   *
+   * @param {ColumnState} state   The current state of the parser
+   */
+  public brace(state: ColumnState) {
+    state.i--;
+    this.processColumn(state, this.getBraces(state));
   }
 }


### PR DESCRIPTION
This PR adds rules to the array preamble column parser to ignore braces within the preamble (when they aren't used to enclose an argument to one of the column specifications).  This isn't exactly in line with LaTeX, which does seem to process the braces in some way, but I can't figure out what it is, and don't see any documentation for it.  It looks like it might be to allow multi-character column specifiers, but then it also seem to allow multiple copies of a single column specifier, but not mixed ones.  So I'm not sure what it actually does.  In any case, ignoring them seems to handle the situation given in the original issue tracker.

I also added test for this situation.

Resolves issue mathjax/MathJax#3565.