### PR TITLE
Handle in-line breaks in a math node that is an embellished operator in SVG output. (mathjax/MathJax#3587)

### DIFF
--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -445,7 +445,10 @@ export abstract class CommonOutputJax<
     if (linebreak) {
       this.getLinebreakWidth();
     }
-    const makeBreaks = this.options.linebreaks.inline && !math.display;
+    const makeBreaks =
+      this.options.linebreaks.inline &&
+      !math.display &&
+      !math.root.isEmbellished;
     let inlineMarked = !!math.root.getProperty('inlineMarked');
     if (
       inlineMarked &&


### PR DESCRIPTION
This PR addresses a problem in SVG output for an inline `math` element that is an embellished operator.  Such an operator should not have line breaks within it (unless they are explicit breaks), but the SVG output was processing them anyway.  The fix is to skip the marking of in-line breaks when the `math` node is an embellished operator.

Resolves issue mathjax/MathJax#3587.