### PR TITLE
Allow renderActions to return promises and use that to better handle retries

### DIFF
--- a/testsuite/tests/util/Retries.test.ts
+++ b/testsuite/tests/util/Retries.test.ts
@@ -3,7 +3,7 @@ import { handleRetriesFor, retryAfter } from '#js/util/Retries.js';
 import { MathJax as MJX, MathJaxObject } from '#js/components/global.js';
 
 /**
- * Add the legacy MathJax.CallBack for teting v2-style restarts
+ * Add the legacy MathJax.CallBack for testing v2-style restarts
  */
 type MathJaxGlobal = MathJaxObject & {
   /* eslint-disable @typescript-eslint/no-unsafe-function-type */
@@ -40,34 +40,33 @@ describe('handleRetriesFor() and retryAfter()', () => {
 
   /********************************************************************************/
 
-  test('handleRetriesFor().then called after 3 retries', () => {
+  test('handleRetriesFor().then called after 3 retries', async () => {
     let n = 0;
-    handleRetriesFor(() => {
+    const result = await handleRetriesFor(() => {
       if (++n < 3) {
         const p = new Promise<void>((ok, _fail) => {
-          setTimeout(() => ok(), 1);
+          setTimeout(ok, 1);
         });
         retryAfter(p);
       }
       return 'success';
-    }).then((result: string) => {
-      expect(result).toBe('success');
-      expect(n).toBe(3);
     });
+    expect(result).toBe('success');
+    expect(n).toBe(3);
   });
 
   /********************************************************************************/
 
-  test('handleRetriesFor().catch called for fail on 3rd retry', () => {
+  test('handleRetriesFor().catch called for fail on 3rd retry', async () => {
     let n = 0;
-    handleRetriesFor(() => {
+    await handleRetriesFor(() => {
       if (++n < 3) {
         const p = new Promise<void>((ok, fail) => {
           setTimeout(() => (n < 2 ? ok() : fail('fail')), 1);
         });
         retryAfter(p);
       }
-      return 'success';
+      throw 'success';
     }).catch((result: string) => {
       expect(result).toBe('fail');
       expect(n).toBe(2);
@@ -76,12 +75,12 @@ describe('handleRetriesFor() and retryAfter()', () => {
 
   /********************************************************************************/
 
-  test('handleRetriesFor().catch called for error on 3rd retry', () => {
+  test('handleRetriesFor().catch called for error on 3rd retry', async () => {
     let n = 0;
-    handleRetriesFor(() => {
+    await handleRetriesFor(() => {
       if (++n < 3) {
         const p = new Promise<void>((ok, _fail) => {
-          setTimeout(() => ok(), 1);
+          setTimeout(ok, 1);
         });
         retryAfter(p);
       }
@@ -94,28 +93,27 @@ describe('handleRetriesFor() and retryAfter()', () => {
 
   /********************************************************************************/
 
-  test('v2 retry', () => {
+  test('v2 retry', async () => {
     let n = 0;
-    handleRetriesFor(() => {
+    const result = await handleRetriesFor(() => {
       if (++n < 3) {
         throw Object.assign(new Error('restart'), {
           restart: MathJax.Callback.mock(), // mark this error as a v2 restart
         });
       }
       return 'success';
-    }).then((result: string) => {
-      expect(result).toBe('success');
-      expect(n).toBe(3);
     });
+    expect(result).toBe('success');
+    expect(n).toBe(3);
   });
 
   /********************************************************************************/
 
-  test('handleRetriedFor() async success', () => {
+  test('handleRetriesFor() async success', () => {
     expect(
       handleRetriesFor(async () => {
         const wait = new Promise((ok, _fail) =>
-          setTimeout(() => ok('success'), 1)
+          setTimeout(ok, 1, 'success')
         );
         return await wait;
       })
@@ -124,11 +122,11 @@ describe('handleRetriesFor() and retryAfter()', () => {
 
   /********************************************************************************/
 
-  test('handleRetriedFor() async fails', () => {
+  test('handleRetriesFor() async fails', () => {
     expect(
       handleRetriesFor(async () => {
         const wait = new Promise((_ok, fail) =>
-          setTimeout(() => fail('fail'), 1)
+          setTimeout(fail, 1, 'fail')
         );
         return await wait;
       })
@@ -137,20 +135,74 @@ describe('handleRetriesFor() and retryAfter()', () => {
 
   /********************************************************************************/
 
-  test('handleRetriedFor() async with retry', () => {
+  test('handleRetriesFor() async with retry', async () => {
     let n = 0;
-    handleRetriesFor(async () => {
+    const result = await handleRetriesFor(async () => {
       if (++n < 3) {
         await new Promise<void>((ok, _fail) => setTimeout(ok, 1));
         const p = new Promise<void>((ok, _fail) => {
-          setTimeout(() => ok(), 1);
+          setTimeout(ok, 1);
         });
         retryAfter(p);
       }
       return 'success';
-    }).then((result: string) => {
+    });
+    expect(result).toBe('success');
+    expect(n).toBe(3);
+  });
+
+  /********************************************************************************/
+
+  test('retryAfter() without restart code', async () => {
+    let n = 0;
+    const result = await handleRetriesFor(() => {
+      if (n++) return 'success';
+      retryAfter(Promise.resolve());
+      return 'failed';
+    })
+    expect(result).toBe('success');
+    expect(n).toBe(2);
+  });
+
+  /********************************************************************************/
+
+  test('retryAfter() with restart code', async () => {
+    let n = 0;
+    const result = await handleRetriesFor(() => {
+      if (n++) return 'failed';
+      retryAfter(Promise.resolve(), () => 'success');
+      return 'failed';
+    });
+    expect(result).toBe('success');
+    expect(n).toBe(1);
+  });
+
+  /********************************************************************************/
+
+  test('retryAfter() throws', async () => {
+    let n = 0;
+    await handleRetriesFor(() => {
+      if (n++) throw 'failed';
+      retryAfter(Promise.reject('success'));
+      throw 'failed';
+    }).catch((result: string) => {
       expect(result).toBe('success');
-      expect(n).toBe(3);
+      expect(n).toBe(1);
+    });
+  });
+
+  /********************************************************************************/
+
+  test('retryAfter() nested', async () => {
+    let n = 0;
+    await handleRetriesFor(() => {
+      retryAfter(new Promise<void>((_ok, _fail) => {
+        retryAfter(n++ < 3 ? Promise.resolve() : Promise.reject('success'))
+      }));
+      throw 'failed';
+    }).catch((result: string) => {
+      expect(result).toBe('success');
+      expect(n).toBe(4);
     });
   });
 

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -29,7 +29,7 @@ import {
 } from '../util/Options.js';
 import { InputJax, AbstractInputJax } from './InputJax.js';
 import { OutputJax, AbstractOutputJax } from './OutputJax.js';
-import { MathList, AbstractMathList } from './MathList.js';
+import { MathList, MathListItem, AbstractMathList } from './MathList.js';
 import { MathItem, AbstractMathItem, STATE } from './MathItem.js';
 import { MmlNode, TextNode } from './MmlTree/MmlNode.js';
 import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
@@ -39,8 +39,14 @@ import { PrioritizedList } from '../util/PrioritizedList.js';
 import { handleRetriesFor } from '../util/Retries.js';
 import { localize } from './__locales__/Component.js';
 import { Locale } from '../util/Locale.js';
+import { mathjax } from '../mathjax.js';
 
 /*****************************************************************/
+
+/**
+ * The return type for a render action
+ */
+export type RenderResult = Promise<boolean | void> | boolean | void;
 
 /**
  * A function to call while rendering a document (usually calls a MathDocument method)
@@ -49,7 +55,9 @@ import { Locale } from '../util/Locale.js';
  * @template T  The Text node class
  * @template D  The Document class
  */
-export type RenderDoc<N, T, D> = (document: MathDocument<N, T, D>) => boolean;
+export type RenderDoc<N, T, D> = (
+  document: MathDocument<N, T, D>
+) => RenderResult;
 
 /**
  * A function to call while rendering a MathItem (usually calls one of its methods)
@@ -61,7 +69,7 @@ export type RenderDoc<N, T, D> = (document: MathDocument<N, T, D>) => boolean;
 export type RenderMath<N, T, D> = (
   math: MathItem<N, T, D>,
   document: MathDocument<N, T, D>
-) => boolean;
+) => RenderResult;
 
 /**
  * The data for an action to perform during rendering or conversion
@@ -200,16 +208,11 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   ): [(document: any) => boolean, (math: any, document: any) => boolean] {
     return [
       (document: any) => {
-        if (method1) {
-          document[method1]();
-        }
-        return false;
+        const result = document[method1]?.() ?? false;
+        return result === document ? false : result;
       },
       (math: any, document: any) => {
-        if (method2) {
-          math[method2](document);
-        }
-        return false;
+        return math[method2]?.(document) ?? false;
       },
     ];
   }
@@ -219,15 +222,21 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    *
    * @param {MathDocument} document   The MathDocument whose methods are to be called
    * @param {number=} start           The state at which to start rendering (default is UNPROCESSED)
+   * @param {number=} i               The index in the renderAction list to start at
    */
   public renderDoc(
     document: MathDocument<N, T, D>,
-    start: number = STATE.UNPROCESSED
+    start: number = STATE.UNPROCESSED,
+    i: number = 0
   ) {
-    for (const item of this.items) {
-      if (item.priority >= start) {
-        if (item.item.renderDoc(document)) return;
+    let item;
+    while ((item = this.items[i++])) {
+      if (item.priority < start) continue;
+      const result = item.item.renderDoc(document);
+      if (result instanceof Promise) {
+        mathjax.retryAfter(result, () => this.renderDoc(document, start, i));
       }
+      if (result) return;
     }
   }
 
@@ -237,16 +246,24 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @param {MathItem} math           The MathItem whose methods are to be called
    * @param {MathDocument} document   The MathDocument to pass to the MathItem methods
    * @param {number=} start           The state at which to start rendering (default is UNPROCESSED)
+   * @param {number=} i               The index in the renderAction list to start at
    */
   public renderMath(
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    start: number = STATE.UNPROCESSED
+    start: number = STATE.UNPROCESSED,
+    i: number = 0
   ) {
-    for (const item of this.items) {
-      if (item.priority >= start) {
-        if (item.item.renderMath(math, document)) return;
+    let item;
+    while ((item = this.items[i++])) {
+      if (item.priority < start || !item.item.renderMath) continue;
+      const result = item.item.renderMath(math, document);
+      if (result instanceof Promise) {
+        mathjax.retryAfter(result, () =>
+          this.renderMath(math, document, start, i)
+        );
       }
+      if (result) return;
     }
   }
 
@@ -256,18 +273,28 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @param {MathItem} math           The MathItem whose methods are to be called
    * @param {MathDocument} document   The MathDocument to pass to the MathItem methods
    * @param {number=} end             The state at which to end rendering (default is LAST)
+   * @param {number=} i               The index in the renderAction list to start at
+   * @returns {N|MmlNode}             The typeset root or the MathML root, whichever is defined
    */
   public renderConvert(
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    end: number = STATE.LAST
-  ) {
-    for (const item of this.items) {
-      if (item.priority > end) return;
-      if (item.item.convert) {
-        if (item.item.renderMath(math, document)) return;
+    end: number = STATE.LAST,
+    i: number = 0
+  ): N | MmlNode {
+    let item;
+    while ((item = this.items[i++])) {
+      if (item.priority > end) break;
+      if (!item.item.convert) continue;
+      const result = item.item.renderMath(math, document);
+      if (result instanceof Promise) {
+        mathjax.retryAfter(result, () =>
+          this.renderConvert(math, document, end, i)
+        );
       }
+      if (result) break;
     }
+    return math.typesetRoot ?? math.root;
   }
 
   /**
@@ -496,7 +523,7 @@ export interface MathDocument<N, T, D> {
    *
    * @returns {MathDocument}  The math document instance
    */
-  compile(): MathDocument<N, T, D>;
+  compile(): MathDocument<N, T, D> | Promise<void>;
 
   /**
    * Gets the metric information for the MathItems
@@ -510,7 +537,7 @@ export interface MathDocument<N, T, D> {
    *
    * @returns {MathDocument}  The math document instance
    */
-  typeset(): MathDocument<N, T, D>;
+  typeset(): MathDocument<N, T, D> | Promise<void>;
 
   /**
    * Updates the document to include the typeset math
@@ -692,9 +719,9 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
     },
     renderActions: expandable({
       find: [STATE.FINDMATH, 'findMath', '', false],
-      compile: [STATE.COMPILED],
+      compile: [STATE.COMPILED, 'compileAction', 'compile'],
       metrics: [STATE.METRICS, 'getMetrics', '', false],
-      typeset: [STATE.TYPESET],
+      typeset: [STATE.TYPESET, 'typesetAction', 'typeset'],
       update: [STATE.INSERTED, 'updateDocument', false],
     }) as RenderActions<any, any, any>,
   };
@@ -847,7 +874,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   public render() {
     this.clearPromises();
-    this.renderActions.renderDoc(this);
+    this.renderActions.renderDoc(this, STATE.UNPROCESSED, 0);
     return this;
   }
 
@@ -923,7 +950,10 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
       mitem.outputData.merrorFamily = family;
     }
     this.clearPromises();
-    mitem.convert(this, end);
+    const result = mitem.convert(this, end);
+    if (result instanceof Promise) {
+      mathjax.retryAfter(result, () => mitem.typesetRoot || mitem.root);
+    }
     return mitem.typesetRoot || mitem.root;
   }
 
@@ -1013,30 +1043,75 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @override
    */
   public compile() {
-    if (!this.processed.isSet('compile')) {
-      //
-      //  Compile all the math in the list
-      //
-      const recompile = [];
-      for (const math of this.math) {
+    return this.compileAction(false);
+  }
+
+  /**
+   * Compile action that handles retryAfter() calls.
+   *
+   * @param {boolean} action           True when called as a renderAction
+   * @param {MathListItem} item        The MathListItem to begin with
+   * @param {MathItem[]} recompile     Array of MathItems to be rerendered (e.g., with forward references)
+   * @returns {MathDocument|Promise}   A promise for restarting, otherwise void
+   */
+  protected compileAction(
+    action: boolean = true,
+    item: MathListItem<N, T, D> = this.math.first(),
+    recompile: MathItem<N, T, D>[] = []
+  ): MathDocument<N, T, D> | Promise<void> {
+    if (this.processed.isSet('compile')) return this;
+    while (!item.isEnd) {
+      const math = item.data as MathItem<N, T, D>;
+      try {
         this.compileMath(math);
-        if (math.inputData.recompile !== undefined) {
-          recompile.push(math);
+      } catch (err) {
+        if (action) {
+          return err.retry.then(() =>
+            this.compileAction(action, item, recompile)
+          );
         }
+        throw err;
       }
-      //
-      //  If any were added to the recompile list,
-      //    compile them again
-      //
-      for (const math of recompile) {
-        const data = math.inputData.recompile;
-        math.state(data.state);
-        math.inputData.recompile = data;
-        this.compileMath(math);
+      if (math.inputData.recompile !== undefined) {
+        recompile.push(math);
       }
-      this.processed.set('compile');
+      item = item.next;
     }
+    const result = this.recompileAction(action, recompile, 0);
+    if (result) return result;
+    this.processed.set('compile');
     return this;
+  }
+
+  /**
+   * If any were added to the recompile list, compile them again
+   *
+   * @param {boolean} action         True when called as a renderAction
+   * @param {MathItem[]} recompile   Array of MathItems to be rerendered (e.g., with forward references)
+   * @param {number} i               The entry in the recompile list to start at
+   * @returns {Promise|void}         A promise for restarting, otherwise void
+   */
+  protected recompileAction(
+    action: boolean,
+    recompile: MathItem<N, T, D>[],
+    i: number = 0
+  ): Promise<void> | void {
+    while (i < recompile.length) {
+      const math = recompile[i++];
+      const data = math.inputData.recompile;
+      math.state(data.state);
+      math.inputData.recompile = data;
+      try {
+        this.compileMath(math);
+      } catch (err) {
+        if (action) {
+          return err.retry.then(() =>
+            this.recompileAction(action, recompile, i)
+          );
+        }
+        throw err;
+      }
+    }
   }
 
   /**
@@ -1046,7 +1121,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
     try {
       math.compile(this);
     } catch (err) {
-      if (err.retry || err.restart) {
+      if (err.retry) {
         throw err;
       }
       this.options['compileError'](this, math, err);
@@ -1084,20 +1159,38 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @override
    */
   public typeset() {
-    if (!this.processed.isSet('typeset')) {
-      for (const math of this.math) {
-        try {
-          math.typeset(this);
-        } catch (err) {
-          if (err.retry || err.restart) {
-            throw err;
+    return this.typesetAction(false);
+  }
+
+  /**
+   * Typeset action that handles retryAfter() calls.
+   *
+   * @param {boolean} action      True when called as a renderAction
+   * @param {MathListItem} item   The MathList item to start with
+   * @returns {MathDocument}      The current MathDocument (for chaining)
+   */
+  protected typesetAction(
+    action: boolean = true,
+    item: MathListItem<N, T, D> = this.math.first()
+  ): AbstractMathDocument<N, T, D> | Promise<void> {
+    if (this.processed.isSet('typeset')) return this;
+    while (!item.isEnd) {
+      const math = item.data as MathItem<N, T, D>;
+      try {
+        math.typeset(this);
+      } catch (err) {
+        if (err.retry) {
+          if (action) {
+            return err.retry.then(() => this.typesetAction(action, item));
           }
-          this.options['typesetError'](this, math, err);
-          math.outputData['error'] = err;
+          throw err;
         }
+        this.options['typesetError'](this, math, err);
+        math.outputData['error'] = err;
       }
-      this.processed.set('typeset');
+      item = item.next;
     }
+    this.processed.set('typeset');
     return this;
   }
 

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -1065,7 +1065,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
       try {
         this.compileMath(math);
       } catch (err) {
-        if (action) {
+        if (action && err.retry) {
           return err.retry.then(() =>
             this.compileAction(action, item, recompile)
           );
@@ -1104,7 +1104,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
       try {
         this.compileMath(math);
       } catch (err) {
-        if (action) {
+        if (action && err.retry) {
           return err.retry.then(() =>
             this.recompileAction(action, recompile, i)
           );

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -141,8 +141,9 @@ export interface MathItem<N, T, D> {
    *
    * @param {MathDocument} document  The MathDocument in which the math resides
    * @param {number=} end            The state to end rerendering at (default = LAST)
+   * @returns {MmlNode | N}          The typesetRoot or root node of the converted MathItem
    */
-  convert(document: MathDocument<N, T, D>, end?: number): void;
+  convert(document: MathDocument<N, T, D>, end?: number): MmlNode | N;
 
   /**
    * Converts the expression into the internal format by calling the input jax
@@ -387,7 +388,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public convert(document: MathDocument<N, T, D>, end: number = STATE.LAST) {
+  public convert(document: MathDocument<N, T, D>, end: number = STATE.LAST): MmlNode | N {
     return document.renderActions.renderConvert(this, document, end);
   }
 

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -388,7 +388,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
    * @override
    */
   public convert(document: MathDocument<N, T, D>, end: number = STATE.LAST) {
-    document.renderActions.renderConvert(this, document, end);
+    return document.renderActions.renderConvert(this, document, end);
   }
 
   /**

--- a/ts/core/MathList.ts
+++ b/ts/core/MathList.ts
@@ -21,8 +21,18 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { LinkedList } from '../util/LinkedList.js';
+import { LinkedList, ListItem } from '../util/LinkedList.js';
 import { MathItem } from './MathItem.js';
+
+/*****************************************************************/
+/**
+ *  The MathListItem type (extends ListItem<MathItem>)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export type MathListItem<N, T, D> = ListItem<MathItem<N, T, D>>;
 
 /*****************************************************************/
 /**

--- a/ts/util/LinkedList.ts
+++ b/ts/util/LinkedList.ts
@@ -59,6 +59,10 @@ export class ListItem<DataClass> {
    */
   public prev: ListItem<DataClass> = null;
 
+  public get isEnd() {
+    return this.data === END;
+  }
+
   /**
    * @param {any} data  The data to be stored in the list item
    * @class
@@ -106,6 +110,10 @@ export class LinkedList<DataClass> {
    */
   public isBefore(a: DataClass, b: DataClass): boolean {
     return a < b;
+  }
+
+  public first(): ListItem<DataClass> {
+    return this.list.next;
   }
 
   /**
@@ -216,7 +224,6 @@ export class LinkedList<DataClass> {
    */
   public *[Symbol.iterator](): IterableIterator<DataClass> {
     let current = this.list.next;
-
     while (current.data !== END) {
       yield current.data as DataClass;
       current = current.next;
@@ -230,7 +237,6 @@ export class LinkedList<DataClass> {
    */
   public *reversed(): IterableIterator<DataClass> {
     let current = this.list.prev;
-
     while (current.data !== END) {
       yield current.data as DataClass;
       current = current.prev;

--- a/ts/util/LinkedList.ts
+++ b/ts/util/LinkedList.ts
@@ -59,7 +59,10 @@ export class ListItem<DataClass> {
    */
   public prev: ListItem<DataClass> = null;
 
-  public get isEnd() {
+  /**
+   * @returns {boolean}   True if the list item is the last one in the list
+   */
+  public get isEnd(): boolean {
     return this.data === END;
   }
 
@@ -112,6 +115,11 @@ export class LinkedList<DataClass> {
     return a < b;
   }
 
+  /**
+   * Get the first item in the list
+   *
+   * @returns {ListItem<DataClass>}   The first item in the lest
+   */
   public first(): ListItem<DataClass> {
     return this.list.next;
   }

--- a/ts/util/Retries.ts
+++ b/ts/util/Retries.ts
@@ -36,20 +36,19 @@ declare const MathJax: {
 
 /*****************************************************************/
 /**
- *  Allow us to pass a promise as part of an Error object
+ *  Allow us to pass a promise and restart code as part of an Error object
  */
 
 export interface RetryError extends Error {
   retry: Promise<any>;
+  code: () => any;
 }
 
 /*****************************************************************/
 /**
  * A wrapper for actions that may be asynchronous.  This will
  *   rerun the action after the asychronous action completes.
- *   Usually, this is for dynamic loading of files.  Legacy
- *   MathJax does that a lot, so we still need it for now, but
- *   may be able to go without it in the future.
+ *   Usually, this is for dynamic loading of files.
  *
  *   Example:
  *
@@ -65,44 +64,43 @@ export interface RetryError extends Error {
  *       console.log(err.message);
  *     });
  *
- * @param {Function} code  The code to run that might cause retries
- * @returns {Promise}       A promise that is satisfied when the code
+ * @param {()=>any} code   The code to run that might cause retries
+ * @returns {Promise}      A promise that is satisfied when the code
  *                         runs completely, and fails if the code
  *                         generates an error (that is not a retry).
  */
-export function handleRetriesFor(code: () => any): Promise<any> {
-  return new Promise(function run(ok, fail) {
+export async function handleRetriesFor(code: () => any): Promise<any> {
+  const CODE = code;
+  while (code) {
     //
-    // Process an error (retry or actual error)
+    // Wait for the user code to run and return its value
+    // If there was an error,
+    //   If it was a retry error, restart with the given or original code,
+    //   Otherwise fail with the error.
+    // Continue to this until the user code runs successfully.
     //
-    const handleRetry = (err: any) => {
+    try {
+      return await code();
+    } catch (err) {
       if (err.retry instanceof Promise) {
-        err.retry.then(() => run(ok, fail)).catch((e: any) => fail(e));
+        code = () => (err as RetryError).retry.then(err.code ?? CODE);
       } else if (err.restart?.isCallback) {
         // FIXME: Remove this branch when all legacy code is gone
-        MathJax.Callback.After(() => run(ok, fail), err.restart);
+        code = () =>
+          new Promise((ok, fail) => {
+            MathJax.Callback.After(() => {
+              try {
+                ok(CODE());
+              } catch (e) {
+                fail(e);
+              }
+            }, err.restart);
+          });
       } else {
-        fail(err);
+        throw err;
       }
-    };
-    //
-    // Run the user code
-    //   If it returns a promise, wait on it
-    //     when done, resolve the original promise with its returned value,
-    //     or if it errors, handle a retry or fail with the error.
-    //   Otherwise resolve the original promise with the result.
-    // If there was an error, handle a retry otherwise fail with the error.
-    try {
-      const result = code();
-      if (result instanceof Promise) {
-        result.then((value) => ok(value)).catch((err) => handleRetry(err));
-      } else {
-        ok(result);
-      }
-    } catch (err) {
-      handleRetry(err);
     }
-  });
+  }
 }
 
 /*****************************************************************/
@@ -111,11 +109,13 @@ export function handleRetriesFor(code: () => any): Promise<any> {
  *   before rerunning the code.  Causes an error to be thrown, so
  *   calling this terminates the code at that point.
  *
- * @param {Promise} promise  The promise that must be satisfied before
- *                            actions will continue
+ * @param {Promise} promise    The promise that must be satisfied before
+ *                               actions will continue
+ * @param {boolean} code       Code to run after the retry is complete
  */
-export function retryAfter(promise: Promise<any>) {
+export function retryAfter(promise: Promise<any>, code: () => any = null) {
   const err = new Error(localize('RetryError')) as RetryError;
   err.retry = promise;
+  err.code = code;
   throw err;
 }


### PR DESCRIPTION
The current `renderActions` list runs synchronously, but can throw a retry error when an asynchronous action is needed, and that error can be caught by `handleRetriesFor()` to rerun the render-action list after the asynchronous action is complete.  The various entries in the list each have a flag in the document's process-bits object that they use to tell if they have already been run or not, and they skip their action if they have been run.  When one that hasn't completed is reached, it runs again, usually running a command on each of the math items on the page.  Each math item marks its own state to tell when its action has been performed.  That way, when a later math item causes a retry to occur, the math items that have already been handled can be skipped.

That all works, but is a bit complicated, and there is a performance hit for handling the retries when you have to loop through the actions again and through the already processed math items for a suspended action.  It would be nice to be able to use promises to make this work more efficiently.

This PR introduces a backward-compatible way to accomplish that.  The `retryAfter()` function can now include a function that is called when the promise is complete, so that the render actions can be suspended and then restarted at the point where they left off, rather than running through the entire action list and beginning of the math list again.  The `handleRetriesFor()` function uses these restart functions when they exist, or re-runs the complete code that it received, as usual, when they don't.  That means that existing code will continue to work without change, but can take advantage of the new promise-based restarts that have been added into the compile and typeset functions (which are the main ones that cause restarts), and new user-defined render actions can use promises to handle tasks that need them.  (I have wished for this several times in the past.)


-----

## Details

The most critical changes are in the `util/Retries.ts` file (at the bottom of the diff).  Here, the `RetryError` adds a new `code` field that includes the code to call in order to restart the process where it left off.  This is supplies as part of the `retryAfter()` call. 

The `handleRetriesFor()` function now works as follows (it may be easier to view this file directly rather than use the diff, it has been heavily revised):

```
Wait for the user code to run and return its value
If there was an error,
   If it was a retry error,
     Restart with the code given in the retry error, or the original code,
   Otherwise fail with the error.
Continue to do this until the user code runs successfully.
```

This way, the actions can restart where they left off without having to go back and rerun earlier actions, even when there are multiple retries required.

The other critical changes are in `core/MathDocument.ts`, where the render-action processing is changed to handle return values that are promises, and where the compile and typeset actions have been refactored to be able to restart in the middle of the math list without having to go back and skip any earlier math items that were already processed.

We define a new `RenderResult` type for convenience, and simplify the function that creates the render actions.  The `renderDoc()` and `renderMath()` (used to process a complete document, or a single math item) both get a new parameter, `i`, that is the index into the render-action list of where to start, and after calling the action, if it returns a promise, we do a retry that continues the process from that point on.

The `renderConvert()` function gets a similar parameter and handles promises like above.  It also now returns the math `typesetRoot` or `root`, depending on which is is defined.

The `compile()` and `typeset()` methods are refactored so that they can be restarted using the new promise approach.  The main work is done by the `compileAction()` and `typesetAction()` functions, which are the ones used by the `renderDoc()` functions.  The `renderMath()` function uses the original `compile()` and `typeset()` functions, passing them `false` as their parameter.  That is used in the action functions to determine if a restart promise should be used (when only compiling or typesetting outside of the render-action list, the original behavior is used).

A try-catch structure is used to check if the `compileMath()` call returns a promise, and if we are in a render action and the error is a retry error, we add a `then` to the promise that finishes the compile or typeset action.  The handling of recompiled expressions (due to references to labels that aren't defined yet) is factored out into a separate function, since that must also handle promise return values.

In `core/MathItem.ts`, the `compile()` function returns the `renderConvert()` value, which will be the typeset root or the MathML root.

The `core/MathList.ts` file now exports a `MathList` type for convenience.

The `util/LinkedList.ts` file now adds `isEnd` and `first()` functions, for convenience.

Finally, a number of new tests are added to the `Retries.test.js` to test the new functionality, and to simplify existing tests using `async` and `await` rather than `.then()`.