### PR TITLE
Accept HTML Whitespace in Parser Tags

### DIFF
--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -33,8 +33,8 @@ import { LiteAdaptor } from '../liteAdaptor.js';
  * Patterns used in parsing serialized HTML
  */
 
-const SPACE = '[ \\n]+';
-const OPTIONALSPACE = '[ \\n]*';
+const SPACE = '[ \\t\\n\\f\\r]+';
+const OPTIONALSPACE = '[ \\t\\n\\f\\r]*';
 const TAGNAME = `[A-Za-z][^\u0000-\u001F "'>/=\u007F-\u009F]*`;
 const ATTNAME = `[^\u0000-\u001F "'>/=\u007F-\u009F]+`;
 const VALUE = `(?:'[^']*'|"[^"]*"|${SPACE})`;


### PR DESCRIPTION
Allow the LiteParser tag patterns to recognize CR, tab, and form-feed as whitespace [1] between tag names and attributes. This fixes serialized HTML with CRLF line breaks inside tags, such as output generated on Windows.

[1] https://infra.spec.whatwg.org/#ascii-whitespace