### PR TITLE
Fix magnification of HTML embedded in MathML or TeX.

### DIFF
--- a/ts/output/chtml/Wrappers/semantics.ts
+++ b/ts/output/chtml/Wrappers/semantics.ts
@@ -243,7 +243,9 @@ export interface ChtmlXmlNodeNTD<N, T, D>
       ChtmlDelimiterData,
       ChtmlFontData,
       ChtmlFontDataClass
-    > {}
+    > {
+  getFontStyles(): {'font-family': string, 'font-size': string};
+}
 
 /**
  * The ChtmlXmlNodeClass interface for the CHTML XmlNode wrapper
@@ -311,6 +313,12 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
     public toCHTML(parents: N[]) {
       this.markUsed();
       this.dom = [this.adaptor.append(parents[0], this.getHTML()) as N];
+    }
+
+    public getFontStyles(): { 'font-family': string; 'font-size': string } {
+      const style = super.getFontStyles();
+      style['font-size'] = '1em';
+      return style;
     }
 
     /**

--- a/ts/output/chtml/Wrappers/semantics.ts
+++ b/ts/output/chtml/Wrappers/semantics.ts
@@ -52,6 +52,11 @@ import { XMLNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { StyleList } from '../../../util/Styles.js';
 
+export type FontStyles = {
+  'font-family': string;
+  'font-size': string;
+};
+
 /*****************************************************************/
 /**
  * The ChtmlSemantics interface for the CHTML Semantics wrapper
@@ -244,7 +249,10 @@ export interface ChtmlXmlNodeNTD<N, T, D>
       ChtmlFontData,
       ChtmlFontDataClass
     > {
-  getFontStyles(): {'font-family': string, 'font-size': string};
+  /**
+   * @returns {FontStyles}  the font family and size data
+   */
+  getFontStyles(): FontStyles;
 }
 
 /**
@@ -315,7 +323,10 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
       this.dom = [this.adaptor.append(parents[0], this.getHTML()) as N];
     }
 
-    public getFontStyles(): { 'font-family': string; 'font-size': string } {
+    /**
+     * @override
+     */
+    public getFontStyles(): FontStyles {
       const style = super.getFontStyles();
       style['font-size'] = '1em';
       return style;

--- a/ts/output/svg/Wrappers/semantics.ts
+++ b/ts/output/svg/Wrappers/semantics.ts
@@ -324,7 +324,8 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
               y: this.jax.fixed(-h * em) + 'px',
               width: this.jax.fixed(w * em) + 'px',
               height: this.jax.fixed((h + d) * em) + 'px',
-              transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`,
+              transform: `scale(${scale} ${-scale})`,
+              'font-size': 'initial',
             },
             [this.getHTML()]
           )


### PR DESCRIPTION
This PR fixes a problem with the keyboard or mouse magnification of expressions that include HTML embedded in the MathML or TeX expressions.  The HTML was not being properly enlarged in the magnification window.  This is due to the use of `px` font sizing in the CHTML output, and a pad interaction with the scaling in SVG output.

The solution for CHTML is to override the `getFontStyles()` method to use a scaling in `em` units (in this case, the parent elements already do the relative scaling, so `1em` keeps it at that scale).  For SVG, setting `font-size` to initial and leaving the `px` values seems to do the trick.