### PR TITLE
Work around issue with Safari 26 not processing math inside otherwise empty containers with overflow: auto.  (mathjax/MathJax#3579)

### DIFF
--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -32,6 +32,7 @@ import { HTMLHandler } from '../../handlers/html/HTMLHandler.js';
 import { SpeechMathItem } from '../../a11y/speech.js';
 import { handleRetriesFor } from '../../util/Retries.js';
 import { OptionList } from '../../util/Options.js';
+import { StyleJson } from '../../util/StyleJson.js';
 
 /**
  * Add the needed function to the window object.
@@ -389,6 +390,19 @@ export function LazyMathDocumentMixin<
     protected lazySet: LazySet = new Set();
 
     /**
+     * Extra styles for lazy nodes.
+     */
+    public static lazyStyles: StyleJson = {
+      'mjx-lazy': {
+        //
+        // Needed for Safari 26 when the math appears inside an othewise empty
+        // node with overflow: auto.  See issue #3579.
+        //
+        display: 'inline-block',
+      },
+    };
+
+    /**
      * Augment the MathItem class used for this MathDocument,
      *   then create the intersection observer and lazy list,
      *   and bind the lazyProcessSet function to this instance
@@ -400,6 +414,7 @@ export function LazyMathDocumentMixin<
      */
     constructor(...args: any[]) {
       super(...args);
+      this.addStyles((this.constructor as typeof BaseClass).lazyStyles);
       //
       //  Use the LazyMathItem for math items
       //


### PR DESCRIPTION
This PR adds some CSS that works around an issue with Safari 26 where math that is inside a container that is otherwise empty and has `overflow: auto` will not by typeset by the lazy typeset component.  It turns out that the `mjx-lazy` elements are being picked up by the intersection observer, but are marked as `isInsersecting: false`.  This seems to be due to the fact that the `mjx-lazy` node has zero height/width inside a container of zero height that has its own block formatting context (and is clipped to its height), so the intersection contains no pixels?

In any case, changing the `mjx-lazy` element to `display: inline-block` resolves the problem without otherwise affecting the display.

Resolves issue mathjax/MathJax#3579.