### PR TITLE
Allow label ids to pass ui/safe filters.  (mathjax/MathJax#3580)

### DIFF
--- a/ts/ui/safe/safe.ts
+++ b/ts/ui/safe/safe.ts
@@ -82,7 +82,7 @@ export class Safe<N, T, D> {
     //
     // Pattern for allowed ids
     //
-    idPattern: /^mjx-[-a-zA-Z0-9_.]+$/,
+    idPattern: /^mjx-(?:eqn:.+|[-a-zA-Z0-9_.]+)$/,
     //
     // Pattern for data attributes
     //


### PR DESCRIPTION
This PR fixes the id filter for `ui/safe` to allow the ids generated by `\label{}` to be used.  Without this PR, the ids needed for `\ref` to link to the labeled equation would be filtered out.

Resolves issue mathjax/MathJax#3580.