### PR TITLE
Don't add file:// to windows path in CommonJS files. (mathjax/MathJax#3585)

### DIFF
--- a/ts/util/context.ts
+++ b/ts/util/context.ts
@@ -22,11 +22,17 @@
  */
 
 declare const process: { platform: string };
+declare const exports: object;
 
 /**
  * True if there is a window object
  */
 export const hasWindow = typeof window !== 'undefined';
+
+/**
+ * True if used from the cjs directory, false for mjs directory
+ */
+export const isCJS = typeof exports !== 'undefined';
 
 /**
  * The browsers window and document objects, if any
@@ -75,6 +81,6 @@ export const context = {
 if (context.os === 'Windows') {
   context.path = (file: string) =>
     file.match(/^[/\\]?[a-zA-Z]:[/\\]/)
-      ? 'file://' + file.replace(/\\/g, '/').replace(/^\//, '')
+      ? (isCJS ? '' : 'file://') + file.replace(/\\/g, '/').replace(/^\//, '')
       : file.replace(/^\//, 'file:///');
 }


### PR DESCRIPTION
This PR fixes a problem with using MathJax CommonJS modules in node applications on windows.  Apparently the `file://` should not be added to absolute paths for CommonJS, but only should be for ESM modules.

Resolves issue mathjax/MathJax#3585.