### PR TITLE
Clear the SVG stylesheet during reset.

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -197,6 +197,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
    */
   public reset() {
     this.clearFontCache();
+    this.svgStyles = null;
   }
 
   /**


### PR DESCRIPTION
This PR adds a line to the SVG output jax's `reset()` function, so that the stylesheet will be regenerated after a reset.  This helps support reusing the SVG output jax in sequentially created math documents (so that in the second document, the SVG output jax doesn't think it already has a stylesheet in place)
