### PR TITLE
Allow entity definitions to load synchronously, and add tests for it.

### DIFF
--- a/testsuite/tests/util/Entities.test.ts
+++ b/testsuite/tests/util/Entities.test.ts
@@ -1,25 +1,64 @@
 import { describe, test, expect } from '@jest/globals';
 import * as Entities from '#js/util/Entities.js';
-import { handleRetriesFor } from '#js/util/Retries.js';
+import { mathjax } from '#js/mathjax.js';
 import '#js/util/asyncLoad/esm.js';
+import '#js/a11y/sre/require.mjs';
 
 describe('Entities translation', () => {
-  test('translate()', async () => {
+  test('translate()', () => {
     expect(Entities.translate('&#97;')).toBe('a');
     expect(Entities.translate('&#x61;')).toBe('a');
     expect(Entities.translate('&amp;')).toBe('&');
+  });
+
+  test('Unknown entity', async () => {
     await expect(
-      handleRetriesFor(() => Entities.translate('&xyz;'))
+      mathjax.handleRetriesFor(() => Entities.translate('&xyz;'))
     ).resolves.toBe('&xyz;'); // no such entity
+  });
+
+  test('Load entity files', async () => {
     await expect(
-      handleRetriesFor(() => Entities.translate('&approx;'))
+      mathjax.handleRetriesFor(() => Entities.translate('&approx;'))
     ).resolves.toBe('\u2248'); // load a.js
     await expect(
-      handleRetriesFor(() => Entities.translate('&Bscr;'))
+      mathjax.handleRetriesFor(() => Entities.translate('&Bscr;'))
     ).resolves.toBe('\u212C'); // load scr.js
-    Entities.remove('approx');
-    expect(Entities.translate('&approx;')).toBe('&approx;'); // undefined entities remain unchanged
     Entities.options.loadMissingEntities = false;
     expect(Entities.translate('&bigwedge;')).toBe('&bigwedge;'); // don't load b.js
+    Entities.options.loadMissingEntities = true;
+  });
+
+  test('Remove entity', () => {
+    Entities.remove('approx');
+    expect(Entities.translate('&approx;')).toBe('&approx;'); // undefined entities remain unchanged
+  });
+
+  test('Synchronous load', () => {
+    const asyncLoad = mathjax.asyncLoad;
+    const REQUIRE = require;
+    mathjax.asyncIsSynchronous = true;
+    mathjax.asyncLoad = (file) => REQUIRE(`#js/../cjs/${file}`);
+    expect((() => {
+      try {
+        Entities.translate('&copy;');
+        return 'success';
+      } catch (_err) {
+        return 'failed';
+      }
+    })()).toBe('success');
+    mathjax.asyncLoad = asyncLoad;
+    mathjax.asyncIsSynchronous = false;
+  });
+
+  test('AsycLoad retries', () => {
+    expect((() => {
+      try {
+        Entities.translate('&divide;');
+        return 'success';
+      } catch (_err) {
+        return 'failed';
+      }
+    })()).toBe('failed');
   });
 });

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -21,8 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { retryAfter } from './Retries.js';
-import { asyncLoad } from './AsyncLoad.js';
+import { mathjax } from '../mathjax.js';
 import { OptionList } from './Options.js';
 
 /**
@@ -493,7 +492,7 @@ export function translate(text: string): string {
  *
  * @param {string} match   The complete entity being replaced
  * @param {string} entity  The name of the entity to be replaced
- * @returns {string}        The unicode character for the entity, or the entity name (if none found)
+ * @returns {string}       The unicode character for the entity, or the entity name (if none found)
  */
 function replace(match: string, entity: string): string {
   if (entity.charAt(0) === '#') {
@@ -503,12 +502,16 @@ function replace(match: string, entity: string): string {
     return entities[entity];
   }
   if (options['loadMissingEntities']) {
-    const file = entity.match(/^[a-zA-Z](fr|scr|opf)$/)
-      ? RegExp.$1
-      : entity.charAt(0).toLowerCase();
+    const file =
+      entity.match(/^[a-zA-Z](fr|scr|opf)$/)?.[1] ??
+      entity.charAt(0).toLowerCase();
     if (!loaded[file]) {
       loaded[file] = true;
-      retryAfter(asyncLoad('./util/entities/' + file + '.js'));
+      const promise = mathjax.asyncLoad(`./util/entities/${name}.js`);
+      if (mathjax.asyncIsSynchronous) {
+        return replace(match, entity);
+      }
+      mathjax.retryAfter(promise);
     }
   }
   return match;


### PR DESCRIPTION
This PR adds the ability to synchronously load entity extensions from node applications that have `asyncIsSyncronous` set.  This is similar to the synchronous loading of dynamic font data font.  A number of new tests are added, and the current single function is broken into several pieces.

It also removes a deprecated use of `RegExp.$1`.

