### PR TITLE
Handle inline line breaking with nested embellished operators.  (mathjax/MathJax#3581)

### DIFF
--- a/ts/output/svg/Wrappers/mrow.ts
+++ b/ts/output/svg/Wrappers/mrow.ts
@@ -233,8 +233,9 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
     public addChildren(parents: N[]) {
       let x = 0;
       let i = 0;
+      const isEmbellished = this.node.isEmbellished;
       for (const child of this.childNodes) {
-        const n = child.breakCount;
+        const n = isEmbellished ? 0 : child.breakCount;
         child.toSVG(parents.slice(i, i + n + 1));
         if (child.dom) {
           let k = 0;


### PR DESCRIPTION
This PR corrects a problem with in-line line breaking in SVG output involving embellished operators involving `mspace` or `mtext` elements containing spaces.  The problem has to do with the inferred `mrow` that contains the spaces; because the breaks occur *outside* the `mrow`, it should always put its output in the first (and only) parent element rather than advance through the parent elements.

Resolves issue mathjax/MathJax#3581.