### PR TITLE
Add dir=ltr to MathJax container element. (mathjax/MathJax#3589)

### DIFF
--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -380,7 +380,7 @@ export abstract class CommonOutputJax<
    */
   protected createNode(): N {
     const jax = (this.constructor as typeof CommonOutputJax).NAME;
-    return this.html('mjx-container', { class: 'MathJax', jax: jax });
+    return this.html('mjx-container', { class: 'MathJax', jax: jax, dir: 'ltr' });
   }
 
   /**

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -98,7 +98,6 @@ export class SVG<N, T, D> extends CommonOutputJax<
   public static commonStyles: StyleJson = {
     ...CommonOutputJax.commonStyles,
     'mjx-container[jax="SVG"]': {
-      direction: 'ltr',
       'white-space': 'nowrap',
     },
     'mjx-container[jax="SVG"] > svg': {


### PR DESCRIPTION
This PR adds a `dir="ltr"` attribute to the `mjx-container` element so that the math remains left-to-right when used in right-to-left contexts.  The SVG output had CSS `direction: ltr`, but apparently this by itself isn't enough to override a right-to-left direction.  Adding `unicode-bidi: isolate` would do it, but apparently `dir="ltr"` is to be preferred (see the warning  on this [MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/direction)).

Resolves issue mathjax/MathJax#3589.